### PR TITLE
Version negotiation

### DIFF
--- a/datacube_wms/ogc.py
+++ b/datacube_wms/ogc.py
@@ -152,20 +152,23 @@ def ogc_svc_impl(svc):
     service = nocase_args.get("service", svc).upper()
 
     # Is service activated in config?
-    if not svc_support.activated():
-        raise svc_support.default_exception_class("Invalid service and/or request", locator="Service and request parameters")
-
-    # Does service match path (if supplied)
-    if service != svc_support.service_upper:
-        raise svc_support.default_exception_class("Invalid service", locator="Service parameter")
-
-    version = nocase_args.get("version")
-    if not version:
-        raise svc_support.default_exception_class("No protocol version supplied", locator="Version parameter")
-    version_support = svc_support.negotiated_version(version)
-
-    # create dummy env if not exists
     try:
+        if not svc_support.activated():
+            raise svc_support.default_exception_class("Invalid service and/or request", locator="Service and request parameters")
+
+        # Does service match path (if supplied)
+        if service != svc_support.service_upper:
+            raise svc_support.default_exception_class("Invalid service", locator="Service parameter")
+
+        version = nocase_args.get("version")
+        if not version:
+            raise svc_support.default_exception_class("No protocol version supplied", locator="Version parameter")
+        version_support = svc_support.negotiated_version(version)
+    except OGCException as e:
+        return e.exception_response()
+
+    try:
+        # create dummy env if not exists
         with rio_env():
             return version_support.router(nocase_args)
     except OGCException as e:

--- a/datacube_wms/ogc.py
+++ b/datacube_wms/ogc.py
@@ -77,6 +77,8 @@ class SupportedSvc(object):
         for v in reversed(self.versions):
             if rv_parts >= v.version_parts:
                 return v
+        # The constructor asserted that self.versions is not empty, so this is safe.
+        #pylint: disable=undefined-loop-variable
         return v
 
     def activated(self):


### PR DESCRIPTION
A cleanup of the routing code, adding in a framework for future support of multiple versions of protocols, and of OGC-style version negotiation.

Not much to see from the outside as we still only support one version per protocol, but it's a foundation for building WCS2.0 support on.