### PR TITLE
#287 Cover update ranges with tests

### DIFF
--- a/.github/.codecov.yml
+++ b/.github/.codecov.yml
@@ -20,6 +20,9 @@ parsers:
       method: no
       macro: no
 
+fixes:
+  - /::datacube_ows/"
+
 comment:
   layout: "reach,diff,flags,tree"
   behavior: default

--- a/.github/.codecov.yml
+++ b/.github/.codecov.yml
@@ -21,7 +21,7 @@ parsers:
       macro: no
 
 fixes:
-  - /::datacube_ows/"
+  - "/::datacube_ows/"
 
 comment:
   layout: "reach,diff,flags,tree"

--- a/.github/.codecov.yml
+++ b/.github/.codecov.yml
@@ -7,7 +7,7 @@ coverage:
       default: # This can be anything, but it needs to exist as the name
         # basic settings
         target: auto
-        threshold: 20%
+        threshold: 40%
   precision: 2
   round: down
   range: "20...100"

--- a/.github/.codecov.yml
+++ b/.github/.codecov.yml
@@ -21,7 +21,7 @@ parsers:
       macro: no
 
 fixes:
-  - "/::datacube_ows/"
+  - "/code::"
 
 comment:
   layout: "reach,diff,flags,tree"

--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -1,4 +1,5 @@
 import pytest
+from click.testing import CliRunner
 
 from datacube_ows.ogc import app
 
@@ -6,3 +7,7 @@ from datacube_ows.ogc import app
 def flask_client():
     with app.test_client() as client:
         yield client
+
+@pytest.fixture
+def runner():
+    return CliRunner()

--- a/integration_tests/test_update_ranges.py
+++ b/integration_tests/test_update_ranges.py
@@ -13,8 +13,15 @@ def test_update_ranges_views(runner):
     result = runner.invoke(main,["--views","--blocking"])
     assert result.exit_code == 0
 
+    result = runner.invoke(main,["--views"])
+    assert result.exit_code == 0
+
 def test_update_version(runner):
     result = runner.invoke(main,["--version"])
+    assert result.exit_code == 0
+
+def test_update_ranges_product(runner):
+    result = runner.invoke(main,["ls8_usgs_level1_scene"])
     assert result.exit_code == 0
 
 def test_update_ranges(runner):

--- a/integration_tests/test_update_ranges.py
+++ b/integration_tests/test_update_ranges.py
@@ -1,10 +1,20 @@
 """Test update ranges on DB using Click testing
 https://click.palletsprojects.com/en/7.x/testing/
 """
+import os
+
 from datacube_ows.update_ranges import main
+
+def test_updates_ranges_schema(runner):
+    result = runner.invoke(main,["--schema","--role",os.getenv("DB_USERNAME")])
+    assert result.exit_code == 0
 
 def test_update_ranges_views(runner):
     result = runner.invoke(main,["--views","--blocking"])
+    assert result.exit_code == 0
+
+def test_update_version(runner):
+    result = runner.invoke(main,["--version"])
     assert result.exit_code == 0
 
 def test_update_ranges(runner):

--- a/integration_tests/test_update_ranges.py
+++ b/integration_tests/test_update_ranges.py
@@ -1,0 +1,12 @@
+"""Test update ranges on DB using Click testing
+https://click.palletsprojects.com/en/7.x/testing/
+"""
+from datacube_ows.update_ranges import main
+
+def test_update_ranges_views(runner):
+    result = runner.invoke(main,["--views","--blocking"])
+    assert result.exit_code == 0
+
+def test_update_ranges(runner):
+    result = runner.invoke(main)
+    assert result.exit_code == 0

--- a/integration_tests/test_update_ranges.py
+++ b/integration_tests/test_update_ranges.py
@@ -21,7 +21,7 @@ def test_update_version(runner):
     assert result.exit_code == 0
 
 def test_update_ranges_product(runner):
-    result = runner.invoke(main,["ls8_usgs_level1_scene"])
+    result = runner.invoke(main,["ls8_usgs_level1_scene_layer"])
     assert result.exit_code == 0
 
 def test_update_ranges(runner):

--- a/ows_test_cfg.py
+++ b/ows_test_cfg.py
@@ -1154,7 +1154,7 @@ ows_cfg = {
                     # NOTE: This layer IS a mappable "named layer" that can be selected in GetMap requests
                     "title": "Level 1 USGS Landsat-8 Public Data Set",
                     "abstract": "Imagery from the Level 1 Landsat-8 USGS Public Data Set",
-                    "name": "ls8_usgs_level1_scene",
+                    "name": "ls8_usgs_level1_scene_layer",
                     "product_name": "ls8_usgs_level1_scene",
                     "bands": landsat8_bands,
                     "resource_limits": standard_resource_limits,


### PR DESCRIPTION
Increase coverage of update ranges tests by calling them from Click runners.
https://click.palletsprojects.com/en/7.x/testing/