### PR TITLE
Fix paths for codecov

### DIFF
--- a/.github/.codecov.yml
+++ b/.github/.codecov.yml
@@ -20,6 +20,9 @@ parsers:
       method: no
       macro: no
 
+fixes:
+  - "/code::"
+
 comment:
   layout: "reach,diff,flags,tree"
   behavior: default


### PR DESCRIPTION
I believe this change needs to hit `master` before codecov starts using it.