### PR TITLE
Sort dataset for new datacube support and improved performance

### DIFF
--- a/datacube_wms/data.py
+++ b/datacube_wms/data.py
@@ -100,9 +100,9 @@ def read_data(datasets, measurements, geobox, use_overviews=False, resampling=Re
         for name, coord in geobox.coordinates.items():
             all_bands[name] = (name, coord.values, {'units': coord.units})
 
+        datasets = sorted(datasets, key=lambda x: x.id)
         for measurement in measurements:
             datasources = [new_datasource(d, measurement['name']) for d in datasets]
-            datasources = sorted(datasources, key=lambda x: x._dataset.id)
             data = _get_measurement(datasources,
                                     geobox,
                                     resampling,


### PR DESCRIPTION
In the upcoming changes defined in #94 the new_datasource output has been modified, it no longer returns an object with the `_dataset` parameter. The fix for this is to sort datasets prior to getting the datasources. This will also give a small performance boost as we don't have to sort on each measurement. 

This change doesn't require the new datacube-core version.