### PR TITLE
Enable 10 second cache on getCaps

### DIFF
--- a/datacube_wms/wcs.py
+++ b/datacube_wms/wcs.py
@@ -109,7 +109,7 @@ def desc_coverages(args):
         200,
         resp_headers({
             "Content-Type": "application/xml",
-            "Cache-Control": "no-cache.max-age=0"
+            "Cache-Control": "max-age=10"
         })
     )
 

--- a/datacube_wms/wms.py
+++ b/datacube_wms/wms.py
@@ -60,6 +60,6 @@ def get_capabilities(args):
             base_url=base_url),
         200,
         resp_headers(
-            {"Content-Type": "application/xml", "Cache-Control": "no-cache,max-age=0"}
+            {"Content-Type": "application/xml", "Cache-Control": "max-age=10"}
         )
     )

--- a/datacube_wms/wmts.py
+++ b/datacube_wms/wmts.py
@@ -117,7 +117,7 @@ def get_capabilities(args):
             webmerc_ss = WebMercScaleSet),
         200,
         resp_headers(
-            {"Content-Type": "application/xml", "Cache-Control": "no-cache,max-age=0"}
+            {"Content-Type": "application/xml", "Cache-Control": "max-age=10"}
         )
     )
 


### PR DESCRIPTION
Enables getCaps to be cached by load balancers / CDNs for 10 seconds, should improve performance and reduce DB / CPU usage.