### PR TITLE
Per-style legend fixes

### DIFF
--- a/datacube_wms/band_mapper.py
+++ b/datacube_wms/band_mapper.py
@@ -63,6 +63,10 @@ class StyleDefBase(object):
     def legend(self, bytesio):
         pass
 
+    def legend_override_with_url(self):
+        return self.legend_cfg.get('url', None)
+
+
 class DynamicRangeCompression(StyleDefBase):
     def __init__(self, product, style_cfg):
         super(DynamicRangeCompression, self).__init__(product, style_cfg)

--- a/datacube_wms/templates/wms_capabilities.xml
+++ b/datacube_wms/templates/wms_capabilities.xml
@@ -188,12 +188,22 @@ http://schemas.opengis.net/wms/1.3.0/capabilities_1_3_0.xsd">
                         <Name>{{ style.name }}</Name>
                         <Title>{{ style.title }}</Title>
                         <Abstract>{{ style.abstract }}</Abstract>
-                        {% if product.legend and style.name in product.legend.styles %}
+                        {% if product.legend and product.legend.styles is defined and style.name in product.legend.styles %}
                         <LegendURL>
                             <Format>image/png</Format>
                             <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink"
                                             xlink:type="simple"
                                             xlink:href="{{ base_url }}/legend/{{ product.name }}/{{ style.name }}/legend.png"/>
+                        </LegendURL>
+                        {% elif product.legend and product.legend.styles is defined %}
+                        {# We are letting the styles define the legend, just not this style, so don't include a URL.
+                        This works better than returning a transparent pixel, as Terria puts that transparent
+                        pixel on a white background. #}
+                        <LegendURL width="0" height="0">
+                            <Format>image/png</Format>
+                            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink"
+                                            xlink:type="simple"
+                                            xlink:href=""/>
                         </LegendURL>
                         {% endif %}
                     </Style>

--- a/datacube_wms/wms_cfg_example.py
+++ b/datacube_wms/wms_cfg_example.py
@@ -706,7 +706,12 @@ layer_cfg = [
                                 "value": 1.0,
                                 "color": "#114D04"
                             }
-                        ]
+                        ],
+                        "legend": {
+                            # Instead of using the generated color ramp legend for the style, a URL to a PNG file can
+                            # be used instead.
+                            "url": "http://example.com/custom_style_image.png"
+                        }
                     },
                     {
                         "name": "ndvi_cloudmask",

--- a/tests/test_legend_generator.py
+++ b/tests/test_legend_generator.py
@@ -17,6 +17,8 @@ def test_create_legends_from_styles(make_response):
         def __init__(self):
             self.legend = MagicMock()
             self.legend.side_effect = fake_img
+            self.legend_override_with_url = MagicMock()
+            self.legend_override_with_url.return_value = None
 
     datacube_wms.legend_generator.create_legends_from_styles([fakestyle()])
 


### PR DESCRIPTION
This PR does 2 things:
* Allows a URL to be provided instead of the style legend (Closes #119)
* For styles not in the list of `product.legend.styles`, advertise a blank URL, to prevent Terria from falling back to `GetLegendGraphic` for the layer.

`GetLegendGraphic` will still work for legends set at the layer level.