### PR TITLE
Band config

### DIFF
--- a/datacube_wms/templates/wcs_desc_coverage.xml
+++ b/datacube_wms/templates/wcs_desc_coverage.xml
@@ -64,14 +64,14 @@
                         <name>measurements</name>
                         <label>Bands/Channels/Samples</label>
                         <values>
-                            {% for b in product.bands %}
+                            {% for b in product.band_idx.band_labels %}
                                 <singleValue>{{ b }}</singleValue>
                             {% endfor %}
                         </values>
                     </AxisDescription>
                 </axisDescription>
                 <nullValues>
-                    {% for nv in product.nodata_values %}
+                    {% for nv in product.band_idx.band_nodata_vals %}
                     <singleValue>{{ nv }}</singleValue>
                     {% endfor %}
                 </nullValues>

--- a/datacube_wms/wcs_utils.py
+++ b/datacube_wms/wcs_utils.py
@@ -16,6 +16,7 @@ from rasterio.enums import ColorInterp
 from datacube_wms.cube_pool import get_cube, release_cube
 from datacube_wms.data import DataStacker
 from datacube_wms.ogc_exceptions import WCS1Exception
+from datacube_wms.ogc_utils import ProductLayerException
 from datacube_wms.wms_layers import get_layers, get_service_cfg
 
 
@@ -142,23 +143,19 @@ class WCS1GetCoverageRequest():
 
         # Range constraint parameter: MEASUREMENTS
         # No default is set in the DescribeCoverage, so it is required
-        # But QGIS wants us to work without one, so let's try picking a reasonable default
+        # But QGIS wants us to work without one, so take default from config
         if "measurements" not in args:
-            if len(self.product.bands) <= 3:
-                self.bands = list(self.product.bands)
-            elif "red" in self.product.bands and "green" in self.product.bands and "blue" in self.product.bands:
-                self.bands = ["red", "green", "blue"]
-            else:
-                self.bands = list(self.product.bands[0:3])
+            self.bands = self.product.wcs_default_bands
         else:
             bands = args["measurements"]
             self.bands = []
             for b in bands.split(","):
-                if b not in self.product.bands:
+                try:
+                    self.bands.append(self.product.band_idx.band(b))
+                except ProductLayerException:
                     raise WCS1Exception("Invalid measurement '%s'" % b,
                                         WCS1Exception.INVALID_PARAMETER_VALUE,
                                         locator="MEASUREMENTS parameter")
