### PR TITLE
Enable coverage flag

### DIFF
--- a/check-code.sh
+++ b/check-code.sh
@@ -8,6 +8,6 @@ pylint -j 2 --reports no datacube_ows --disable=C,R
 
 # Run tests, taking coverage.
 # Users can specify extra folders as arguments.
-python3 -m pytest tests/ --ignore tests/test_wms_server.py --ignore tests/test_layers.py
+python3 -m pytest --cov=datacube_ows tests/ --ignore tests/test_wms_server.py --ignore tests/test_layers.py
 
 set +x


### PR DESCRIPTION
- Enable coverage analysis via pytest-cov
- Publist coverage results to Coveralls and show analysis in PR's