### PR TITLE
Enable coverage flag

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,6 +40,13 @@ jobs:
       run: |
         docker run ${ORG}/${IMAGE}:_builder /bin/sh -c "./check-code.sh"
 
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v1
+      with:
+        token: ${{ secrets.CodeCovToken }}
+        file: ./coverage.xml
+        fail_ci_if_error: false
+
 
     # Build prod image and tag as latest, connect to pre-indexed database
     - name: Build and run prod OWS images (stage 2)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,13 +38,14 @@ jobs:
 
     - name: Test and lint dev OWS image (stage 1)
       run: |
-        docker run ${ORG}/${IMAGE}:_builder /bin/sh -c "./check-code.sh"
+        mkdir artifacts
+        docker run -v ${PWD}/artifacts:/mnt/artifacts ${ORG}/${IMAGE}:_builder /bin/sh -c "./check-code.sh"
 
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v1
       with:
         token: ${{ secrets.CodeCovToken }}
-        file: ./coverage.xml
+        file: ./artifacts/coverage.xml
         fail_ci_if_error: false
 
 

--- a/README.rst
+++ b/README.rst
@@ -4,6 +4,9 @@ datacube-ows
 
 .. image:: https://img.shields.io/travis/opendatacube/datacube-ows.svg
         :target: https://travis-ci.org/opendatacube/datacube-ows
+        
+.. image:: https://codecov.io/gh/opendatacube/datacube-ows/branch/master/graph/badge.svg
+        :target: https://codecov.io/gh/opendatacube/datacube-ows
 
 Datacube Web Map Service
 

--- a/check-code.sh
+++ b/check-code.sh
@@ -9,5 +9,6 @@ pylint -j 2 --reports no datacube_ows --disable=C,R
 # Run tests, taking coverage.
 # Users can specify extra folders as arguments.
 python3 -m pytest --cov=datacube_ows --cov-report=xml tests/ --ignore tests/test_wms_server.py --ignore tests/test_layers.py
+cp coverage.xml /mnt/artifacts
 
 set +x

--- a/check-code.sh
+++ b/check-code.sh
@@ -8,6 +8,6 @@ pylint -j 2 --reports no datacube_ows --disable=C,R
 
 # Run tests, taking coverage.
 # Users can specify extra folders as arguments.
-python3 -m pytest --cov=datacube_ows tests/ --ignore tests/test_wms_server.py --ignore tests/test_layers.py
+python3 -m pytest --cov=datacube_ows --cov-report=xml tests/ --ignore tests/test_wms_server.py --ignore tests/test_layers.py
 
 set +x

--- a/check-code.sh
+++ b/check-code.sh
@@ -8,6 +8,6 @@ pylint -j 2 --reports no datacube_ows --disable=C,R
 
 # Run tests, taking coverage.
 # Users can specify extra folders as arguments.
-python3 -m pytest tests/ --ignore tests/test_wms_server.py --ignore tests/test_layers.py
+python3 -m pytest --cov=datacube_ows tests/ --ignore tests/test_wms_server.py --ignore tests/test_layers.py
 
 set +x

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 --extra-index-url="https://packages.dea.ga.gov.au"
 datacube[performance,s3]
 pytest
+pytest-cov
 pylint==2.4.4
 flask
 colour


### PR DESCRIPTION
Closes #238 
- Coverage analysis via pytest-cov
- Publish coverage results to [CodeCov](https://codecov.io/gh/opendatacube/datacube-ows) and show as part of PR's