### PR TITLE
Configure gunicorn to use /dev/shm instead of /tmp

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,10 +26,6 @@ RUN pip3 install --upgrade pip \
 RUN pip3 install -r requirements.txt \
     && rm -rf $HOME/.cache/pip
 
-# ODC cloud tools depend on aiobotocore which has a dependency on a specific version of botocore,
-# boto3 also depends on a specific version of botocore as a result having both aiobotocore and boto3 in one
-# environment can be a bit tricky. The easiest way to solve this is to install aiobotocore[awscli,boto3] before
-# anything else, which will pull in a compatible version of boto3 and awscli into the environment.
 RUN pip install -U 'aiobotocore[awscli,boto3]' \
     && rm -rf $HOME/.cache/pip
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,10 +30,10 @@ RUN pip3 install -r requirements.txt \
 # boto3 also depends on a specific version of botocore as a result having both aiobotocore and boto3 in one
 # environment can be a bit tricky. The easiest way to solve this is to install aiobotocore[awscli,boto3] before
 # anything else, which will pull in a compatible version of boto3 and awscli into the environment.
-RUN pip3 install -U 'aiobotocore[awscli,boto3]' \
+RUN pip install -U 'aiobotocore[awscli,boto3]' \
     && rm -rf $HOME/.cache/pip
 
-RUN pip3 install --extra-index-url="https://packages.dea.gadevs.ga" \
+RUN pip install --extra-index-url="https://packages.dea.gadevs.ga" \
     odc-apps-cloud \
     odc-apps-dc-tools \
     && rm -rf $HOME/.cache/pip

--- a/Dockerfile
+++ b/Dockerfile
@@ -80,4 +80,4 @@ WORKDIR /code
 
 ENTRYPOINT ["wms-entrypoint.sh"]
 
-CMD gunicorn -b '0.0.0.0:8000' --workers=3 --threads=2 --worker-class=gthread --worker-tmp-dir /dev/shm --timeout 120 --pid=gunicorn.pid datacube_wms.wsgi
+CMD gunicorn -b '0.0.0.0:8000' --workers=3 --threads=2 -k gevent --timeout 121 --pid gunicorn.pid --log-level info --worker-tmp-dir /dev/shm datacube_wms.wsgi


### PR DESCRIPTION
## Following are the changes implemented in this PR:
1) To ensures maximum CPU utilization, and reduces the chances of being unable to respond to a heartbeat query, update `gunicorn` as follows:

    ` CMD gunicorn -b '0.0.0.0:8000' --workers=3 --threads=2 -k gevent --timeout 121 --pid gunicorn.pid --log-level info --worker-tmp-dir /dev/shm datacube_wms.wsgi`

2) Install `dea-proto` dependencies using `--extra-index-url` option and remove use of `git+https` in the dependency list

3) Use `pip3` for installation