### PR TITLE
Return empty images if pq_data is missing when it was requested

### DIFF
--- a/datacube_wms/data.py
+++ b/datacube_wms/data.py
@@ -337,10 +337,11 @@ def get_map(args):
                         else:
                             extent_mask &= f(data, band)
 
-            if data is not None:
-                body = _write_png(data, pq_data, params.style, extent_mask)
-            else:
+            if data is None or (params.style.masks and pq_data is None):
                 body = _write_empty(params.geobox)
+            else:
+                body = _write_png(data, pq_data, params.style, extent_mask)
+                
 
     return body, 200, resp_headers({"Content-Type": "image/png"})
 


### PR DESCRIPTION
With cases such as fractional cover being pq masked by WOfS, this prevents data from being displayed where the pq mask data does not exist in a particular area or time slice due to mismatches in what data is processed / available.