### PR TITLE
FunctionWrappers for all functional configuration entries. (Config no…

### DIFF
--- a/datacube_wms/band_utils.py
+++ b/datacube_wms/band_utils.py
@@ -1,0 +1,35 @@
+# Style index functions
+
+def norm_diff(data, band1, band2, product_cfg=None):
+    # Calculate a normalised difference index.
+
+    if product_cfg:
+        b1=product_cfg.band_idx.band(band1)
+        b2=product_cfg.band_idx.band(band2)
+    else:
+        b1 = band1
+        b2 = band2
+    return (data[b1] - data[b2]) / (data[b1] + data[b2])
+
+
+def constant(data, band, const, product_cfg=None):
+    # Covert an xarray for a flat constant.
+    # Useful for displaying mask extents as a flat colour and debugging.
+    # params is assumed to be a tuple containing a constant value and a band name/alias.
+
+    if product_cfg:
+        b = product_cfg.band_idx.band(band)
+    else:
+        b = band
+    return data[b] * 0.0 + const
+
+
+def single_band(data, band, product_cfg=None):
+    # Use the raw value of a band directly as the index function.
+
+    if product_cfg:
+        b = product_cfg.band_idx.band(band)
+    else:
+        b = band
+    return data[b]
+


### PR DESCRIPTION
…w fully serialisable)

All Config entries that previously took a function object or lambda (e.g. index_function, extent_mask_func, fuse_func, etc.) now behave uniformly and can be set to ANY of the following formats:

1) A lambda (or any callable Python object)
2) A string containing the fully qualified name of a callable Python object
3) A dict containing the following elements:
    a) "function" (required): A string containing the fully qualified path to a callable python object
     b) "args" (optional): An array of additional positional arguments that will always be passed to the function. (after any positional arguments passed to the function directly)
     c) "kwargs" (optional): An array of additional keyword arguments that will always be passed to the function. (in addition to any keyword arguments passed to the function directly)
     d) "pass_product_cfg" (optional): Boolean (defaults to False). If true, the relevant ProductLayerConfig is passed to the function as a keyword argument named "product_cfg".  This is useful if you are passing band aliases to the function in the args or kwargs as the product_cfg allows the index function to convert band aliases to band names.

(extent_mask_func can also be set to a list of any combination of the above formats.)

Refer to wms_cfg_example.py for examples of the new formats.  Format 3 allows e.g. using the one function for all ND*I styles - you reference the `datacube_wms.ogc_utils.norm_diff` function and pass the relevant bands in the kwargs.

This should be 100% backwards compatible with existing config files (as the various config entries previously supported either format 1 or 2, but config files can now be refactored to be 100% serialisable by using either format 2 or 3, which is apparently something the dev-ops guys will appreciate.