-                self.bands.append(b)
             if not bands:
                 raise WCS1Exception("No measurements supplied",
                                     WCS1Exception.INVALID_PARAMETER_VALUE,
@@ -372,8 +369,7 @@ def get_tiff(req, data):
     yname = svc.published_CRSs[req.request_crsid]["vertical_coord"]
     nodata = 0
     for band in data.data_vars:
-        if band in req.product.nodata_dict:
-            nodata = req.product.nodata_dict[band]
+        nodata = req.product.band_idx.nodata_val(band)
     with MemoryFile() as memfile:
         #pylint: disable=protected-access, bad-continuation
         with memfile.open(
@@ -390,7 +386,7 @@ def get_tiff(req, data):
             dtype=dtype) as dst:
             for idx, band in enumerate(data.data_vars, start=1):
                 dst.write(data[band].values, idx)
-                dst.set_band_description(idx, band)
+                dst.set_band_description(idx, req.product.band_idx.band_label(band))
                 dst.update_tags(idx, STATISTICS_MINIMUM=data[band].values.min())
                 dst.update_tags(idx, STATISTICS_MAXIMUM=data[band].values.max())
                 dst.update_tags(idx, STATISTICS_MEAN=data[band].values.mean())
@@ -411,13 +407,3 @@ def get_netcdf(req, data):
     # And export to NetCDF
     return data.to_netcdf()
 
-
-# pylint: disable=invalid-name
-wcs_formats = {
-    "GeoTIFF": {
-        "renderer": "datacube_wms.wcs_utils.get_tiff",
-        "mime": "image/geotiff",
-        "extension": "tif",
-        "multi-time": False
-    },
-}

--- a/datacube_wms/wms_cfg_example.py
+++ b/datacube_wms/wms_cfg_example.py
@@ -154,7 +154,7 @@ layer_cfg = [
                 # 2. Band aliases can be used anywhere in the configuration that refers to bands by name.
                 # 3. The native band name MAY be explicitly declared as an alias for the band, but are always treated as
                 # a valid alias.
-                # 4. The band labels used in GetFeatureInfo responses will be the first declared alias (or the native name
+                # 4. The band labels used in GetFeatureInfo and WCS responses will be the first declared alias (or the native name
                 # if no aliases are declared.)
                 # 5. Bands NOT listed here will not be included in the GetFeatureInfo output and cannot be referenced
                 # elsewhere in the configuration.
@@ -219,6 +219,12 @@ layer_cfg = [
                 # date and advertises no time dimension in GetCapabilities.
                 # Intended mostly for WCS debugging.
                 "wcs_sole_time": "2017-01-01",
+                # The default bands for a WCS request.
+                # 1. Must be provided if WCS is activated.
+                # 2. Must contain at least one band.
+                # 3. All bands must exist
+                # 4. Bands may be referred to by either native name or alias
+                "wcs_default_bands": [ "red", "green", "azure" ],
                 # Styles.
                 #
                 # See band_mapper.py

--- a/datacube_wms/wms_cfg_example.py
+++ b/datacube_wms/wms_cfg_example.py
@@ -150,6 +150,19 @@ layer_cfg = [
                 # The name of the measurement band for the pixel-quality product
                 # (Only required if pq_dataset is set)
                 "pq_band": "pixelquality",
+                # Supported bands, mapping native band names to a list of possible aliases. Aliases must be unique for the product.
+                # Band aliases can be used anywhere in the configuration that refers to bands by name (the native name can also be used).
+                # Bands NOT listed here will not be included in the GetFeatureInfo output and cannot be referenced elsewhere in the configuration.
+                # If not specified for a product, defaults to all available bands, using only their native names.
+                "bands": {
+                    "red": ["crimson"],
+                    "green": [],
+                    "blue": [ "azure" ],
+                    "nir": [ "near_infrared" ],
+                    "swir1": [ "shortwave_infrared_1", "near_shortwave_infrared" ],
+                    "swir2": [ "shortwave_infrared_2", "far_shortwave_infrared" ],
+                    "coastal_aerosol": [ "far_blue" ],
+                },
                 # Min zoom factor - sets the zoom level where the cutover from indicative polygons
                 # to actual imagery occurs.
                 "min_zoom_factor": 500.0,

--- a/datacube_wms/wms_cfg_example.py
+++ b/datacube_wms/wms_cfg_example.py
@@ -22,10 +22,9 @@ service_cfg = {
     ## Required config for WMS and/or WCS
     # Service title - appears e.g. in Terria catalog
     "title": "WMS server for Australian Landsat Datacube",
-    # Service URL.  Should a fully qualified URL
-    # Can also be a list of URLs that the service can return
+    # Service URL.  Should a fully qualified URL or a list of fully qualified URLs that the service can return
     # in the GetCapabilities document based on the requesting url
-    "url": "http://9xjfk12.nexus.csiro.au/datacube_wms",
+    "url": [ "http://9xjfk12.nexus.csiro.au/datacube_wms", "http://alternateurl.nexus.csiro.au/datacube_wms" ],
     # URL that humans can visit to learn more about the WMS or organization
     # should be fully qualified
     "human_url": "http://csiro.au",
@@ -150,10 +149,16 @@ layer_cfg = [
                 # The name of the measurement band for the pixel-quality product
                 # (Only required if pq_dataset is set)
                 "pq_band": "pixelquality",
-                # Supported bands, mapping native band names to a list of possible aliases. Aliases must be unique for the product.
-                # Band aliases can be used anywhere in the configuration that refers to bands by name (the native name can also be used).
-                # Bands NOT listed here will not be included in the GetFeatureInfo output and cannot be referenced elsewhere in the configuration.
-                # If not specified for a product, defaults to all available bands, using only their native names.
+                # Supported bands, mapping native band names to a list of possible aliases.
+                # 1. Aliases must be unique for the product.
+                # 2. Band aliases can be used anywhere in the configuration that refers to bands by name.
+                # 3. The native band name MAY be explicitly declared as an alias for the band, but are always treated as
+                # a valid alias.
+                # 4. The band labels used in GetFeatureInfo responses will be the first declared alias (or the native name
+                # if no aliases are declared.)
+                # 5. Bands NOT listed here will not be included in the GetFeatureInfo output and cannot be referenced
+                # elsewhere in the configuration.
+                # 6. If not specified for a product, defaults to all available bands, using only their native names.
                 "bands": {
                     "red": ["crimson"],
                     "green": [],
@@ -232,8 +237,10 @@ layer_cfg = [
                         "title": "Simple RGB",
                         "abstract": "Simple true-colour image, using the red, green and blue bands",
                         "components": {
+                            # The component keys MUST be "red", "green" and "blue" (and optionally "alpha")
                             "red": {
-                                "red": 1.0
+                                # Band aliases may be used here.
+                                "crimson": 1.0
                             },
                             "green": {
                                 "green": 1.0
@@ -484,7 +491,9 @@ layer_cfg = [
                         "title": "NDVI",
                         "abstract": "Normalised Difference Vegetation Index - a derived index that correlates well with the existence of vegetation",
                         "heat_mapped": True,
+                        # Note that lambdas CANNOT use band aliases - they MUST use the native band name
                         "index_function": lambda data: (data["nir"] - data["red"]) / (data["nir"] + data["red"]),
+                        # Band aliases can be used here.
                         "needed_bands": ["red", "nir"],
                         # Areas where the index_function returns outside the range are masked.
                         "range": [0.0, 1.0],

--- a/datacube_wms/wms_layers.py
+++ b/datacube_wms/wms_layers.py
@@ -65,6 +65,12 @@ class BandIndex(object):
             raise ProductLayerException(f"Unknown band name/alias: {name_alias}")
         return self._idx[name_alias]
 
+    def band_label(self, name_alias):
+        name = self.band(name_alias)
+        if self.band_cfg[name]:
+            return self.band_cfg[name][0]
+        else:
+            return name
 
 
 class ProductLayerDef(object):

--- a/datacube_wms/wms_layers.py
+++ b/datacube_wms/wms_layers.py
@@ -49,6 +49,7 @@ class BandIndex(object):
         else:
             self.band_cfg = band_cfg
         self._idx = {}
+        self._nodata_vals = {}
         for b, aliases in self.band_cfg.items():
             if b not in self.native_bands.index:
                 raise ProductLayerException(f"Unknown band: {b}")
@@ -59,6 +60,7 @@ class BandIndex(object):
                 if a in self._idx:
                     raise ProductLayerException(f"Duplicate band name/alias: {a}")
                 self._idx[a] = b
+            self._nodata_vals[b] = self.native_bands['nodata'][b]
 
     def band(self, name_alias):
         if name_alias not in self._idx:
@@ -71,6 +73,16 @@ class BandIndex(object):
             return self.band_cfg[name][0]
         else:
             return name
+
+    def nodata_val(self, name_alias):
+        name = self.band(name_alias)
+        return self._nodata_vals[name]
+
+    def band_labels(self):
+        return [ self.band_label(b) for b in self.native_bands.index ]
+
+    def band_nodata_vals(self):
+        return [ self.nodata_val(b) for b in self.native_bands.index ]
 
 
 class ProductLayerDef(object):
@@ -164,6 +176,7 @@ class ProductLayerDef(object):
             self.nodata_values = bands['nodata'].values
             self.nodata_dict = {a:b for a, b in zip(self.bands, self.nodata_values)}
             self.wcs_sole_time = product_cfg.get("wcs_sole_time")
+            self.wcs_default_bands = [ self.band_idx.band(b) for b in product_cfg["wcs_default_bands"] ]
 
     @property
     def bboxes(self):

--- a/datacube_wms/wms_layers.py
+++ b/datacube_wms/wms_layers.py
@@ -43,11 +43,13 @@ class BandIndex(object):
         self.product_name = product.name
         self.native_bands = dc.list_measurements().ix[self.product_name]
         if band_cfg is None:
-            band_cfg = {}
+            self.band_cfg = {}
             for b in self.native_bands.index:
-                band_cfg[b] = []
+                self.band_cfg[b] = []
+        else:
+            self.band_cfg = band_cfg
         self._idx = {}
-        for b, aliases in band_cfg.items():
+        for b, aliases in self.band_cfg.items():
             if b not in self.native_bands.index:
                 raise ProductLayerException(f"Unknown band: {b}")
             if b in self._idx:
@@ -62,6 +64,7 @@ class BandIndex(object):
         if name_alias not in self._idx:
             raise ProductLayerException(f"Unknown band name/alias: {name_alias}")
         return self._idx[name_alias]
+
 
 
 class ProductLayerDef(object):
@@ -97,7 +100,10 @@ class ProductLayerDef(object):
         self.ignore_flags_info = product_cfg.get("ignore_flags_info", [])
         self.feature_info_include_utc_dates = product_cfg.get("feature_info_include_utc_dates", False)
         self.feature_info_include_custom = product_cfg.get("feature_info_include_custom", None)
-        self.always_fetch_bands = product_cfg.get("always_fetch_bands", [])
+        raw_always_fetch_bands = product_cfg.get("always_fetch_bands", [])
+        self.always_fetch_bands = []
+        for b in raw_always_fetch_bands:
+            self.always_fetch_bands.append(self.band_idx.band(b))
         self.data_manual_merge = product_cfg.get("data_manual_merge", False)
         self.solar_correction = product_cfg.get("apply_solar_corrections", False)
         self.sub_product_extractor = product_cfg.get("sub_product_extractor", None)


### PR DESCRIPTION
A largish pull request, that breaks backwards compatibility on configuration format.

Addresses (finally) #12 . Also provides a fix for WCS on Sentinel2 NRT data.

BACKWARD INCOMPATIBLE CONFIG CHANGE:  The new "wcs_default_bands" product config entry is now required for WCS.  The previous "best guess" default was so broken for Sentinel-2 that I think it's best that we remove it altogether and force the administrator to explicitly declare a default.

The new "bands" product config entry is now strongly recommended (although it defaults to the current behaviour).

See `example_wms_cfg.py` for details.