### PR TITLE
fix chained compose with db

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -48,6 +48,7 @@ To start OWS with flask connected to a pre-existing database on your local machi
   export DB_PASSWORD=password
   export DB_DATABASE=opendatacube
   export DB_HOSTNAME=localhost
+  export DB_PORT=5432
   OWS_CFG_FILE=/path/to/ows_cfg.py
   docker-compose up
 

--- a/docker-compose.db.yaml
+++ b/docker-compose.db.yaml
@@ -5,7 +5,7 @@ services:
     # db with some data from ls8_usgs_level1_scene pre-indexed
     build: docker/database/
     environment:
-      - POSTGRES_DB=${DB_USERNAME}
+      - POSTGRES_DB=${DB_DATABASE}
       - POSTGRES_PASSWORD=${DB_PASSWORD}
       - POSTGRES_USER=${DB_USERNAME}
     network_mode: bridge

--- a/docker-compose.db.yaml
+++ b/docker-compose.db.yaml
@@ -17,3 +17,5 @@ services:
     network_mode: bridge
     links:
       - postgres:postgres
+    environment:
+      DB_PORT: 5432


### PR DESCRIPTION
Internally within the composed stack, 
`Postgres` container maps to IP `127.172.0.2` and port `5432`

The benefit of `ports: "${DB_PORT}:5432` is to avoid port clash on the host machine