### PR TITLE
Style-level legends.

### DIFF
--- a/datacube_wms/legend_generator.py
+++ b/datacube_wms/legend_generator.py
@@ -32,6 +32,13 @@ def legend_graphic(args):
     return img
 
 
+def create_legend_for_style(product, style_name):
+    if not product.legend or style_name not in product.legend:
+        return None
+    style = product.style_index[style_name]
+    return create_legends_from_styles([style])
+
+
 def create_legends_from_styles(styles):
     # Run through all values in style cfg and generate
     imgs = []
@@ -50,3 +57,4 @@ def create_legends_from_styles(styles):
     legend.mimetype = 'image/png'
     b.close()
     return legend
+

--- a/datacube_wms/templates/wms_capabilities.xml
+++ b/datacube_wms/templates/wms_capabilities.xml
@@ -175,6 +175,14 @@ http://schemas.opengis.net/wms/1.3.0/capabilities_1_3_0.xsd">
                             <Name>{{ style.name }}</Name>
                             <Title>{{ style.title }}</Title>
                             <Abstract>{{ style.abstract }}</Abstract>
+                            {% if product.legend and style.name in product.legend %}
+                            <LegendURL>
+                                <Format>image/png</Format>
+                                <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink"
+                                                xlink:type="simple"
+                                                xlink:href="{{ base_url }}/legend/{{ product.name }}/{{ style.name }}/legend.png"/>
+                            </LegendURL>
+                            {% endif %}
                         </Style>
                     {% endfor %}
                     <!-- TODO: Populate from config (but OK to ignore for now)
@@ -234,6 +242,14 @@ http://schemas.opengis.net/wms/1.3.0/capabilities_1_3_0.xsd">
                                     <Name>{{ style.name }}</Name>
                                     <Title>{{ style.title }}</Title>
                                     <Abstract>{{ style.abstract }}</Abstract>
+                                    {% if product.legend and style.name in product.legend %}
+                                    <LegendURL>
+                                        <Format>image/png</Format>
+                                        <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink"
+                                                        xlink:type="simple"
+                                                        xlink:href="{{ base_url }}/legend/{{ product.name }}/{{ style.name }}/legend.png"/>
+                                    </LegendURL>
+                                    {% endif %}
                                 </Style>
                             {% endfor %}
                         </Layer>


### PR DESCRIPTION
By serving single-style legends from a set url and advertising it in the style section of the GetCapabilities document, we can just get a legend for the currently selected style (where that makes sense).  (Terria uses this method in preference to GetLegendGraphic if used in the GetCaps).

This seems to mostly work - there are a few code-branches in the legend code that look broken and presumably never get called.  Also, only a couple of band-mapping classes actually support legends currently.