### PR TITLE
Only show the legend of the current style

### DIFF
--- a/datacube_wms/legend_generator.py
+++ b/datacube_wms/legend_generator.py
@@ -16,24 +16,24 @@ _LOG = logging.getLogger(__name__)
 def legend_graphic(args):
     params = GetLegendGraphicParameters(args)
     img = None
-    if not params.style_name:
-        product = params.product
-        legend_config = product.legend
-        if legend_config is not None:
-            if legend_config.get('url', None):
-                img_url = legend_config.get('url')
-                r = requests.get(img_url, timeout=1)
-                if r.status_code == 200 and r.headers['content-type'] == 'image/png':
-                    img = make_response(r.content)
-                    img.mimetype = 'image/png'
-            else:
-                styles = [product.style_index[s] for s in legend_config.get('styles', [])]
-                img = create_legends_from_styles(styles)
+    product = params.product
+    legend_config = product.legend
+    style = params.style_name
+    if legend_config is not None:
+        if legend_config.get('url', None):
+            img_url = legend_config.get('url')
+            r = requests.get(img_url, timeout=1)
+            if r.status_code == 200 and r.headers['content-type'] == 'image/png':
+                img = make_response(r.content)
+                img.mimetype = 'image/png'
+        else:
+            styles = [product.style_index[s] for s in legend_config.get('styles', []) if not style or s == style]
+            img = create_legends_from_styles(styles)
     return img
 
 
 def create_legend_for_style(product, style_name):
-    if not product.legend or style_name not in product.legend:
+    if not product.legend or style_name not in product.legend.get('styles', product.legend):
         return None
     style = product.style_index[style_name]
     return create_legends_from_styles([style])

--- a/datacube_wms/legend_generator.py
+++ b/datacube_wms/legend_generator.py
@@ -17,8 +17,8 @@ def legend_graphic(args):
     params = GetLegendGraphicParameters(args)
     img = None
     product = params.product
-    legend_config = product.legend
     style = params.style_name
+    legend_config = getattr(product, 'legend', None)
     if legend_config is not None:
         if legend_config.get('url', None):
             img_url = legend_config.get('url')

--- a/datacube_wms/templates/wms_capabilities.xml
+++ b/datacube_wms/templates/wms_capabilities.xml
@@ -185,7 +185,7 @@ http://schemas.opengis.net/wms/1.3.0/capabilities_1_3_0.xsd">
                         <Name>{{ style.name }}</Name>
                         <Title>{{ style.title }}</Title>
                         <Abstract>{{ style.abstract }}</Abstract>
-                        {% if product.legend and style.name in product.legend %}
+                        {% if product.legend and style.name in product.legend.styles %}
                         <LegendURL>
                             <Format>image/png</Format>
                             <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink"


### PR DESCRIPTION
There were a couple of places the code was looking for the style name in `product.legend` instead of `product.legend['styles']`
Not sure if there a wider implications on particular WMS client interactions?