### PR TITLE
Arcmap-compatible WCS support

### DIFF
--- a/datacube_wms/product_ranges.py
+++ b/datacube_wms/product_ranges.py
@@ -68,6 +68,7 @@ def determine_product_ranges(dc, product_name, extractor):
     product = dc.index.products.get_by_name(product_name)
     print("Product: ", product_name)
     if product is None:
+        print ("Product does not exist!")
         raise Exception("Product does not exist")
     r = {
         "product_id": product.id,
@@ -83,13 +84,14 @@ def determine_product_ranges(dc, product_name, extractor):
     }
     sub_r = {}
     time_set = set()
-
+    print ("OK, Let's do it")
     crsids = service_cfg["published_CRSs"]
     calculate_extent = not service_cfg.get("use_default_extent", False)
     extents = {crsid: None for crsid in crsids}
     crses = {crsid: datacube.utils.geometry.CRS(crsid) for crsid in crsids}
     ds_count = 0
     for ds in dc.find_datasets(product=product_name):
+        print("Processing a dataset", ds.id)
         local_date = local_date(ds)
         time_set.add(local_date)
         if calculate_extent or extractor is not None:
@@ -126,6 +128,7 @@ def determine_product_ranges(dc, product_name, extractor):
                 sub_r[path]["time_set"].add(local_date)
 
             for crsid in crsids:
+                print("Working with CRS", crsid)
                 crs = crses[crsid]
                 ext = ds.extent
                 if ext.crs != crs:

--- a/datacube_wms/templates/wcs_desc_coverage.xml
+++ b/datacube_wms/templates/wcs_desc_coverage.xml
@@ -36,7 +36,8 @@
                         <gml:pos dimension="2">{{ product.ranges.lon.max }} {{ product.ranges.lat.max }}</gml:pos>
                     </gml:Envelope>
                 {% endif %}
-                {% if product.native_CRS %}
+                {% if product.grid_high_x %}
+                <!-- Real RectifiedGrid section -->
                 <gml:RectifiedGrid srsName="{{ product.native_CRS }}" dimension="2">
                     <gml:limits>
                         <gml:GridEnvelope>
@@ -55,6 +56,7 @@
                     <gml:offsetVector>0.0 {{ product.resolution_y }}</gml:offsetVector>
                 </gml:RectifiedGrid>
                 {% else %}
+                    <!-- Dummy RectifiedGrid section -->
                     <gml:RectifiedGrid srsName="EPSG:3577" dimension="2">
                         <gml:limits>
                             <gml:GridEnvelope>
@@ -70,7 +72,7 @@
                             </gml:pos>
                         </gml:origin>
                         <gml:offsetVector>25.0 0.0</gml:offsetVector>
-                        <gml:offsetVector>0.0 -25.0</gml:offsetVector>
+                        <gml:offsetVector>0.0 25.0</gml:offsetVector>
                     </gml:RectifiedGrid>
                 {% endif %}
             </spatialDomain>

--- a/datacube_wms/templates/wcs_desc_coverage.xml
+++ b/datacube_wms/templates/wcs_desc_coverage.xml
@@ -16,17 +16,26 @@
             <gml:pos>{{ product.ranges.lon.min }} {{ product.ranges.lat.min }}</gml:pos>
             <gml:pos>{{ product.ranges.lon.max }} {{ product.ranges.lat.max }}</gml:pos>
             {% if not product.wcs_sole_time %}
-            <gml:timePosition>{{ product.ranges.start_time.isoformat() }}</gml:timePosition>
-            <gml:timePosition>{{ product.ranges.end_time.isoformat() }}</gml:timePosition>
+            <gml:timePosition>{{ product.ranges.start_time.isoformat() }}T00:00:00.000Z</gml:timePosition>
+            <gml:timePosition>{{ product.ranges.end_time.isoformat() }}T00:00:00.000Z</gml:timePosition>
             {% endif %}
         </lonLatEnvelope>
 
         <domainSet>
             <spatialDomain>
-                <gml:Envelope srsName="{{ service.default_geographic_CRS }}">
-                    <gml:pos dimension="2">{{ product.ranges.lon.min }} {{ product.ranges.lat.min }}</gml:pos>
-                    <gml:pos dimension="2">{{ product.ranges.lon.max }} {{ product.ranges.lat.max }}</gml:pos>
-                </gml:Envelope>
+                {% if not product.wcs_sole_time %}
+                    <gml:EnvelopeWithTimePeriod srsName="{{ service.default_geographic_CRS }}">
+                        <gml:pos>{{ product.ranges.lon.min }} {{ product.ranges.lat.min }}</gml:pos>
+                        <gml:pos>{{ product.ranges.lon.max }} {{ product.ranges.lat.max }}</gml:pos>
+                        <gml:timePosition>{{ product.ranges.start_time.isoformat() }}T00:00:00.000Z</gml:timePosition>
+                        <gml:timePosition>{{ product.ranges.end_time.isoformat() }}T00:00:00.000Z</gml:timePosition>
+                    </gml:EnvelopeWithTimePeriod>
+                {% else %}
+                    <gml:Envelope srsName="{{ service.default_geographic_CRS }}">
+                        <gml:pos dimension="2">{{ product.ranges.lon.min }} {{ product.ranges.lat.min }}</gml:pos>
+                        <gml:pos dimension="2">{{ product.ranges.lon.max }} {{ product.ranges.lat.max }}</gml:pos>
+                    </gml:Envelope>
+                {% endif %}
                 {% if product.native_CRS %}
                 <gml:RectifiedGrid srsName="{{ product.native_CRS }}" dimension="2">
                     <gml:limits>
