### PR TITLE
Update ranges should get database name from odc config when available.

### DIFF
--- a/datacube_ows/update_ranges.py
+++ b/datacube_ows/update_ranges.py
@@ -128,7 +128,9 @@ def main(layers, blocking,
 
 
 def create_views(dc):
-    run_sql(dc, "extent_views/create", database=os.environ.get("DB_DATABASE"))
+    from datacube.config import parse_env_params
+    dbname = parse_env_params()["database"]
+    run_sql(dc, "extent_views/create", database=dbname)
 
 
 def refresh_views(dc, blocking):

--- a/datacube_ows/update_ranges.py
+++ b/datacube_ows/update_ranges.py
@@ -128,8 +128,12 @@ def main(layers, blocking,
 
 
 def create_views(dc):
-    from datacube.config import parse_env_params
-    dbname = parse_env_params()["database"]
+    try:
+        from datacube.config import LocalConfig
+        odc_cfg = LocalConfig.find()
+        dbname = odc_cfg.get("db_database")
+    except ImportError:
+        dbname = os.environ.get("DB_DATABASE")
     run_sql(dc, "extent_views/create", database=dbname)
 
 


### PR DESCRIPTION
Update_ranges `--schema` option needs to know the database name.  It was simply reading the environment variable `$DB_DATABASE`, which leads to unexpected behaviour on systems making heavy use of `datacube.conf` style configuration.

Update_ranges now uses the datacube core `config.parse_env_params` method to determine the database name.

Fixes Issue #267 