### PR TITLE
Fix where getfeatureinfo would fail if multiple available images at that point have different crs

### DIFF
--- a/datacube_ows/data.py
+++ b/datacube_ows/data.py
@@ -389,10 +389,14 @@ def _write_polygon(geobox, polygon, zoom_fill):
 @log_call
 def get_s3_browser_uris(datasets, pt=None, s3url="", s3bucket=""):
     uris = []
+    last_crs = None
     for tds in datasets:
         for ds in tds.values.item():
             if pt and ds.extent:
-                if ds.extent.contains(pt):
+                if ds.crs != last_crs:
+                    pt_native = pt.to_crs(ds.crs)
+                    last_crs = ds.crs
+                if ds.extent.contains(pt_native):
                     uris.append(ds.uris)
             else:
                 uris.append(ds.uris)
@@ -633,10 +637,11 @@ def feature_info(args):
                     if pt_native is None:
                         pt_native = geo_point.to_crs(ds.crs)
                     if ds.extent and ds.extent.contains(pt_native):
+                        # if so then there is data at this date
                         feature_json["data_available_for_dates"].append(dt.strftime("%Y-%m-%d"))
                         break
             if ds_at_times:
-                feature_json["data_links"] = sorted(get_s3_browser_uris(ds_at_times, pt_native, s3_url, s3_bucket))
+                feature_json["data_links"] = sorted(get_s3_browser_uris(ds_at_times, pt, s3_url, s3_bucket))
             else:
                 feature_json["data_links"] = []
             if params.product.feature_info_include_utc_dates:

--- a/datacube_ows/data.py
+++ b/datacube_ows/data.py
@@ -637,7 +637,6 @@ def feature_info(args):
                     if pt_native is None:
                         pt_native = geo_point.to_crs(ds.crs)
                     if ds.extent and ds.extent.contains(pt_native):
-                        # if so then there is data at this date
                         feature_json["data_available_for_dates"].append(dt.strftime("%Y-%m-%d"))
                         break
             if ds_at_times:


### PR DESCRIPTION
Occasionally datasets can overlap and have different crs. Logic in feature_info assigned and used pt_native to looked datasets but assumed a common crs. This fix moves logic to determine the appropriate crs into get_s3_browser_uris and directly uses the candidate dataset crs to transform the pt to a native pt before checking if that native pt is within the extent of the dataset. 
