### PR TITLE
Run OWS docker image as an owsuser instead of a root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -78,10 +78,16 @@ ADD https://raw.githubusercontent.com/opendatacube/datacube-dataset-config/maste
 
 WORKDIR /code
 
+# Create owsuser directory using root access
+RUN mkdir -p "$HOME"/owsuser
+
+# Provide access to owsuser
+RUN chown owsuser "$HOME"/owsuser
+
+# Run container as an owsuser instead as root user
 USER owsuser
 
 # Create a new .datacube.conf file in owsuser home directory
-RUN mkdir -p "$HOME"
 RUN echo "[datacube]" > "$HOME/.datacube.conf"
 ENTRYPOINT ["wms-entrypoint.sh"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -81,6 +81,9 @@ WORKDIR /code
 # Create owsuser directory using root access
 RUN mkdir -p "$HOME"/owsuser
 
+# Create a new .datacube.conf file in owsuser home directory
+RUN echo "[datacube]" > "$HOME/owsuser/.datacube.conf"
+
 # Provide access to owsuser
 RUN chown owsuser "$HOME"/owsuser
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -84,8 +84,14 @@ RUN mkdir -p /home/owsuser
 # Create a new .datacube.conf file in owsuser home directory as a root user
 RUN echo "[datacube]" > /home/owsuser/.datacube.conf
 
-# Change the ownership from root:root to owsgroup:owsuser
-RUN chown -c owsgroup:owsuser /home/owsuser/.datacube.conf
+RUN cd /home/owsuser/
+RUN ls -la
+
+# Change the ownership from root to owsuser
+RUN chown -c owsuser /home/owsuser/.datacube.conf
+
+RUN cd /home/owsuser/
+RUN ls -la
 
 # Run container as an owsuser instead as root user
 USER owsuser

--- a/Dockerfile
+++ b/Dockerfile
@@ -82,7 +82,7 @@ WORKDIR /code
 RUN mkdir -p /home/owsuser
 
 # Create a new .datacube.conf file in owsuser home directory as a root user
-RUN echo "[datacube]" > "$HOME"/.datacube.conf
+RUN echo "[datacube]" > /home/owsuser/.datacube.conf
 
 # Run container as an owsuser instead as root user
 USER owsuser

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,9 @@ FROM opendatacube/datacube-core:1.7
 
 ENV DEBIAN_FRONTEND=noninteractive
 
+RUN groupadd -r owsgroup && \
+    useradd -r -g owsgroup owsuser
+
 RUN apt-get update && apt-get install -y \
     python3-matplotlib \
     python3-pil\
@@ -75,6 +78,7 @@ ADD https://raw.githubusercontent.com/opendatacube/datacube-dataset-config/maste
 
 WORKDIR /code
 
+USER owsuser
 ENTRYPOINT ["wms-entrypoint.sh"]
 
 CMD gunicorn -b '0.0.0.0:8000' -w 4 --timeout 120 datacube_wms.wsgi --pid=gunicorn.pid

--- a/Dockerfile
+++ b/Dockerfile
@@ -81,14 +81,11 @@ WORKDIR /code
 # Create owsuser directory using root access
 RUN mkdir -p /home/owsuser
 
-# Create a new .datacube.conf file in owsuser home directory
+# Create a new .datacube.conf file in owsuser home directory as a root user
 RUN echo "[datacube]" > "$HOME"/.datacube.conf
 
 # Run container as an owsuser instead as root user
 USER owsuser
-
-# Provide access to owsuser
-RUN chown owsuser "$HOME"
 
 ENTRYPOINT ["wms-entrypoint.sh"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -79,6 +79,9 @@ ADD https://raw.githubusercontent.com/opendatacube/datacube-dataset-config/maste
 WORKDIR /code
 
 USER owsuser
+
+# Create a new .datacube.conf file in owsuser home directory
+RUN echo "[datacube]" > "$HOME/.datacube.conf"
 ENTRYPOINT ["wms-entrypoint.sh"]
 
 CMD gunicorn -b '0.0.0.0:8000' -w 4 --timeout 120 datacube_wms.wsgi --pid=gunicorn.pid

--- a/Dockerfile
+++ b/Dockerfile
@@ -78,19 +78,17 @@ ADD https://raw.githubusercontent.com/opendatacube/datacube-dataset-config/maste
 
 WORKDIR /code
 
-# Run container as an owsuser instead as root user
-USER owsuser
-
-WORKDIR "$HOME"
-
 # Create owsuser directory using root access
-RUN mkdir -p "$HOME"/owsuser
-
-# Provide access to owsuser
-RUN chown owsuser "$HOME"/owsuser
+RUN mkdir -p /home/owsuser
 
 # Create a new .datacube.conf file in owsuser home directory
 RUN echo "[datacube]" > "$HOME"/.datacube.conf
+
+# Run container as an owsuser instead as root user
+USER owsuser
+
+# Provide access to owsuser
+RUN chown owsuser "$HOME"/owsuser
 
 ENTRYPOINT ["wms-entrypoint.sh"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -84,14 +84,8 @@ RUN mkdir -p /home/owsuser
 # Create a new .datacube.conf file in owsuser home directory as a root user
 RUN echo "[datacube]" > /home/owsuser/.datacube.conf
 
-RUN cd /home/owsuser/
-RUN ls -la
-
 # Change the ownership from root to owsuser
 RUN chown -c owsuser /home/owsuser/.datacube.conf
-
-RUN cd /home/owsuser/
-RUN ls -la
 
 # Run container as an owsuser instead as root user
 USER owsuser

--- a/Dockerfile
+++ b/Dockerfile
@@ -88,7 +88,7 @@ RUN echo "[datacube]" > "$HOME"/.datacube.conf
 USER owsuser
 
 # Provide access to owsuser
-RUN chown owsuser "$HOME"/owsuser
+RUN chown owsuser "$HOME"
 
 ENTRYPOINT ["wms-entrypoint.sh"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -81,6 +81,8 @@ WORKDIR /code
 # Run container as an owsuser instead as root user
 USER owsuser
 
+WORKDIR "$HOME"
+
 # Create owsuser directory using root access
 RUN mkdir -p "$HOME"/owsuser
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -84,6 +84,9 @@ RUN mkdir -p /home/owsuser
 # Create a new .datacube.conf file in owsuser home directory as a root user
 RUN echo "[datacube]" > /home/owsuser/.datacube.conf
 
+# Change the ownership from root:root to owsgroup:owsuser
+RUN chown -c owsgroup:owsuser /home/owsuser/.datacube.conf
+
 # Run container as an owsuser instead as root user
 USER owsuser
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -78,19 +78,17 @@ ADD https://raw.githubusercontent.com/opendatacube/datacube-dataset-config/maste
 
 WORKDIR /code
 
+# Run container as an owsuser instead as root user
+USER owsuser
+
 # Create owsuser directory using root access
 RUN mkdir -p "$HOME"/owsuser
-RUN echo "$HOME"
 
 # Provide access to owsuser
 RUN chown owsuser "$HOME"/owsuser
 
-# Run container as an owsuser instead as root user
-USER owsuser
-
 # Create a new .datacube.conf file in owsuser home directory
-RUN echo "$HOME"
-RUN echo "[datacube]" > /home/owsuser/.datacube.conf
+RUN echo "[datacube]" > "$HOME"/.datacube.conf
 
 ENTRYPOINT ["wms-entrypoint.sh"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -86,9 +86,6 @@ RUN chown owsuser "$HOME"/owsuser
 
 # Run container as an owsuser instead as root user
 USER owsuser
-
-# Create a new .datacube.conf file in owsuser home directory
-RUN echo "[datacube]" > "$HOME/.datacube.conf"
 ENTRYPOINT ["wms-entrypoint.sh"]
 
 CMD gunicorn -b '0.0.0.0:8000' -w 4 --timeout 120 datacube_wms.wsgi --pid=gunicorn.pid

--- a/Dockerfile
+++ b/Dockerfile
@@ -81,6 +81,7 @@ WORKDIR /code
 USER owsuser
 
 # Create a new .datacube.conf file in owsuser home directory
+RUN mkdir -p "$HOME"
 RUN echo "[datacube]" > "$HOME/.datacube.conf"
 ENTRYPOINT ["wms-entrypoint.sh"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -80,15 +80,18 @@ WORKDIR /code
 
 # Create owsuser directory using root access
 RUN mkdir -p "$HOME"/owsuser
-
-# Create a new .datacube.conf file in owsuser home directory
-RUN echo "[datacube]" > "$HOME/owsuser/.datacube.conf"
+RUN echo "$HOME"
 
 # Provide access to owsuser
 RUN chown owsuser "$HOME"/owsuser
 
 # Run container as an owsuser instead as root user
 USER owsuser
+
+# Create a new .datacube.conf file in owsuser home directory
+RUN echo "$HOME"
+RUN echo "[datacube]" > /home/owsuser/.datacube.conf
+
 ENTRYPOINT ["wms-entrypoint.sh"]
 
 CMD gunicorn -b '0.0.0.0:8000' -w 4 --timeout 120 datacube_wms.wsgi --pid=gunicorn.pid


### PR DESCRIPTION
Add `ows users` within `ows group` and enable `ows user` to run `ows` `image` as an `user` instead of `root` user.