### PR TITLE
Addresses Matplotlib ColorMaps support

### DIFF
--- a/datacube_ows/band_mapper.py
+++ b/datacube_ows/band_mapper.py
@@ -15,7 +15,7 @@ import matplotlib
 # Do not use X Server backend
 matplotlib.use('Agg')
 import matplotlib.pyplot as plt
-from matplotlib.colors import LinearSegmentedColormap
+from matplotlib.colors import LinearSegmentedColormap, to_hex
 import matplotlib.patches as mpatches
 from textwrap import fill
 
@@ -285,6 +285,7 @@ class LinearStyleDef(DynamicRangeCompression):
 
 
 UNSCALED_DEFAULT_RAMP = [
+    # TODO: -0.0 is not really different number to 0.0 (does this indicate a specific limit case)
     {
         "value": -0.0,
         "color": "#000080",
@@ -330,6 +331,28 @@ def scale_unscaled_ramp(rmin, rmax, unscaled):
         } for u in unscaled
     ]
 
+def read_mpl_ramp(mpl_ramp : str):
+    unscaled_cmap = []
+    cmap = plt.get_cmap(mpl_ramp)
+    val_range = numpy.arange(0.1, 1.1, 0.1)
+    rgba_hex = to_hex(cmap(0.0))
+    unscaled_cmap.append(
+        {
+            "value" : 0.0,
+            "color" : rgba_hex,
+            "alpha" : 1.0
+        }
+    )
+    for val in val_range:
+        rgba_hex = to_hex(cmap(val))
+        unscaled_cmap.append(
+            {
+                "value" : float(val),
+                "color" : rgba_hex
+            }
+        )
+    return unscaled_cmap
+
 
 class RgbaColorRampDef(StyleDefBase):
     auto_legend = True
@@ -356,9 +379,11 @@ class RgbaColorRampDef(StyleDefBase):
             self.color_ramp = style_cfg["color_ramp"]
         else:
             rmin, rmax = style_cfg["range"]
+            unscaled_ramp = UNSCALED_DEFAULT_RAMP
+            if "mpl_ramp" in style_cfg:
+                unscaled_ramp = read_mpl_ramp(style_cfg["mpl_ramp"])
             self.color_ramp = scale_unscaled_ramp(
-                    rmin, rmax,
-                    UNSCALED_DEFAULT_RAMP)
+                    rmin, rmax, unscaled_ramp)
         values, r, g, b, a = crack_ramp(self.color_ramp)
         self.values = values
         self.components = {
@@ -489,6 +514,9 @@ class RgbaColorRampDef(StyleDefBase):
         combined_cfg["ramp"] = self.color_ramp
 
         cdict, ticks = create_cdict_ticks(self.components, combined_cfg)
+        
+        # TODO: Potentially short-circuit this if using string based mpl_ramp
+        # custom_map = plt.get_cmap(style_cfg["mpl_ramp"]) should return a LinearSegmentedColormap
 
         plt.rcdefaults()
         if combined_cfg.get("rcParams", None) is not None:

--- a/datacube_ows/ows_cfg_example.py
+++ b/datacube_ows/ows_cfg_example.py
@@ -528,6 +528,31 @@ style_ndvi = {
     }
 }
 
+# Examples of Matplotlib Color-Ramp styles
+style_deform = {
+    "name": "deform",
+    "title": "InSAR Deformation",
+    "abstract": "InSAR Derived Deformation Map",
+    # Range is needed to map values in color ramp
+    "range": [0.0, 1.0],
+    # The Matplotlib color ramp. Value specified is a string that indicates a Matplotlib Colour Ramp should be
+    # used. Reference here: https://matplotlib.org/examples/color/colormaps_reference.html
+    "mpl_ramp": "RdBu",
+    # If true, the calculated index value for the pixel will be included in GetFeatureInfo responses.
+    # Defaults to True.
+    "include_in_feature_info": True,
+    # Legend section is optional for non-linear colour-ramped styles.
+    # If not supplied, a legend for the style will be automatically generated from the colour ramp.
+    "legend": {
+        # Whether or not to display a legend for this style.
+        # Defaults to True for non-linear colour-ramped styles.
+        "show_legend": True,
+        # Instead of using the generated color ramp legend for the style, a URL to an PNG file can
+        # be used instead.  If 'url' is not supplied, the generated legend is used.
+        "url": "http://example.com/custom_style_image.png"
+    }
+}
+
 style_ndvi_cloudmask = {
     "name": "ndvi_cloudmask",
     "title": "NDVI with cloud masking",

--- a/tests/test_mpl_cmaps.py
+++ b/tests/test_mpl_cmaps.py
@@ -1,0 +1,16 @@
+"""
+Test creation of colour maps from matplotlib
+"""
+from datacube_ows.ows_cfg_example import style_deform
+from datacube_ows.band_mapper import read_mpl_ramp
+
+def test_get_mpl_cmap():
+    matplotlib_ramp_name = style_deform['mpl_ramp']
+    assert matplotlib_ramp_name
+    ows_ramp_dict = read_mpl_ramp(matplotlib_ramp_name)
+    assert len(ows_ramp_dict) == 11
+    for cmap in ows_ramp_dict:
+        assert "color" in cmap
+        assert "value" in cmap
+        assert cmap["color"].startswith("#")
+        assert isinstance(cmap["value"], float)


### PR DESCRIPTION
New Feature:
- Support string shortcut based reuse of Matplotlib colormaps
- Notes around strange code paths where matplotlib is used and could be shortcut using these name based mappings for legend generation.