### PR TITLE
Updating version of dea-proto

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,9 +26,6 @@ RUN pip3 install -r requirements.txt \
 RUN pip3 install -r requirements-opencensus.txt \
     && rm -rf $HOME/.cache/pip
 
-RUN pip3 install git+https://github.com/opendatacube/dea-proto.git@2da959d3747e4bb0db8025407220bb2589bbee10 \
-    && rm -rf $HOME/.cache/pip
-
 RUN python3 setup.py install
 
 COPY docker/wms-entrypoint.sh /usr/local/bin/wms-entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,13 +20,17 @@ WORKDIR /code
 
 ADD . .
 
+RUN pip3 install --upgrade pip \
+    && rm -rf $HOME/.cache/pip
+
 RUN pip3 install -r requirements.txt \
     && rm -rf $HOME/.cache/pip
 
 RUN pip3 install -r requirements-opencensus.txt \
     && rm -rf $HOME/.cache/pip
 
-RUN python3 setup.py install
+RUN pip3 install . \
+  && rm -rf $HOME/.cache/pip
 
 COPY docker/wms-entrypoint.sh /usr/local/bin/wms-entrypoint.sh
 COPY docker/get_wms_config.sh /usr/local/bin/get_wms_config.sh

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,4 +17,3 @@ pytest-localserver
 pytest-mock
 requests
 watchdog
-aiohttp

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,10 @@ with open('HISTORY.rst') as history_file:
     history = history_file.read()
 
 requirements = [
-    'datacube', 'flask', 'dea-proto'
+    'datacube', 'flask',
+    ('dea-proto @ git+https://github.com/opendatacube/dea-proto.git'
+     '@02b531d3cba9dad3bcccce44e90628bf69fef5b4'
+     '#egg=dea-proto')
 ]
 
 test_requirements = [
@@ -45,6 +48,5 @@ setup(
         'Programming Language :: Python :: 3.5',
     ],
     test_suite='tests',
-    tests_require=test_requirements,
-    dependency_links=['git+https://github.com/opendatacube/dea-proto.git@stable#egg=dea-proto-0.2']
+    tests_require=test_requirements
 )


### PR DESCRIPTION
`dea-proto` has been trimmed down by moving various helper apps out of main
`dea-proto` lib. Particularly there is no more `aiobotocore` dependency present.