### PR TITLE
WMTS Exception url was wrong - uses OWS-Common 1.1.0

### DIFF
--- a/datacube_ows/ogc_exceptions.py
+++ b/datacube_ows/ogc_exceptions.py
@@ -55,7 +55,7 @@ class WMSException(OGCException):
 
 class WMTSException(WMSException):
     version = "1.0.0"
-    schema_url = "http://schemas.opengis.net/wmts/1.0.0/exceptions_1_0_0.xsd"
+    schema_url = "http://schemas.opengis.net/ows/1.1.0/owsExceptionReport.xsd"
 
 
 class WCS1Exception(OGCException):


### PR DESCRIPTION
WMTS Exceptions referenced an incorrect Exception XSD URL.  The correct XSD comes from the OWS-Common 1.1.0 spec.

Fixes #308  (and it's a trivial one liner.)