### PR TITLE
Forcing aiobotocore installation with compatible boto3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,6 @@ eventlet
 gunicorn
 gunicorn[gevent]
 gunicorn[eventlet]
-boto3
 rasterio>=1.0.9
 ruamel.yaml
 prometheus-client
@@ -17,4 +16,5 @@ pytest-localserver
 pytest-mock
 requests
 watchdog
-aiobotocore
+aiobotocore[awscli]
+boto3


### PR DESCRIPTION
maybe fix `dea-proto` install

Newer version of `dea-proto` has `aiobotocore` as a non-optional dependency, but `aiobotocore` can not catch up with constant change in `botocore` library, so it has a limited range of supported versions. Installing it with feature flag `[awscli]` forces installation of compatible `boto3` lib.