### PR TITLE
Support Host header in determining base url

### DIFF
--- a/datacube_wms/ogc.py
+++ b/datacube_wms/ogc.py
@@ -8,6 +8,7 @@ import boto3
 import rasterio
 import os
 
+from datacube_wms.ogc_utils import capture_headers
 from datacube_wms.wms import handle_wms, WMS_REQUESTS
 from datacube_wms.wcs import handle_wcs, WCS_REQUESTS
 from datacube_wms.ogc_exceptions import OGCException, WCS1Exception, WMSException
@@ -44,10 +45,7 @@ def lower_get_args():
 def ogc_impl():
     #pylint: disable=too-many-branches
     nocase_args = lower_get_args()
-    nocase_args['referer'] = request.headers.get('Referer', None)
-    nocase_args['origin'] = request.headers.get('Origin', None)
-    nocase_args['requestid'] = request.environ.get("FLASK_REQUEST_ID")
-    nocase_args['url_root'] = request.url_root
+    nocase_args = capture_headers(request, nocase_args)
     service = nocase_args.get("service", "").upper()
     svc_cfg = get_service_cfg()
     # create dummy env if not exists

--- a/datacube_wms/ogc_utils.py
+++ b/datacube_wms/ogc_utils.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, division, print_function
 from importlib import import_module
 from datetime import timedelta, datetime
 from dateutil.parser import parse
+from urllib.parse import urlparse
 try:
     from datacube_wms.wms_cfg_local import service_cfg, layer_cfg, response_cfg
 except ImportError:
@@ -62,15 +63,32 @@ def get_function(func):
         assert callable(func)
     return func
 
+def parse_for_base_url(url):
+    parsed = urlparse(url)
+    parsed = (parsed.netloc + parsed.path).rstrip("/")
+    return parsed
+
 
 def get_service_base_url(allowed_urls, request_url):
     if not isinstance(allowed_urls, list):
         return allowed_urls
-    request_url = request_url.rstrip("/")
-    allowed_urls = [u.rstrip("/") for u in allowed_urls]
-    url = request_url if request_url in allowed_urls else allowed_urls[0]
+    parsed_request_url = parse_for_base_url(request_url)
+    parsed_allowed_urls = [parse_for_base_url(u) for u in allowed_urls]
+    url = request_url if parsed_request_url in parsed_allowed_urls else allowed_urls[0]
+    # template includes tailing /, strip any trail slash here to avoid duplicates
+    url = url.rstrip("/")
     return url
 
+
+# Collects additional headers from flask request objects
+def capture_headers(request, args_dict):
+    args_dict['referer'] = request.headers.get('Referer', None)
+    args_dict['origin'] = request.headers.get('Origin', None)
+    args_dict['requestid'] = request.environ.get("FLASK_REQUEST_ID")
+    args_dict['host'] = request.headers.get('Host', None)
+    args_dict['url_root'] = request.url_root
+
+    return args_dict
 
 # Exceptions raised when attempting to create a
 # product layer form a bad config or without correct

--- a/datacube_wms/wcs.py
+++ b/datacube_wms/wcs.py
@@ -54,7 +54,8 @@ def get_capabilities(args):
     # Extract layer metadata from Datacube.
     platforms = get_layers(refresh=True)
     service_cfg = get_service_cfg()
-    base_url = get_service_base_url(service_cfg.allowed_urls, args['url_root'])
+    url = args.get('Host', args['url_root'])
+    base_url = get_service_base_url(service_cfg.allowed_urls, url)
     return (
         render_template("wcs_capabilities.xml",
                         show_service=show_service,

--- a/datacube_wms/wms.py
+++ b/datacube_wms/wms.py
@@ -45,7 +45,8 @@ def get_capabilities(args):
     # Extract layer metadata from Datacube.
     platforms = get_layers(refresh=True)
     service_cfg = get_service_cfg()
-    base_url = get_service_base_url(service_cfg.allowed_urls, args['url_root'])
+    url = args.get('Host', args['url_root'])
+    base_url = get_service_base_url(service_cfg.allowed_urls, url)
     return (
         render_template(
             "wms_capabilities.xml",

--- a/tests/test_ogc_utils.py
+++ b/tests/test_ogc_utils.py
@@ -28,3 +28,14 @@ def test_get_service_base_url():
     ret = datacube_wms.ogc_utils.get_service_base_url(allowed_urls, request_url)
     assert ret == "https://foo.bar.baz"
 
+    #include path
+    allowed_urls = ["https://foo.bar.baz", "https://foo.bar.baz/wms/"]
+    request_url = "https://foo.bar.baz/wms/"
+    ret = datacube_wms.ogc_utils.get_service_base_url(allowed_urls, request_url)
+    assert ret == "https://foo.bar.baz/wms"
+
+
+def test_parse_for_base_url():
+    url = "https://hello.world.bar:8000/wms/?CheckSomething"
+    ret = datacube_wms.ogc_utils.parse_for_base_url(url)
+    assert ret == "hello.world.bar:8000/wms"


### PR DESCRIPTION
Using the Host Header is useful for WMS deployments behind reverse proxies such as nginx.