### PR TITLE
Add masking options

### DIFF
--- a/datacube_wms/band_mapper.py
+++ b/datacube_wms/band_mapper.py
@@ -49,7 +49,11 @@ class StyleDefBase(object):
                 mask_data = getattr(odc_mask, self.product.pq_band)
                 if mask.invert:
                     mask_data = ~mask_data
-                data = data.where(mask_data)
+                for band in data.data_vars:
+                    try:
+                        data[band] = data[band].where(mask_data, other=data[band].attrs['nodata'])
+                    except (AttributeError, KeyError):
+                        data[band] = data[band].where(mask_data)
         return data
 
     def transform_data(self, data, pq_data, extent_mask, *masks):

--- a/datacube_wms/data.py
+++ b/datacube_wms/data.py
@@ -280,7 +280,7 @@ def get_map(args):
                     flag_def = data[params.product.pq_band].flags_definition
                     pq_data[params.product.pq_band].attrs["flags_definition"] = flag_def
                 else:
-                    pq_datasets = stacker.datasets(dc.index, mask=True)
+                    pq_datasets = stacker.datasets(dc.index, mask=True, all_time=params.product.pq_ignore_time)
                     if pq_datasets:
                         pq_data = stacker.data(pq_datasets,
                                                mask=True,

--- a/datacube_wms/data.py
+++ b/datacube_wms/data.py
@@ -286,7 +286,7 @@ def get_map(args):
                                                mask=True,
                                                manual_merge=params.product.pq_manual_merge,
                                                use_overviews=True,
-                                               fuse_func=params.product.fuse_func)
+                                               fuse_func=params.product.pq_fuse_func)
                     else:
                         pq_data = None
             else:

--- a/datacube_wms/wms_cfg_example.py
+++ b/datacube_wms/wms_cfg_example.py
@@ -199,6 +199,9 @@ layer_cfg = [
                 # Fuse func
                 # Determines how multiple dataset arrays are compressed into a single time array
                 "fuse_func": "datacube_wms.wms_utils.wofls_fuser",
+                # PQ Fuse func
+                # Determines how multiple dataset arrays are compressed into a single time array for the PQ layer
+                "pq_fuse_func": "datacube.helpers.ga_pq_fuser",
                 # Flags listed here are ignored in GetFeatureInfo requests.
                 # (defaults to empty list)
                 "ignore_info_flags": [],

--- a/datacube_wms/wms_cfg_example.py
+++ b/datacube_wms/wms_cfg_example.py
@@ -202,6 +202,10 @@ layer_cfg = [
                 # PQ Fuse func
                 # Determines how multiple dataset arrays are compressed into a single time array for the PQ layer
                 "pq_fuse_func": "datacube.helpers.ga_pq_fuser",
+                # PQ Ignore time
+                # Doesn't use the time from the data to find a corresponding mask layer
+                # Used when you have a mask layer that doesn't have time
+                "pq_ignore_time": True,
                 # Flags listed here are ignored in GetFeatureInfo requests.
                 # (defaults to empty list)
                 "ignore_info_flags": [],

--- a/datacube_wms/wms_layers.py
+++ b/datacube_wms/wms_layers.py
@@ -148,7 +148,7 @@ class ProductLayerDef(object):
         except TypeError:
             self.extent_mask_func = [product_cfg["extent_mask_func"]]
         self.fuse_func = get_function(product_cfg.get("fuse_func", None))
-        self.pq_fuse_func = get_function(product_cfg.get("pq_fuse_func", None))
+        self.pq_fuse_func = get_function(product_cfg.get("pq_fuse_func", self.fuse_func))
         self.pq_manual_merge = product_cfg.get("pq_manual_merge", False)
         self.pq_ignore_time = product_cfg.get("pq_ignore_time", False)
 

--- a/datacube_wms/wms_layers.py
+++ b/datacube_wms/wms_layers.py
@@ -150,6 +150,7 @@ class ProductLayerDef(object):
         self.fuse_func = get_function(product_cfg.get("fuse_func", None))
         self.pq_fuse_func = get_function(product_cfg.get("pq_fuse_func", None))
         self.pq_manual_merge = product_cfg.get("pq_manual_merge", False)
+        self.pq_ignore_time = product_cfg.get("pq_ignore_time", False)
 
         # For WCS
         svc_cfg = get_service_cfg()

--- a/datacube_wms/wms_layers.py
+++ b/datacube_wms/wms_layers.py
@@ -148,6 +148,7 @@ class ProductLayerDef(object):
         except TypeError:
             self.extent_mask_func = [product_cfg["extent_mask_func"]]
         self.fuse_func = get_function(product_cfg.get("fuse_func", None))
+        self.pq_fuse_func = get_function(product_cfg.get("pq_fuse_func", None))
         self.pq_manual_merge = product_cfg.get("pq_manual_merge", False)
 
         # For WCS


### PR DESCRIPTION
This PR is required to have a masking layer independent from the data.
It adds the options:
`pq_fuse_func`
`pq_ignore_time`
If not set, existing behaviour is maintained