### PR TITLE
Fix Band Index so redundant aliases work as documented.

### DIFF
--- a/datacube_ows/ows_configuration.py
+++ b/datacube_ows/ows_configuration.py
@@ -150,7 +150,7 @@ class BandIndex(object):
                 raise ConfigException(f"Duplicate band name/alias: {b} in layer {product}")
             self._idx[b] = b
             for a in aliases:
-                if a in self._idx:
+                if a != b and a in self._idx:
                     raise ConfigException(f"Duplicate band name/alias: {a} in layer {product}")
                 self._idx[a] = b
             self._nodata_vals[b] = self.native_bands['nodata'][b]

--- a/tests/test_ows_configuration.py
+++ b/tests/test_ows_configuration.py
@@ -1,5 +1,6 @@
 import datacube_ows.ows_configuration
-
+from datacube_ows.ows_configuration import BandIndex
+from unittest.mock import patch, MagicMock
 import pytest
 
 def test_accum_max():
@@ -9,3 +10,30 @@ def test_accum_max():
 def test_accum_min():
     ret = datacube_ows.ows_configuration.accum_min(1, 3)
     assert ret == 1
+
+def test_band_index():
+    dc = MagicMock()
+    prod = MagicMock()
+    prod.name = "prod_name"
+    nb = MagicMock()
+    nb.index = ['band1', 'band2', 'band3', 'band4']
+    nb.get.return_val = {
+        "band1": -999,
+        "band2": -999,
+        "band3": -999,
+        "band4": -999,
+    }
+    dc.list_measurements().loc = {
+        "prod_name": nb
+    }
+
+    foo =dc.list_measurements().loc["prod_name"]
+
+    cfg = {
+        "band1": [],
+        "band2": ["alias1"],
+        "band3": ["alias2", "alias3"],
+        "band4": ["band4", "alias4"],
+    }
+
+    bidx = BandIndex(prod, cfg, dc)


### PR DESCRIPTION
First alias in band index is what is displayed in getfeatureinfo.  Using the native name by adding a redundant first alias was broken.