### PR TITLE
Revert "fixinate gunicorn version to 19.9.0"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,9 +4,9 @@ colour
 scikit-image
 gevent
 eventlet
-gunicorn==19.9.0
-gunicorn[gevent]==19.9.0
-gunicorn[eventlet]==19.9.0
+gunicorn
+gunicorn[gevent]
+gunicorn[eventlet]
 boto3
 rasterio>=1.0.9
 ruamel.yaml


### PR DESCRIPTION
Reverts opendatacube/datacube-ows#183,

CRITICAL TIMEOUT ERROR is still occuring on dev ows