### PR TITLE
Support time range queries

### DIFF
--- a/datacube_wms/wms_utils.py
+++ b/datacube_wms/wms_utils.py
@@ -186,6 +186,9 @@ def get_time(args, product, raw_product):
             locator="Time parameter")
 
     times = times.split('/')
+    # Time range handling follows the implementation described by GeoServer
+    # https://docs.geoserver.org/stable/en/user/services/wms/time.html
+
     # If all times are equal we can proceed
     if len(set(times)) > 1:
         start, end = parse_wms_time_strings(times)

--- a/datacube_wms/wms_utils.py
+++ b/datacube_wms/wms_utils.py
@@ -190,18 +190,13 @@ def get_time(args, product, raw_product):
     # https://docs.geoserver.org/stable/en/user/services/wms/time.html
 
     # If all times are equal we can proceed
-    if len(set(times)) > 1:
+    if len(times) > 1:
         start, end = parse_wms_time_strings(times)
         start, end = start.date(), end.date()
         matching_times = [t for t in product.ranges['times'] if start <= t <= end]
-        if len(matching_times) == 1:
+        if matching_times:
+            # default to the first matching time
             return matching_times[0]
-        elif len(matching_times) > 1:
-            # We could default to first time instead?
-            raise WMSException(
-                "Selecting multiple time dimension values not supported",
-                WMSException.INVALID_DIMENSION_VALUE,
-                locator="Time parameter")
         else:
             raise WMSException(
                 "Time dimension range '%s'-'%s' not valid for this layer" % (start, end),
@@ -262,7 +257,7 @@ def parse_wms_time_strings(parts):
         return fuzzy_end - start + a_tiny_bit, end
     if isinstance(end, relativedelta):
         return start, start + end - a_tiny_bit
-    return start, end
+    return start, end - a_tiny_bit
 
 
 def bounding_box_to_geom(bbox, bb_crs, target_crs):

--- a/datacube_wms/wms_utils.py
+++ b/datacube_wms/wms_utils.py
@@ -257,7 +257,7 @@ def parse_wms_time_strings(parts):
         return fuzzy_end - start + a_tiny_bit, end
     if isinstance(end, relativedelta):
         return start, start + end - a_tiny_bit
-    return start, end - a_tiny_bit
+    return start, end
 
 
 def bounding_box_to_geom(bbox, bb_crs, target_crs):

--- a/datacube_wms/wms_utils.py
+++ b/datacube_wms/wms_utils.py
@@ -1,9 +1,16 @@
 from __future__ import absolute_import, division, print_function
 
+try:
+    import regex as re
+except ImportError:
+    import re
+
 from datetime import datetime
 from dateutil.parser import parse
+from dateutil.relativedelta import relativedelta
 from pytz import utc
 from urllib.parse import unquote
+
 try:
     from rasterio.warp import Resampling
 except ImportError:
@@ -31,8 +38,9 @@ RESAMPLING_METHODS = {
     'average': Resampling.average,
 }
 
+
 def _bounding_pts(minx, miny, maxx, maxy, width, height, src_crs, dst_crs=None):
-    #pylint: disable=too-many-locals
+    # pylint: disable=too-many-locals
     p1 = geometry.point(minx, maxy, src_crs)
     p2 = geometry.point(minx, miny, src_crs)
     p3 = geometry.point(maxx, maxy, src_crs)
@@ -52,6 +60,7 @@ def _bounding_pts(minx, miny, maxx, maxy, width, height, src_crs, dst_crs=None):
     # miny-maxy for negative scale factor and maxy in the translation, includes inversion of Y axis.
 
     return minx, miny, maxx, maxy
+
 
 def _get_geobox_xy(args, crs):
     if get_service_cfg().published_CRSs[crs.crs_str]["vertical_coord_first"]:
@@ -157,26 +166,48 @@ def get_arg(args, argname, verbose_name, lower=False,
     return fmt
 
 
+def get_times_for_product(product, raw_product):
+    chunks = raw_product.split("__")
+    if len(chunks) == 1:
+        ranges = product.ranges
+    else:
+        path = int(chunks[1])
+        ranges = product.sub_ranges[path]
+    return ranges['times']
+
+
 def get_time(args, product, raw_product):
     # Time parameter
-    times = args.get('time', '').split('/')
-    # If all times are equal we can proceed
-    if len(set(times)) > 1:
+    times = args.get('time', '')
+    if times.find(',') != -1:
         raise WMSException(
-            "Selecting multiple time dimension values not supported",
+            "Selecting a list of time dimension values not supported",
             WMSException.INVALID_DIMENSION_VALUE,
             locator="Time parameter")
+
+    times = times.split('/')
+    # If all times are equal we can proceed
+    if len(set(times)) > 1:
+        start, end = parse_wms_time_strings(times)
+        start, end = start.date(), end.date()
+        matching_times = [t for t in product.ranges['times'] if start <= t <= end]
+        if len(matching_times) == 1:
+            return matching_times[0]
+        elif len(matching_times) > 1:
+            # We could default to first time instead?
+            raise WMSException(
+                "Selecting multiple time dimension values not supported",
+                WMSException.INVALID_DIMENSION_VALUE,
+                locator="Time parameter")
+        else:
+            raise WMSException(
+                "Time dimension range '%s'-'%s' not valid for this layer" % (start, end),
+                WMSException.INVALID_DIMENSION_VALUE,
+                locator="Time parameter")
     elif not times[0]:
         # default to last available time if not supplied.
-        chunks = raw_product.split("__")
-        if len(chunks) == 1:
-            path = None
-            ranges = product.ranges
-        else:
-            path = int(chunks[1])
-            ranges = product.sub_ranges[path]
-
-        return ranges["times"][-1]
+        product_times = get_times_for_product(product, raw_product)
+        return product_times[-1]
     try:
         time = parse(times[0]).date()
     except ValueError:
@@ -185,13 +216,45 @@ def get_time(args, product, raw_product):
             WMSException.INVALID_DIMENSION_VALUE,
             locator="Time parameter")
 
-    # Validate time paramter for requested layer.
+    # Validate time parameter for requested layer.
     if time not in product.ranges["time_set"]:
         raise WMSException(
             "Time dimension value '%s' not valid for this layer" % times[0],
             WMSException.INVALID_DIMENSION_VALUE,
             locator="Time parameter")
     return time
+
+
+def parse_time_delta(delta_str):
+    pattern = (r'P((?P<years>\d+)Y)?((?P<months>\d+)M)?((?P<days>\d+)D)?'
+               r'(T(((?P<hours>\d+)H)?((?P<minutes>\d+)M)?((?P<seconds>\d+)S)?)?)?')
+    parts = re.search(pattern, delta_str).groupdict()
+    return relativedelta(**{k: float(v) for k, v in parts.items() if v is not None})
+
+
+def parse_wms_time_string(t):
+    if t.upper() == 'PRESENT':
+        return datetime.utcnow()
+    elif t.startswith('P'):
+        return parse_time_delta(t)
+    else:
+        return parse(t)
+
+
+def parse_wms_time_strings(parts):
+    start = parse_wms_time_string(parts[0])
+    end = parse_wms_time_string(parts[-1])
+
+    if isinstance(start, relativedelta):
+        if isinstance(end, relativedelta):
+            raise WMSException(
+                "Could not understand time value '%s'" %parts,
+                WMSException.INVALID_DIMENSION_VALUE,
+                locator="Time parameter")
+        return end - start, end
+    if isinstance(end, relativedelta):
+        return start, start + end
+    return start, end
 
 
 def bounding_box_to_geom(bbox, bb_crs, target_crs):
@@ -240,6 +303,7 @@ class GetParameters():
 
     def get_raw_product(self, args):
         return args["layers"].split(",")[0]
+
 
 class GetLegendGraphicParameters():
     def __init__(self, args):
@@ -326,7 +390,7 @@ def declination_rad(dt):
     # Estimate solar declination from a datetime.  (value returned in radians).
     # Formula taken from https://en.wikipedia.org/wiki/Position_of_the_Sun#Declination_of_the_Sun_as_seen_from_Earth
     timedel = dt - datetime(dt.year, 1, 1, 0, 0, 0, tzinfo=utc)
-    day_count = timedel.days + timedel.seconds/(60.0*60.0*24.0)
+    day_count = timedel.days + timedel.seconds / (60.0 * 60.0 * 24.0)
     return -1.0 * math.radians(23.44) * math.cos(2 * math.pi / 365 * (day_count + 10))
 
 
@@ -335,7 +399,7 @@ def cosine_of_solar_zenith(lat, lon, utc_dt):
     # (angle between sun and local zenith) at requested latitude, longitude and datetime.
     # Formula taken from https://en.wikipedia.org/wiki/Solar_zenith_angle
     utc_seconds_since_midnight = ((utc_dt.hour * 60) + utc_dt.minute) * 60 + utc_dt.second
-    utc_hour_deg_angle = (utc_seconds_since_midnight / (60*60*24) * 360.0) - 180.0
+    utc_hour_deg_angle = (utc_seconds_since_midnight / (60 * 60 * 24) * 360.0) - 180.0
     local_hour_deg_angle = utc_hour_deg_angle + lon
     local_hour_angle_rad = math.radians(local_hour_deg_angle)
     latitude_rad = math.radians(lat)
@@ -348,8 +412,8 @@ def cosine_of_solar_zenith(lat, lon, utc_dt):
 def solar_correct_data(data, dataset):
     # Apply solar angle correction to the data for a dataset.
     # See for example http://gsp.humboldt.edu/olm_2015/Courses/GSP_216_Online/lesson4-1/radiometric.html
-    native_x = (dataset.bounds.right + dataset.bounds.left)/2.0
-    native_y = (dataset.bounds.top + dataset.bounds.bottom)/2.0
+    native_x = (dataset.bounds.right + dataset.bounds.left) / 2.0
+    native_y = (dataset.bounds.top + dataset.bounds.bottom) / 2.0
     pt = geometry.point(native_x, native_y, dataset.crs)
     crs_geo = geometry.CRS("EPSG:4326")
     geo_pt = pt.to_crs(crs_geo)
@@ -365,6 +429,7 @@ def wofls_fuser(dest, src):
     where_nodata = (src & 1) == 0
     numpy.copyto(dest, src, where=where_nodata)
     return dest
+
 
 def item_fuser(dest, src):
     where_combined = numpy.isnan(dest) | (dest == -6666.)

--- a/tests/test_wms_utils.py
+++ b/tests/test_wms_utils.py
@@ -14,7 +14,7 @@ def test_parse_time_delta():
             assert td == datacube_wms.wms_utils.parse_time_delta(td_str)
 
 
-def test_parse_wms_time_string():
+def test_parse_wms_time_strings():
     import datetime
     tests = {
         '2018-01-10/2019-01-10': (datetime.datetime(2018, 1, 10, 0, 0), datetime.datetime(2019, 1, 10, 23, 23, 59)),
@@ -24,11 +24,11 @@ def test_parse_wms_time_string():
     }
 
     for value, result in tests.items():
-        assert result == datacube_wms.wms_utils.parse_wms_time_string(value)
+        assert result == datacube_wms.wms_utils.parse_wms_time_strings(value)
 
 
-def test_parse_wms_time_string():
+def test_parse_wms_time_strings_with_present():
     import datetime
-    start, end = datacube_wms.wms_utils.parse_wms_time_string('2018-01-10/PRESENT')
+    start, end = datacube_wms.wms_utils.parse_wms_time_strings('2018-01-10/PRESENT')
     assert start == datetime.datetime(2018, 1, 10, 0, 0)
     assert (datetime.utcnow() - end).total_seconds() < 60

--- a/tests/test_wms_utils.py
+++ b/tests/test_wms_utils.py
@@ -1,0 +1,33 @@
+import datacube_wms.wms_utils
+
+
+def test_parse_time_delta():
+    from dateutil.relativedelta import relativedelta
+
+    tests = {
+        relativedelta(hours=1): ['P0Y0M0DT1H0M0S', 'PT1H0M0S', 'PT1H', ],
+        relativedelta(months=18): ['P1Y6M0DT0H0M0S', 'P1Y6M0D', 'P0Y18M0DT0H0M0S', 'P18M', ],
+        relativedelta(minutes=90): ['PT1H30M', 'P0Y0M0DT1H30M0S', 'PT90M'],
+    }
+    for td, td_str_list in tests.items():
+        for td_str in td_str_list:
+            assert td == datacube_wms.wms_utils.parse_time_delta(td_str)
+
+
+def test_parse_wms_time_string():
+    import datetime
+    tests = {
+        '2018-01-10/2019-01-10': (datetime.datetime(2018, 1, 10, 0, 0), datetime.datetime(2019, 1, 10, 0, 0)),
+        '2018-01-10/P5D': (datetime.datetime(2018, 1, 10, 0, 0), datetime.datetime(2018, 1, 15, 0, 0)),
+        'P1M/2018-01-10': (datetime.datetime(2017, 12, 10, 0, 0), datetime.datetime(2018, 1, 10, 0, 0))
+    }
+
+    for value, result in tests.items():
+        assert result == datacube_wms.wms_utils.parse_wms_time_string(value)
+
+
+def test_parse_wms_time_string():
+    import datetime
+    start, end = datacube_wms.wms_utils.parse_wms_time_string('2018-01-10/PRESENT')
+    assert start == datetime.datetime(2018, 1, 10, 0, 0)
+    assert (datetime.utcnow() - end).total_seconds() < 60

--- a/tests/test_wms_utils.py
+++ b/tests/test_wms_utils.py
@@ -15,12 +15,12 @@ def test_parse_time_delta():
 
 
 def test_parse_wms_time_strings():
-    import datetime
+    import datetime as dt
     tests = {
-        '2018-01-10/2019-01-10': (datetime.datetime(2018, 1, 10, 0, 0), datetime.datetime(2019, 1, 10, 23, 23, 59)),
-        '2000/P1Y': (datetime.datetime(2000, 1, 1, 0, 0), datetime.datetime(2000, 12, 31, 23, 59, 59, 999999)),
-        '2018-01-10/P5D': (datetime.datetime(2018, 1, 10, 0, 0), datetime.datetime(2018, 1, 14, 23, 59, 59, 999999)),
-        'P1M/2018-01-10': (datetime.datetime(2017, 12, 10, 0, 0, 0, 1), datetime.datetime(2018, 1, 10, 23, 23, 59)),
+        '2018-01-10/2019-01-10': (dt.datetime(2018, 1, 10, 0, 0), dt.datetime(2019, 1, 10, 23, 23, 59, 999999)),
+        '2000/P1Y': (dt.datetime(2000, 1, 1, 0, 0), dt.datetime(2000, 12, 31, 23, 59, 59, 999999)),
+        '2018-01-10/P5D': (dt.datetime(2018, 1, 10, 0, 0), dt.datetime(2018, 1, 14, 23, 59, 59, 999999)),
+        'P1M/2018-01-10': (dt.datetime(2017, 12, 10, 0, 0, 0, 1), dt.datetime(2018, 1, 10, 23, 23, 59, 999999)),
     }
 
     for value, result in tests.items():
@@ -28,7 +28,7 @@ def test_parse_wms_time_strings():
 
 
 def test_parse_wms_time_strings_with_present():
-    import datetime
+    import datetime as dt
     start, end = datacube_wms.wms_utils.parse_wms_time_strings('2018-01-10/PRESENT'.split('/'))
-    assert start == datetime.datetime(2018, 1, 10, 0, 0)
-    assert (datetime.utcnow() - end).total_seconds() < 60
+    assert start == dt.datetime(2018, 1, 10, 0, 0)
+    assert (dt.datetime.utcnow() - end).total_seconds() < 60

--- a/tests/test_wms_utils.py
+++ b/tests/test_wms_utils.py
@@ -17,9 +17,10 @@ def test_parse_time_delta():
 def test_parse_wms_time_string():
     import datetime
     tests = {
-        '2018-01-10/2019-01-10': (datetime.datetime(2018, 1, 10, 0, 0), datetime.datetime(2019, 1, 10, 0, 0)),
-        '2018-01-10/P5D': (datetime.datetime(2018, 1, 10, 0, 0), datetime.datetime(2018, 1, 15, 0, 0)),
-        'P1M/2018-01-10': (datetime.datetime(2017, 12, 10, 0, 0), datetime.datetime(2018, 1, 10, 0, 0))
+        '2018-01-10/2019-01-10': (datetime.datetime(2018, 1, 10, 0, 0), datetime.datetime(2019, 1, 10, 23, 23, 59)),
+        '2000/P1Y': (datetime.datetime(2000, 1, 1, 0, 0), datetime.datetime(2000, 12, 31, 23, 59, 59, 999999)),
+        '2018-01-10/P5D': (datetime.datetime(2018, 1, 10, 0, 0), datetime.datetime(2018, 1, 14, 23, 59, 59, 999999)),
+        'P1M/2018-01-10': (datetime.datetime(2017, 12, 10, 0, 0, 0, 1), datetime.datetime(2018, 1, 10, 23, 23, 59)),
     }
 
     for value, result in tests.items():

--- a/tests/test_wms_utils.py
+++ b/tests/test_wms_utils.py
@@ -24,11 +24,11 @@ def test_parse_wms_time_strings():
     }
 
     for value, result in tests.items():
-        assert result == datacube_wms.wms_utils.parse_wms_time_strings(value)
+        assert result == datacube_wms.wms_utils.parse_wms_time_strings(value.split('/'))
 
 
 def test_parse_wms_time_strings_with_present():
     import datetime
-    start, end = datacube_wms.wms_utils.parse_wms_time_strings('2018-01-10/PRESENT')
+    start, end = datacube_wms.wms_utils.parse_wms_time_strings('2018-01-10/PRESENT'.split('/'))
     assert start == datetime.datetime(2018, 1, 10, 0, 0)
     assert (datetime.utcnow() - end).total_seconds() < 60


### PR DESCRIPTION
The PR adds support for WMS time range queries, defaulting to the first time, when multiple valid times are found in the requested time range ~~when the time range covers a single time~~.

It supports:

- fixed ranges: `2018-01-10/2019-01-10` 
- fixed ranges with reduced accuracy: `2018-01/2018-03`
- range/duration: `2000/P1Y`, 
- current time: `2019-01-01/PRESENT`

It uses GeoServer's documentation as a guide:
https://docs.geoserver.org/stable/en/user/services/wms/time.html

This will allow use with the QGIS TimeManager WMS client.
Closes #65