### PR TITLE
Partial undo LegendURL changes

### DIFF
--- a/datacube_wms/legend_generator.py
+++ b/datacube_wms/legend_generator.py
@@ -26,9 +26,13 @@ def legend_graphic(args):
             if r.status_code == 200 and r.headers['content-type'] == 'image/png':
                 img = make_response(r.content)
                 img.mimetype = 'image/png'
-        else:
-            styles = [product.style_index[s] for s in legend_config.get('styles', []) if not style or s == style]
-            img = create_legends_from_styles(styles)
+        elif legend_config.get('styles', []):
+            if style in legend_config.get('styles', []):
+                img = create_legends_from_styles([style])
+            elif set(legend_config.get('styles', [])) == set(product.style_index.keys()):
+                # We want all the styles, and all the styles have legends
+                styles = [product.style_index[s] for s in legend_config.get('styles', [])]
+                img = create_legends_from_styles(styles)
     return img
 
 

--- a/datacube_wms/templates/wms_capabilities.xml
+++ b/datacube_wms/templates/wms_capabilities.xml
@@ -195,16 +195,6 @@ http://schemas.opengis.net/wms/1.3.0/capabilities_1_3_0.xsd">
                                             xlink:type="simple"
                                             xlink:href="{{ base_url }}/legend/{{ product.name }}/{{ style.name }}/legend.png"/>
                         </LegendURL>
-                        {% elif product.legend and product.legend.styles is defined %}
-                        {# We are letting the styles define the legend, just not this style, so don't include a URL.
-                        This works better than returning a transparent pixel, as Terria puts that transparent
-                        pixel on a white background. #}
-                        <LegendURL width="0" height="0">
-                            <Format>image/png</Format>
-                            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink"
-                                            xlink:type="simple"
-                                            xlink:href=""/>
-                        </LegendURL>
                         {% endif %}
                     </Style>
                 {% endfor %}


### PR DESCRIPTION
No longer provide empty LegendURL strings, as this broke OGC compliance
Don't provide a combined Legend image if not all styles are on it