### PR TITLE
Update pydev version number in Dockerfile.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,7 +55,7 @@ ENV PATH=${py_env_path}/bin:$PATH \
 ## Only install pydev requirements if arg PYDEV_DEBUG is set to 'yes'
 ARG PYDEV_DEBUG="no"
 RUN if [ "$PYDEV_DEBUG" = "yes" ]; then \
-    pip install pydevd-pycharm~=201.7223.92 \
+    pip install pydevd-pycharm~=201.7846.77 \
 ;fi
 
 RUN chown 1000:100 /dev/shm


### PR DESCRIPTION
Is there a way to get Dockerfile to use requirements-dev.txt to avoid setting this version number in two places?  I tried a few things but none of them worked.