### PR TITLE
Heatmap winddown

### DIFF
--- a/datacube_wms/band_mapper.py
+++ b/datacube_wms/band_mapper.py
@@ -253,7 +253,7 @@ class LinearStyleDef(DynamicRangeCompression):
         return imgdata
 
 
-unscaled_default_ramp = [
+UNSCALED_DEFAULT_RAMP = [
     {
         "value": -0.0,
         "color": "#000080",
@@ -326,7 +326,7 @@ class RgbaColorRampDef(StyleDefBase):
             rmin, rmax = style_cfg["range"]
             self.color_ramp = scale_unscaled_ramp(
                     rmin, rmax,
-                    unscaled_default_ramp)
+                    UNSCALED_DEFAULT_RAMP)
         values, r, g, b, a = crack_ramp(self.color_ramp)
         self.values = values
         self.components = {

--- a/datacube_wms/band_utils.py
+++ b/datacube_wms/band_utils.py
@@ -35,3 +35,17 @@ def single_band(data, band, product_cfg=None):
         b = band
     return data[b]
 
+
+def band_quotient(data, band1, band2, product_cfg=None):
+    if product_cfg:
+        b1=product_cfg.band_idx.band(band1)
+        b2=product_cfg.band_idx.band(band2)
+    else:
+        b1 = band1
+        b2 = band2
+    return data[band1] / data[band2]
+
+
+def band_quotient_sum(data, band1a, band1b, band2a, band2b, product_cfg=None):
+    return band_quotient(data, band1a, band1b, product_cfg) + band_quotient(data, band2a, band2b, product_cfg)
+

--- a/datacube_wms/wms_cfg.py
+++ b/datacube_wms/wms_cfg.py
@@ -669,7 +669,6 @@ layer_cfg = [
                         "title": "NDVI plus RGB",
                         "abstract": "Normalised Difference Vegetation Index (blended with RGB) - a derived index that correlates well with the existence of vegetation",
                         "component_ratio": 0.6,
-                        "heat_mapped": True,
                         "index_function": {
                             "function": "datacube_wms.band_utils.norm_diff",
                             "pass_product_cfg": True,
@@ -699,7 +698,6 @@ layer_cfg = [
                         "title": "NDVI plus RGB (Cloud masked)",
                         "abstract": "Normalised Difference Vegetation Index (blended with RGB and cloud masked) - a derived index that correlates well with the existence of vegetation",
                         "component_ratio": 0.6,
-                        "heat_mapped": True,
                         "index_function": {
                             "function": "datacube_wms.band_utils.norm_diff",
                             "pass_product_cfg": True,

--- a/datacube_wms/wms_cfg.py
+++ b/datacube_wms/wms_cfg.py
@@ -426,7 +426,6 @@ layer_cfg = [
                         "name": "ndvi",
                         "title": "NDVI",
                         "abstract": "Normalised Difference Vegetation Index - a derived index that correlates well with the existence of vegetation",
-                        "heat_mapped": True,
                         # The index function is continuous value from which the heat map is derived.
                         #
                         # Three formats are supported:
@@ -465,7 +464,6 @@ layer_cfg = [
                         "name": "ndvi_cloudmask",
                         "title": "NDVI with cloud masking",
                         "abstract": "Normalised Difference Vegetation Index (with cloud masking) - a derived index that correlates well with the existence of vegetation",
-                        "heat_mapped": True,
                         "index_function": {
                             "function": "datacube_wms.band_utils.norm_diff",
                             "pass_product_cfg": True,
@@ -490,7 +488,6 @@ layer_cfg = [
                         "name": "ndwi",
                         "title": "NDWI",
                         "abstract": "Normalised Difference Water Index - a derived index that correlates well with the existence of water",
-                        "heat_mapped": True,
                         "index_function": {
                             "function": "datacube_wms.band_utils.norm_diff",
                             "pass_product_cfg": True,
@@ -506,7 +503,6 @@ layer_cfg = [
                         "name": "ndwi_cloudmask",
                         "title": "NDWI with cloud and cloud-shadow masking",
                         "abstract": "Normalised Difference Water Index (with cloud and cloud-shadow masking) - a derived index that correlates well with the existence of water",
-                        "heat_mapped": True,
                         "index_function": {
                             "function": "datacube_wms.band_utils.norm_diff",
                             "pass_product_cfg": True,
@@ -530,7 +526,6 @@ layer_cfg = [
                         "name": "ndbi",
                         "title": "NDBI",
                         "abstract": "Normalised Difference Buildup Index - a derived index that correlates with the existence of urbanisation",
-                        "heat_mapped": True,
                         "index_function": {
                             "function": "datacube_wms.band_utils.norm_diff",
                             "pass_product_cfg": True,
@@ -548,7 +543,6 @@ layer_cfg = [
                         "name": "cloud_mask",
                         "title": "Cloud Mask",
                         "abstract": "Highlight pixels with cloud.",
-                        "heat_mapped": True,
                         "index_function": {
                             "function": "datacube_wms.band_utils.constant",
                             "pass_product_cfg": True,
@@ -581,7 +575,6 @@ layer_cfg = [
                         "name": "cloud_and_shadow_mask",
                         "title": "Cloud and Shadow Mask",
                         "abstract": "Highlight pixels with cloud or cloud shadow.",
-                        "heat_mapped": True,
                         "index_function": {
                             "function": "datacube_wms.band_utils.constant",
                             "pass_product_cfg": True,
@@ -608,7 +601,6 @@ layer_cfg = [
                         "name": "cloud_acca",
                         "title": "Cloud acca Mask",
                         "abstract": "Highlight pixels with cloud.",
-                        "heat_mapped": True,
                         "index_function": {
                             "function": "datacube_wms.band_utils.constant",
                             "pass_product_cfg": True,
@@ -631,7 +623,6 @@ layer_cfg = [
                         "name": "cloud_fmask",
                         "title": "Cloud fmask Mask",
                         "abstract": "Highlight pixels with cloud.",
-                        "heat_mapped": True,
                         "index_function": {
                             "function": "datacube_wms.band_utils.constant",
                             "pass_product_cfg": True,
@@ -654,7 +645,6 @@ layer_cfg = [
                         "name": "contiguous_mask",
                         "title": "Contiguous Data Mask",
                         "abstract": "Highlight pixels with non-contiguous data",
-                        "heat_mapped": True,
                         "index_function": {
                             "function": "datacube_wms.band_utils.constant",
                             "pass_product_cfg": True,
@@ -823,7 +813,6 @@ layer_cfg = [
                         "name": "water_masked",
                         "title": "Water (masked)",
                         "abstract": "Water, with clouds, terrain shadows, etc. masked",
-                        "heat_mapped": True,
                         "index_function": {
                                               "function": "datacube_wms.band_utils.constant",
                                               "pass_product_cfg": True,
@@ -857,7 +846,6 @@ layer_cfg = [
                         "name": "water",
                         "title": "Water (unmasked)",
                         "abstract": "Simple water data, no masking",
-                        "heat_mapped": True,
                         "index_function": {
                             "function": "datacube_wms.band_utils.constant",
                             "pass_product_cfg": True,
@@ -889,183 +877,3 @@ layer_cfg = [
     },
 ]
 
-to_be_added_to_layer_cfg = {
-    "name": "LANDSAT_7",
-    "title": "Landsat 7",
-    "abstract": "Images from the Landsat 7 satellite",
-
-    "products": [
-        {
-            "label": "NBAR-T",
-            "type": "surface reflectance",
-            "variant": "terrain corrected",
-            "name": "ls7_nbart_albers",
-            "product_name": "ls7_nbart_albers",
-            "pq_dataset": "ls7_pq_albers",
-            "pq_band": "pixelquality",
-            "pq_mask_flags": {
-                "contiguous": True
-            },
-            "min_zoom_factor": 500.0
-        },
-    ],
-    "styles": [
-        {
-            "name": "simple_rgb",
-            "title": "Simple RGB",
-            "abstract": "Simple true-colour image, using the red, green and blue bands",
-            "components": {
-                "red": {
-                    "red": 1.0
-                },
-                "green": {
-                    "green": 1.0
-                },
-                "blue": {
-                    "blue": 1.0
-                }
-            },
-            "scale_range": [0.0, 3000.0]
-        },
-        {
-            "name": "wideband",
-            "title": "Wideband false-colour",
-            "abstract": "False-colour image, incorporating all available spectral bands",
-            "components": {
-                "red": {
-                    "swir2": 0.5,
-                    "swir1": 0.5,
-                },
-                "green": {
-                    "nir": 0.5,
-                    "red": 0.5,
-                },
-                "blue": {
-                    "green": 0.5,
-                    "blue": 0.5,
-                }
-            },
-            "scale_range": [0.0, 3000.0]
-        },
-        {
-            "name": "infra_red",
-            "title": "False colour multi-band infra-red",
-            "abstract": "Simple false-colour image, using the near and short-wave infra-red bands",
-            "components": {
-                "red": {
-                    "swir1": 1.0
-                },
-                "green": {
-                    "swir2": 1.0
-                },
-                "blue": {
-                    "nir": 1.0
-                }
-            },
-            "scale_factor": 12.0
-        },
-        {
-            "name": "blue",
-            "title": "Spectral band 1 - Blue",
-            "abstract": "Blue band, approximately 450nm to 520nm",
-            "components": {
-                "red": {
-                    "blue": 1.0
-                },
-                "green": {
-                    "blue": 1.0
-                },
-                "blue": {
-                    "blue": 1.0
-                }
-            },
-            "scale_factor": 12.0
-        },
-        {
-            "name": "green",
-            "title": "Spectral band 2 - Green",
-            "abstract": "Green band, approximately 530nm to 610nm",
-            "components": {
-                "red": {
-                    "green": 1.0
-                },
-                "green": {
-                    "green": 1.0
-                },
-                "blue": {
-                    "green": 1.0
-                }
-            },
-            "scale_factor": 12.0
-        },
-        {
-            "name": "red",
-            "title": "Spectral band 3 - Red",
-            "abstract": "Red band, roughly 630nm to 690nm",
-            "components": {
-                "red": {
-                    "red": 1.0
-                },
-                "green": {
-                    "red": 1.0
-                },
-                "blue": {
-                    "red": 1.0
-                }
-            },
-            "scale_factor": 12.0
-        },
-        {
-            "name": "nir",
-            "title": "Spectral band 4 - Near infra-red",
-            "abstract": "Near infra-red band, roughly 780nm to 840nm",
-            "components": {
-                "red": {
-                    "nir": 1.0
-                },
-                "green": {
-                    "nir": 1.0
-                },
-                "blue": {
-                    "nir": 1.0
-                }
-            },
-            "scale_factor": 12.0
-        },
-        {
-            "name": "swir1",
-            "title": "Spectral band 5 - Short wave infra-red 1",
-            "abstract": "Short wave infra-red band 1, roughly 1550nm to 1750nm",
-            "components": {
-                "red": {
-                    "swir1": 1.0
-                },
-                "green": {
-                    "swir1": 1.0
-                },
-                "blue": {
-                    "swir1": 1.0
-                }
-            },
-            "scale_factor": 12.0
-        },
-        {
-            "name": "swir2",
-            "title": "Spectral band 6 - Short wave infra-red 2",
-            "abstract": "Short wave infra-red band 2, roughly 2090nm to 2220nm",
-            "components": {
-                "red": {
-                    "swir2": 1.0
-                },
-                "green": {
-                    "swir2": 1.0
-                },
-                "blue": {
-                    "swir2": 1.0
-                }
-            },
-            "scale_factor": 12.0
-        }
-    ],
-    "default_style": "simple_rgb",
-}

--- a/datacube_wms/wms_cfg_example.py
+++ b/datacube_wms/wms_cfg_example.py
@@ -531,7 +531,6 @@ layer_cfg = [
                         "name": "ndvi",
                         "title": "NDVI",
                         "abstract": "Normalised Difference Vegetation Index - a derived index that correlates well with the existence of vegetation",
-                        "heat_mapped": True,
                         # The index function is continuous value from which the heat map is derived.
                         #
                         # Three formats are supported:
@@ -571,7 +570,6 @@ layer_cfg = [
                         "name": "ndvi_cloudmask",
                         "title": "NDVI with cloud masking",
                         "abstract": "Normalised Difference Vegetation Index (with cloud masking) - a derived index that correlates well with the existence of vegetation",
-                        "heat_mapped": True,
                         "index_function": {
                             "function": "datacube_wms.band_utils.norm_diff",
                             "pass_product_cfg": True,
@@ -596,7 +594,6 @@ layer_cfg = [
                         "name": "ndwi",
                         "title": "NDWI",
                         "abstract": "Normalised Difference Water Index - a derived index that correlates well with the existence of water",
-                        "heat_mapped": True,
                         "index_function": {
                             "function": "datacube_wms.band_utils.norm_diff",
                             "pass_product_cfg": True,
@@ -612,7 +609,6 @@ layer_cfg = [
                         "name": "ndwi_cloudmask",
                         "title": "NDWI with cloud and cloud-shadow masking",
                         "abstract": "Normalised Difference Water Index (with cloud and cloud-shadow masking) - a derived index that correlates well with the existence of water",
-                        "heat_mapped": True,
                         "index_function": {
                             "function": "datacube_wms.band_utils.norm_diff",
                             "pass_product_cfg": True,
@@ -636,7 +632,6 @@ layer_cfg = [
                         "name": "ndbi",
                         "title": "NDBI",
                         "abstract": "Normalised Difference Buildup Index - a derived index that correlates with the existence of urbanisation",
-                        "heat_mapped": True,
                         "index_function": {
                             "function": "datacube_wms.band_utils.norm_diff",
                             "pass_product_cfg": True,
@@ -654,7 +649,6 @@ layer_cfg = [
                         "name": "cloud_mask",
                         "title": "Cloud Mask",
                         "abstract": "Highlight pixels with cloud.",
-                        "heat_mapped": True,
                         "index_function": {
                             "function": "datacube_wms.band_utils.constant",
                             "pass_product_cfg": True,
@@ -687,7 +681,6 @@ layer_cfg = [
                         "name": "cloud_and_shadow_mask",
                         "title": "Cloud and Shadow Mask",
                         "abstract": "Highlight pixels with cloud or cloud shadow.",
-                        "heat_mapped": True,
                         "index_function": {
                             "function": "datacube_wms.band_utils.constant",
                             "pass_product_cfg": True,
@@ -1499,7 +1492,6 @@ layer_cfg = [
                         "name": "water_masked",
                         "title": "Water (masked)",
                         "abstract": "Water, with clouds, terrain shadows, etc. masked",
-                        "heat_mapped": True,
                         "index_function": {
                             "function": "datacube_wms.band_utils.constant",
                             "pass_product_cfg": True,
@@ -1533,7 +1525,6 @@ layer_cfg = [
                         "name": "water",
                         "title": "Water (unmasked)",
                         "abstract": "Simple water data, no masking",
-                        "heat_mapped": True,
                         "index_function": {
                             "function": "datacube_wms.band_utils.constant",
                             "pass_product_cfg": True,

--- a/datacube_wms/wms_cfg_example.py
+++ b/datacube_wms/wms_cfg_example.py
@@ -835,14 +835,14 @@ layer_cfg = [
                             },
                         ],
                     },
-                    # Hybrid style - mixes a linear mapping and an old-style heat mapped index style
-                    # Deprecated as old-style heat-mapped index styles are deprecated.
+                    # Hybrid style - blends a linear mapping and an colour-ramped index style
+                    # There is no scientific justification for these styles, I just think they look cool.  :)
                     {
                         "name": "rgb_ndvi",
                         "title": "NDVI plus RGB",
                         "abstract": "Normalised Difference Vegetation Index (blended with RGB) - a derived index that correlates well with the existence of vegetation",
+                        # Mixing ration between linear components and colour ramped index. 1.0 is fully linear components, 0.0 is fully colour ramp.
                         "component_ratio": 0.6,
-                        "heat_mapped": True,
                         "index_function": {
                             "function": "datacube_wms.band_utils.norm_diff",
                             "pass_product_cfg": True,
@@ -852,7 +852,6 @@ layer_cfg = [
                             }
                         },
                         "needed_bands": ["red", "nir"],
-                        # Areas where the index_function returns outside the range are masked.
                         "range": [0.0, 1.0],
                         "components": {
                             "red": {
@@ -872,7 +871,6 @@ layer_cfg = [
                         "title": "NDVI plus RGB (Cloud masked)",
                         "abstract": "Normalised Difference Vegetation Index (blended with RGB and cloud masked) - a derived index that correlates well with the existence of vegetation",
                         "component_ratio": 0.6,
-                        "heat_mapped": True,
                         "index_function": {
                             "function": "datacube_wms.band_utils.norm_diff",
                             "pass_product_cfg": True,
@@ -882,7 +880,6 @@ layer_cfg = [
                             }
                         },
                         "needed_bands": ["red", "nir"],
-                        # Areas where the index_function returns outside the range are masked.
                         "range": [0.0, 1.0],
                         "components": {
                             "red": {
@@ -1328,13 +1325,13 @@ layer_cfg = [
                             },
                         ],
                     },
-                    # Hybrid style - mixes a linear mapping and a heat mapped index
+                    # Hybrid style - blends a linear mapping and an colour-ramped index style
+                    # There is no scientific justification for these styles, I just think they look cool.  :)
                     {
                         "name": "rgb_ndvi",
                         "title": "NDVI plus RGB",
                         "abstract": "Normalised Difference Vegetation Index (blended with RGB) - a derived index that correlates well with the existence of vegetation",
                         "component_ratio": 0.6,
-                        "heat_mapped": True,
                         "index_function": {
                             "function": "datacube_wms.band_utils.norm_diff",
                             "pass_product_cfg": True,
@@ -1344,7 +1341,6 @@ layer_cfg = [
                             }
                         },
                         "needed_bands": ["red", "nir"],
-                        # Areas where the index_function returns outside the range are masked.
                         "range": [0.0, 1.0],
                         "components": {
                             "red": {
@@ -1364,7 +1360,6 @@ layer_cfg = [
                         "title": "NDVI plus RGB (Cloud masked)",
                         "abstract": "Normalised Difference Vegetation Index (blended with RGB and cloud masked) - a derived index that correlates well with the existence of vegetation",
                         "component_ratio": 0.6,
-                        "heat_mapped": True,
                         "index_function": {
                             "function": "datacube_wms.band_utils.norm_diff",
                             "pass_product_cfg": True,

--- a/tests/test_band_mapper.py
+++ b/tests/test_band_mapper.py
@@ -191,14 +191,6 @@ def test_correct_style_hybrid(product_layer, style_cfg_lin):
 
     assert isinstance(style_def, bm.HybridStyleDef)
 
-def test_correct_style_heatmap(product_layer, style_cfg_lin):
-    style_cfg_lin["heat_mapped"] = 1.0
-    style_cfg_lin["range"] = [1, 2]
-    style_cfg_lin["index_function"] = lambda x: x
-    style_def = StyleDef(product_layer, style_cfg_lin)
-
-    assert isinstance(style_def, bm.HeatMappedStyleDef)
-
 def test_correct_style_linear(product_layer, style_cfg_lin):
     style_def = StyleDef(product_layer, style_cfg_lin)
 


### PR DESCRIPTION
The cleanup of the config continues.  

This PR exhances the `RgbaColorRampDef` style class to also provide the behaviour of the old `HeatMapStyleDef` style class, which has been removed.  Effectively you can now specify a value range instead of an explicit colour map and a default heatmap-style colour map will be generated for you.

Also the `HybridStyleDef` style class has been rejigged to extend the `RgbaColorRampDef` style class instead of the old `HeatMapStyleDef`.

Should be fully backwards compatible with old config files that used the heatmap or hybrid style classes (although I believe no official GA config files do so), except the `"heat_mapped": True,` entry is no longer needed (it is ignored).