### PR TITLE
#187 A typecast fix for get featureinfo error

### DIFF
--- a/datacube_ows/data.py
+++ b/datacube_ows/data.py
@@ -382,7 +382,12 @@ def _make_band_dict(prod_cfg, pixel_dataset, band_list):
             else:
                 if 'flags_definition' in pixel_dataset[band].attrs:
                     flag_def = pixel_dataset[band].attrs['flags_definition']
-                    flag_dict = mask_to_dict(flag_def, band_val)
+                    # HACK: Work around bands with floating point values
+                    try:
+                        flag_dict = mask_to_dict(flag_def, band_val)
+                    except TypeError as te:
+                        logging.warning('Working around for float bands')
+                        flag_dict = mask_to_dict(flag_def, int(band_val))
                     try:
                         ret_val = [flag_def[flag]['description'] for flag, val in flag_dict.items() if val]
                     except KeyError:

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -143,4 +143,50 @@ def test_make_band_dict_nan(product_layer):
     band_dict = datacube_ows.data._make_band_dict(product_layer, fake_dataset(), bands)
     assert band_dict["fake"] == "n/a"
 
+def test_make_band_dict_float(product_layer):
+    import yaml
+    flags_yaml = """
+    flags_definition:
+        category:
+          bits: [0,1,2,3,4,5,6,7]
+          description: Mask image as provided by JAXA - Ocean and water, lay over, shadowing, land.
+          values:
+            0: no_data
+            50: water
+            100: lay_over
+            150: shadowing
+            255: land
+    """
+    class int_data:
+        def __init__(self):
+            self.nodata = np.nan
+            self.attrs = yaml.load(flags_yaml, yaml.Loader)
+        def item(self):
+            return 100
+
+    class int_dataset:
+        def __getitem__(self, key):
+            return int_data()
+
+    class float_data:
+        def __init__(self):
+            self.nodata = np.nan
+            self.attrs = yaml.load(flags_yaml, yaml.Loader)
+        def item(self):
+            return 100.0
+
+    class float_dataset:
+        def __getitem__(self, key):
+            return float_data()
+
+    bands = ["fake"]
+
+    band_dict = datacube_ows.data._make_band_dict(product_layer, int_dataset(), bands)
+    assert isinstance(band_dict["fake"], list) 
+    assert band_dict["fake"] == ['Mask image as provided by JAXA - Ocean and water, lay over, shadowing, land.']
+
+    band_dict = datacube_ows.data._make_band_dict(product_layer, float_dataset(), bands)
+    assert isinstance(band_dict["fake"], list) 
+    assert band_dict["fake"] == ['Mask image as provided by JAXA - Ocean and water, lay over, shadowing, land.']
+
 


### PR DESCRIPTION
Add a workaround to pass getfeatureinfo requests being passed to floating point input bands with masking where datacube fails due to bitwise masking being used in:

https://github.com/opendatacube/datacube-core/blob/2890b0b16b3259f9a516fb4315d44b738880c7a1/datacube/storage/masking.py#L220

Need to make datacube more robust to handling floating point input bands particularly for SAR Gamma0 style products.