@@ -42,18 +51,36 @@
                             {{ [product.ranges["bboxes"][product.native_CRS]["left"], product.ranges["bboxes"][product.native_CRS]["right"]]|min }} {{ [product.ranges["bboxes"][product.native_CRS]["top"], product.ranges["bboxes"][product.native_CRS]["bottom"]]|min }}
                         </gml:pos>
                     </gml:origin>
-                    <gml:offsetVector>{{ product.resolution_x }} 0</gml:offsetVector>
-                    <gml:offsetVector>0 {{ product.resolution_y }}</gml:offsetVector>
+                    <gml:offsetVector>{{ product.resolution_x }} 0.0</gml:offsetVector>
+                    <gml:offsetVector>0.0 {{ product.resolution_y }}</gml:offsetVector>
                 </gml:RectifiedGrid>
+                {% else %}
+                    <gml:RectifiedGrid srsName="EPSG:3577" dimension="2">
+                        <gml:limits>
+                            <gml:GridEnvelope>
+                                <gml:low>0 0</gml:low>
+                                <gml:high>188804 164575</gml:high>
+                            </gml:GridEnvelope>
+                        </gml:limits>
+                        <gml:axisName>x</gml:axisName>
+                        <gml:axisName>y</gml:axisName>
+                        <gml:origin>
+                            <gml:pos>
+                                -2083052.7983727155 -5063148.378770097
+                            </gml:pos>
+                        </gml:origin>
+                        <gml:offsetVector>25.0 0.0</gml:offsetVector>
+                        <gml:offsetVector>0.0 -25.0</gml:offsetVector>
+                    </gml:RectifiedGrid>
                 {% endif %}
             </spatialDomain>
             {% if not product.wcs_sole_time %}
             <temporalDomain>
                 {% for t in product.ranges.times %}
-                    <gml:timePosition frame="#ISO-8601">{{ t.isoformat() }}</gml:timePosition>
+                    <gml:timePosition>{{ t.isoformat() }}T00:00:00.000Z</gml:timePosition>
                 {%  endfor %}
             </temporalDomain>
-            {%  endif %} %}
+            {% endif %}
         </domainSet>
         <rangeSet>
             <RangeSet>

--- a/datacube_wms/wcs_utils.py
+++ b/datacube_wms/wcs_utils.py
@@ -291,7 +291,7 @@ def get_coverage_data(req):
         datasets.extend(t_datasets)
     if not datasets:
         # TODO: Return an empty coverage file with full metadata?
-        extents = dc.load(dask_chunks={}, product=req.product_name, geopolygon=req.geobox.extent, time=stacker._time)
+        extents = dc.load(dask_chunks={}, product=req.product.product.name, geopolygon=req.geobox.extent, time=stacker._time)
         svc = get_service_cfg()
         x_range = (req.minx, req.maxx)
         y_range = (req.miny, req.maxy)

--- a/datacube_wms/wms_cfg_example.py
+++ b/datacube_wms/wms_cfg_example.py
@@ -225,6 +225,13 @@ layer_cfg = [
                 # 3. All bands must exist
                 # 4. Bands may be referred to by either native name or alias
                 "wcs_default_bands": [ "red", "green", "azure" ],
+                # The "native" CRS for WCS.
+                # Can be omitted if the product has a single native CRS, as this will be used in preference.
+                "native_wcs_crs": "EPSG:3577",
+                # The resolution (x,y) for WCS.
+                # This is the number of CRS units (e.g. degrees, metres) per pixel in the horizontal and vertical
+                # directions for the native resolution.  E.g. for a EPSG:3577  (25.0,25.0) for Landsat-8 and (10.0,10.0 for Sentinel-2)
+                "native_wcs_resolution": [ 25.0, 25.0 ],
                 # Styles.
                 #
                 # See band_mapper.py

--- a/datacube_wms/wms_layers.py
+++ b/datacube_wms/wms_layers.py
@@ -162,8 +162,7 @@ class ProductLayerDef(object):
             if not self.native_CRS:
                 self.native_CRS = product_cfg.get("native_wcs_crs")
             if self.native_CRS not in svc_cfg.published_CRSs:
-                logging.warning("Native CRS for product {} ({}) not in published CRSs".format(self.product_name,
-                                                                                  self.native_CRS))
+                logging.warning("Native CRS for product %s (%s) not in published CRSs", self.product_name, self.native_CRS)
                 self.native_CRS = None
             if self.native_CRS:
                 self.native_CRS_def = svc_cfg.published_CRSs[self.native_CRS]

--- a/datacube_wms/wms_layers.py
+++ b/datacube_wms/wms_layers.py
@@ -103,6 +103,8 @@ class ProductLayerDef():
             if svc_cfg.create_grid:
                 try:
                     self.native_CRS = self.product.definition["storage"]["crs"]
+                    if not self.native_CRS:
+                        self.native_CRS = product_cfg.get("native_wcs_crs")
                     if self.native_CRS not in svc_cfg.published_CRSs:
                         raise Exception(
                             "Native CRS for product {} ({}) not in published CRSs".format(self.product_name,


### PR DESCRIPTION
WCS now works with ESRI Arcmap.

1. The actual storage CRS is always used as the native CRS if it exists. If it doesn't, the WCS native resolution can be specified in configuration.  If possible the native CRS should be as close to equal area over the region covered.  (GDA94/EPSG:3577 is an excellent choice for Australia!)
2. WCS servers must now explicitly declare their resolution in the native CRS.
3. The rectified grid is calculated from the bounding box and the configured native resolution - this is MUCH faster than the previous method.
4. Various bug fixes.

There are a couple of undocumented configuration items that have been useful for testing.  I am leaving them in place for now, but they may be removed without notice at a later date.