### PR TITLE
MV search redux

### DIFF
--- a/datacube_ows/band_mapper.py
+++ b/datacube_ows/band_mapper.py
@@ -1,6 +1,0 @@
-from __future__ import absolute_import, division, print_function
-
-# Do not use X Server backend
-
-#pylint: disable=invalid-name, inconsistent-return-statements
-

--- a/datacube_ows/data.py
+++ b/datacube_ows/data.py
@@ -231,10 +231,13 @@ def get_map(args):
             )
         if too_many_datasets or zoomed_out:
             extent  = stacker.datasets(dc.index, mode=MVSelectOpts.EXTENT)
-            body = _write_polygon(
-                params.geobox,
-                extent,
-                params.product.zoom_fill)
+            if extent is None:
+                body = _write_empty(params.geobox)
+            else:
+                body = _write_polygon(
+                    params.geobox,
+                    extent,
+                    params.product.zoom_fill)
         elif n_datasets == 0:
             body = _write_empty(params.geobox)
         else:

--- a/datacube_ows/data.py
+++ b/datacube_ows/data.py
@@ -229,17 +229,14 @@ def get_map(args):
             too_many_datasets = (params.product.max_datasets_wms > 0
                                  and n_datasets > params.product.max_datasets_wms
             )
-        if too_many_datasets or zoomed_out:
-            extent  = stacker.datasets(dc.index, mode=MVSelectOpts.EXTENT)
-            if extent is None:
-                body = _write_empty(params.geobox)
-            else:
-                body = _write_polygon(
-                    params.geobox,
-                    extent,
-                    params.product.zoom_fill)
-        elif n_datasets == 0:
+        if n_datasets == 0:
             body = _write_empty(params.geobox)
+        elif too_many_datasets or zoomed_out:
+            extent  = stacker.datasets(dc.index, mode=MVSelectOpts.EXTENT)
+            body = _write_polygon(
+                params.geobox,
+                extent,
+                params.product.zoom_fill)
         else:
             datasets = stacker.datasets(dc.index)
             _LOG.debug("load start %s %s", datetime.now().time(), args["requestid"])

--- a/datacube_ows/data.py
+++ b/datacube_ows/data.py
@@ -229,14 +229,17 @@ def get_map(args):
             too_many_datasets = (params.product.max_datasets_wms > 0
                                  and n_datasets > params.product.max_datasets_wms
             )
-        if n_datasets == 0:
-            body = _write_empty(params.geobox)
-        elif too_many_datasets or zoomed_out:
+        if too_many_datasets or zoomed_out:
             extent  = stacker.datasets(dc.index, mode=MVSelectOpts.EXTENT)
-            body = _write_polygon(
-                params.geobox,
-                extent,
-                params.product.zoom_fill)
+            if extent is None:
+                body = _write_empty(params.geobox)
+            else:
+                body = _write_polygon(
+                    params.geobox,
+                    extent,
+                    params.product.zoom_fill)
+        elif n_datasets == 0:
+            body = _write_empty(params.geobox)
         else:
             datasets = stacker.datasets(dc.index)
             _LOG.debug("load start %s %s", datetime.now().time(), args["requestid"])

--- a/datacube_ows/mv_index.py
+++ b/datacube_ows/mv_index.py
@@ -106,6 +106,8 @@ def mv_search_datasets(index,
                 return r[0]
             if sel == MVSelectOpts.EXTENT:
                 geojson = r[0]
+                if geojson is None:
+                    return None
                 uniongeom = ODCGeom(json.loads(geojson), crs="EPSG:4326")
                 if geom:
                     intersect = uniongeom.intersection(geom)

--- a/datacube_ows/mv_index.py
+++ b/datacube_ows/mv_index.py
@@ -9,6 +9,7 @@ from sqlalchemy.dialects.postgresql import UUID, TSTZRANGE
 from sqlalchemy.sql.functions import count, func
 
 def get_sqlalc_engine(index):
+    # pylint: disable=protected-access
     return index._db._engine
 
 def get_st_view(meta):

--- a/datacube_ows/mv_index.py
+++ b/datacube_ows/mv_index.py
@@ -103,7 +103,8 @@ def mv_search_datasets(index,
                 return r[0]
             if sel == MVSelectOpts.EXTENT:
                 geojson = r[0]
-                return ODCGeom(json.loads(geojson))
+                uniongeom = ODCGeom(json.loads(geojson))
+                return uniongeom.intersection(geom)
     if sel == MVSelectOpts.DATASETS:
         return index.datasets.bulk_get(
                  [r[0] for r in conn.execute(s)]

--- a/datacube_ows/mv_index.py
+++ b/datacube_ows/mv_index.py
@@ -1,0 +1,98 @@
+from enum import Enum
+
+from geoalchemy2 import Geometry
+from sqlalchemy import MetaData, Table, select, or_, Column, SMALLINT
+from psycopg2.extras import DateTimeTZRange
+from sqlalchemy.dialects.postgresql import UUID, TSTZRANGE
+from sqlalchemy.sql.functions import count
+
+
+def get_sqlalc_engine(dc=None, index=None, engine=None):
+    if engine:
+        return engine
+    if index:
+        return index._db._engine
+    if dc:
+        return dc.index._db._engine
+    raise NotImplementedError("Give me something to work with here")
+
+_meta = MetaData()
+
+def st_view():
+    return Table('space_time_view', _meta,
+             Column('id', UUID()),
+             Column('dataset_type_ref', SMALLINT()),
+             Column('spatial_extent', Geometry(from_text='ST_GeomFromEWKT', name='geometry')),
+             Column('temporal_extent', TSTZRANGE())
+                 )
+
+class MVSelectOpts(Enum):
+    """
+    Enum for mv_search_datasets sel parameter.
+
+    ALL: return all columns, select *, as result set
+    IDS: return list of database_ids only.
+    COUNT: return a count of matching datasets
+    """
+    ALL = 0
+    IDS = 1
+    COUNT = 2
+
+    def sel(self, stv):
+        if self == self.ALL:
+            return [stv]
+        if self == self.IDS:
+            return [stv.c.id]
+        if self == self.COUNT:
+            return [count(stv.c.id)]
+        assert False
+
+def mv_search_datasets(dc=None, index=None, engine=None,
+                       sel=MVSelectOpts.IDS,
+                       times=None,
+                       layer=None,
+                       geom=None):
+    """
+    Perform a dataset query via the space_time_view
+
+    :param layer:
+
+    A ows_configuration.OWSNamedLayer object (single or multiproduct)
+
+    You must supply one of
+    :param dc: A Datacube object
+    :param index: A datacube index
+    :param engine: An SQLAlchemy engine
+    :param sel: Selection mode - a MVSelectOpts enum. Defaults to IDS.
+    :param times: A list of pairs of datetimes (with time zone)
+    :param geom: A datacube.utils.geometry.Geometry object
+    :return: See MVSelectOpts doc
+    """
+    engine = get_sqlalc_engine(dc=dc, index=index, engine=engine)
+    stv = st_view()
+    if layer is None:
+        raise Exception("Must filter by product/layer")
+    prod_ids = [p.id for p in layer.products]
+    s = select(sel.sel(stv)).where(stv.c.dataset_type_ref.in_(prod_ids))
+    if times is not None:
+        s = s.where(
+            or_(
+                *[
+                    stv.c.temporal_extent.op("&&")(DateTimeTZRange(*t))
+                    for t in times
+                ]
+            )
+        )
+    if geom is not None:
+        stv.c.spatial_extent.intersects(geom)
+    # print(s) Print SQL Statement
+    conn = engine.connect()
+    if sel == MVSelectOpts.ALL:
+        return conn.execute(s)
+    if sel == MVSelectOpts.IDS:
+        return [r[0] for r in conn.execute(s)]
+    if sel == MVSelectOpts.COUNT:
+        for r in conn.execute(s):
+            return r[0]
+
+    assert False

--- a/datacube_ows/mv_index.py
+++ b/datacube_ows/mv_index.py
@@ -86,7 +86,9 @@ def mv_search_datasets(index,
                 ]
             )
         )
+    orig_crs = None
     if geom is not None:
+        orig_crs = geom.crs
         if str(geom.crs) != "EPSG:4326":
             geom = geom.to_crs("EPSG:4326")
         geom_js = json.dumps(geom.json)
@@ -103,8 +105,11 @@ def mv_search_datasets(index,
                 return r[0]
             if sel == MVSelectOpts.EXTENT:
                 geojson = r[0]
-                uniongeom = ODCGeom(json.loads(geojson))
-                return uniongeom.intersection(geom)
+                uniongeom = ODCGeom(json.loads(geojson), crs="EPSG:4326")
+                intersect = uniongeom.intersection(geom)
+                if orig_crs and orig_crs != "EPSG:4326":
+                    intersect = intersect.to_crs(orig_crs)
+                return intersect
     if sel == MVSelectOpts.DATASETS:
         return index.datasets.bulk_get(
                  [r[0] for r in conn.execute(s)]

--- a/datacube_ows/mv_index.py
+++ b/datacube_ows/mv_index.py
@@ -107,9 +107,12 @@ def mv_search_datasets(index,
             if sel == MVSelectOpts.EXTENT:
                 geojson = r[0]
                 uniongeom = ODCGeom(json.loads(geojson), crs="EPSG:4326")
-                intersect = uniongeom.intersection(geom)
-                if orig_crs and orig_crs != "EPSG:4326":
-                    intersect = intersect.to_crs(orig_crs)
+                if geom:
+                    intersect = uniongeom.intersection(geom)
+                    if orig_crs and orig_crs != "EPSG:4326":
+                        intersect = intersect.to_crs(orig_crs)
+                else:
+                    intersect = uniongeom
                 return intersect
     if sel == MVSelectOpts.DATASETS:
         return index.datasets.bulk_get(

--- a/datacube_ows/sql/extent_views/create/018_grant.sql
+++ b/datacube_ows/sql/extent_views/create/018_grant.sql
@@ -1,0 +1,4 @@
+-- Granting read permission to public
+
+GRANT SELECT ON space_time_view TO public;
+

--- a/datacube_ows/sql/extent_views/refresh/002_refresh_time.sql
+++ b/datacube_ows/sql/extent_views/refresh/002_refresh_time.sql
@@ -1,3 +1,3 @@
--- Refreshing TIME materialized view
+-- Refreshing TIME materialized view (Blocking)
 
 REFRESH MATERIALIZED VIEW time_view

--- a/datacube_ows/sql/extent_views/refresh/003_refresh_space.sql
+++ b/datacube_ows/sql/extent_views/refresh/003_refresh_space.sql
@@ -1,3 +1,3 @@
--- Refreshing SPACE materialized view
+-- Refreshing SPACE materialized view (blocking)
 
 REFRESH MATERIALIZED VIEW space_view

--- a/datacube_ows/sql/extent_views/refresh/004_refresh_spacetime.sql
+++ b/datacube_ows/sql/extent_views/refresh/004_refresh_spacetime.sql
@@ -1,0 +1,3 @@
+-- Refreshing combined SPACE-TIME materialized view (concurrently)
+
+REFRESH MATERIALIZED VIEW CONCURRENTLY space_time_view

--- a/datacube_ows/sql/extent_views/refresh/004_refresh_spacetime_requires_blocking.sql
+++ b/datacube_ows/sql/extent_views/refresh/004_refresh_spacetime_requires_blocking.sql
@@ -1,3 +1,0 @@
--- Refreshing combined SPACE-TIME materialized view
-
-REFRESH MATERIALIZED VIEW {blocking} space_time_view

--- a/datacube_ows/update_ranges.py
+++ b/datacube_ows/update_ranges.py
@@ -111,7 +111,7 @@ def main(layers, blocking,
             print("WARNING: The 'blocking' flag is "
                   "no longer supported and will be ignored.")
         print("Refreshing materialised views...")
-        refresh_views(dc, blocking)
+        refresh_views(dc)
         print("Done")
         return 0
 

--- a/datacube_ows/update_ranges.py
+++ b/datacube_ows/update_ranges.py
@@ -14,7 +14,7 @@ import click
 
 @click.command()
 @click.option("--views", is_flag=True, default=False, help="Refresh the ODC spatio-temporal materialised views.")
-@click.option("--blocking/--no-blocking", is_flag=True, default=False, help="In conjunction with --views, controls whether the materialised view refresh is blocking or concurrent. (defaults to concurrent)")
+@click.option("--blocking/--no-blocking", is_flag=True, default=False, help="Obsolete")
 @click.option("--schema", is_flag=True, default=False, help="Create or update the OWS database schema, including the spatio-temporal materialised views.")
 @click.option("--role", default=None, help="Role to grant database permissions to")
 @click.option("--summary", is_flag=True, default=False, help="Treat any named ODC products with no corresponding configured OWS Layer as summary products" )
@@ -107,6 +107,9 @@ def main(layers, blocking,
         print("Done")
         return 0
     elif views:
+        if blocking:
+            print("WARNING: The 'blocking' flag is "
+                  "no longer supported and will be ignored.")
         print("Refreshing materialised views...")
         refresh_views(dc, blocking)
         print("Done")
@@ -137,14 +140,8 @@ def create_views(dc):
     run_sql(dc, "extent_views/create", database=dbname)
 
 
-def refresh_views(dc, blocking):
-    if blocking:
-        blocking = ""
-        print("N.B. Blocking refresh. Spacetime view will be locked until completion.")
-    else:
-        blocking = "CONCURRENTLY"
-        print("N.B. Concurrent refresh. Refresh will not take place immediately.")
-    run_sql(dc, "extent_views/refresh", blocking=blocking)
+def refresh_views(dc):
+    run_sql(dc, "extent_views/refresh")
 
 
 def create_schema(dc, role):

--- a/datacube_ows/wcs1_utils.py
+++ b/datacube_ows/wcs1_utils.py
@@ -16,6 +16,7 @@ from datacube_ows.data import DataStacker, datasets_in_xarray
 from datacube_ows.ogc_exceptions import WCS1Exception
 from datacube_ows.ogc_utils import ProductLayerException
 from datacube_ows.ows_configuration import get_config
+from datacube_ows.mv_index import MVSelectOpts
 
 class WCS1GetCoverageRequest():
     version = Version(1,0,0)
@@ -291,9 +292,9 @@ def get_coverage_data(req):
                               req.geobox,
                               req.times,
                               bands=req.bands)
-        datasets = stacker.datasets(dc.index)
-        if not datasets:
-            # TODO: Return an empty coverage file with full metadata?
+        n_datasets = stacker.datasets(dc.index, mode=MVSelectOpts.COUNT)
+        if n_datasets > 0:
+            # Return an empty coverage file with full metadata?
             cfg = get_config()
             x_range = (req.minx, req.maxx)
             y_range = (req.miny, req.maxy)
@@ -336,12 +337,11 @@ def get_coverage_data(req):
 
             return data
 
-        n_datasets = datasets_in_xarray(datasets)
         if req.product.max_datasets_wcs > 0 and n_datasets > req.product.max_datasets_wcs:
             raise WCS1Exception("This request processes too much data to be served in a reasonable amount of time."
                                 "Please reduce the bounds of your request and try again."
                                 "(max: %d, this request requires: %d)" % (req.product.max_datasets_wcs, n_datasets))
-
+        datasets = stacker.datasets(index=dc.index)
         stacker = DataStacker(req.product,
                               req.geobox,
                               req.times,

--- a/datacube_ows/wcs1_utils.py
+++ b/datacube_ows/wcs1_utils.py
@@ -293,7 +293,7 @@ def get_coverage_data(req):
                               req.times,
                               bands=req.bands)
         n_datasets = stacker.datasets(dc.index, mode=MVSelectOpts.COUNT)
-        if n_datasets > 0:
+        if n_datasets == 0:
             # Return an empty coverage file with full metadata?
             cfg = get_config()
             x_range = (req.minx, req.maxx)

--- a/docs/database.rst
+++ b/docs/database.rst
@@ -24,9 +24,10 @@ Materialised Views over ODC Indexes
 The materialised views provide a dataset level extent index
 using PostGIS <https://postgis.net>`_ datatypes.
 
-These views are currently used only as an intermediate calculation
-step to populate the Layer Extent Cache, as described below, however
-there are plans to make much more extensive direct use of them.
+These views are used only as an intermediate calculation
+step to populate the Layer Extent Cache, as described below,
+and for doing dataset queries for GetMap, GetFeatureInfo
+and GetCoverage requests.
 
 It is hoped that this layer will eventually be implemented as tables
 maintained as part of the core ODC index.  Currently it must be
@@ -65,6 +66,10 @@ Note that the last step of the view refresh (joining the time
 and space views into a single space-time view) is done
 CONCURRENTLY. This means that it may not take effect until
 some minutes after ``datacube-ows-update`` exits.
+
+DO NOT ATTEMPT TO REFRESH VIEWS NON-CONCURRENTLY IN A PRODUCTION
+ENVIRONMENT. This will leave OWS broken and unable to respond to
+requests until the refresh is complete.
 
 In a production environment you should not be refreshing views
 much more than 3 or 4 times a day unless your database is very small.

--- a/integration_tests/test_mv_index.py
+++ b/integration_tests/test_mv_index.py
@@ -1,0 +1,103 @@
+import pytest
+
+from datacube.utils.geometry import box
+
+from datacube_ows.cube_pool import cube
+from datacube_ows.ogc_utils import local_solar_date_range
+from datacube_ows.ows_configuration import get_config
+from datacube_ows.mv_index import MVSelectOpts, mv_search_datasets
+
+def test_full_layer():
+    cfg = get_config()
+    lyr = list(cfg.product_index.values())[0]
+    with cube() as dc:
+        sel = mv_search_datasets(dc.index, MVSelectOpts.COUNT,
+                                 layer=lyr)
+        assert sel > 0
+
+class MockGeobox:
+    def __init__(self, geom):
+        if geom.crs != "EPSG:4326":
+            geom = geom.to_crs("EPSG:4326")
+        self.geographic_extent = geom
+
+
+def test_time_search():
+    cfg = get_config()
+    lyr = list(cfg.product_index.values())[0]
+    time = lyr.ranges["times"][-1]
+    geom = box(
+        lyr.bboxes["EPSG:4326"]["bottom"],
+        lyr.bboxes["EPSG:4326"]["left"],
+        lyr.bboxes["EPSG:4326"]["top"],
+        lyr.bboxes["EPSG:4326"]["right"],
+        "EPSG:4326")
+
+    time_rng = local_solar_date_range(MockGeobox(geom), time)
+    with cube() as dc:
+        sel = mv_search_datasets(dc.index, MVSelectOpts.COUNT,
+                                 times = [time_rng],
+                                 layer=lyr)
+        assert sel > 0
+
+def test_count():
+    cfg = get_config()
+    lyr = list(cfg.product_index.values())[0]
+    with cube() as dc:
+        count = mv_search_datasets(dc.index, MVSelectOpts.COUNT,
+                                   layer=lyr)
+        ids = mv_search_datasets(dc.index, MVSelectOpts.IDS,
+                                 layer=lyr)
+        assert len(ids) == count
+
+def test_datasets():
+    cfg = get_config()
+    lyr = list(cfg.product_index.values())[0]
+    with cube() as dc:
+        dss = mv_search_datasets(dc.index, MVSelectOpts.DATASETS,
+                                   layer=lyr)
+        ids = mv_search_datasets(dc.index, MVSelectOpts.IDS,
+                                 layer=lyr)
+        assert len(ids) == len(dss)
+        for ds in dss:
+            assert str(ds.id) in ids
+
+def test_extent_and_spatial():
+    cfg = get_config()
+    lyr = list(cfg.product_index.values())[0]
+    layer_ext_bbx = (
+        lyr.bboxes["EPSG:4326"]["bottom"],
+        lyr.bboxes["EPSG:4326"]["left"],
+        lyr.bboxes["EPSG:4326"]["top"],
+        lyr.bboxes["EPSG:4326"]["right"],
+        )
+    small_bbox = pytest.helpers.enclosed_bbox(layer_ext_bbx)
+    layer_ext_geom = box(layer_ext_bbx[0],
+                         layer_ext_bbx[1],
+                         layer_ext_bbx[2],
+                         layer_ext_bbx[3],
+                         "EPSG:4326")
+    small_geom = box(small_bbox[0],
+                        small_bbox[1],
+                        small_bbox[2],
+                        small_bbox[3],
+                        "EPSG:4326")
+    with cube() as dc:
+        all_ext = mv_search_datasets(dc.index, MVSelectOpts.EXTENT,
+                                     geom=layer_ext_geom,
+                                     layer=lyr)
+        small_ext = mv_search_datasets(dc.index, MVSelectOpts.EXTENT,
+                                 geom=small_geom,
+                                 layer=lyr)
+        assert layer_ext_geom.contains(all_ext)
+        assert small_geom.contains(small_ext)
+        assert all_ext.contains(small_ext)
+        assert small_ext.area < all_ext.area
+
+        all_count = mv_search_datasets(dc.index, MVSelectOpts.COUNT,
+                                     geom=layer_ext_geom,
+                                     layer=lyr)
+        small_count = mv_search_datasets(dc.index, MVSelectOpts.COUNT,
+                                       geom=small_geom,
+                                       layer=lyr)
+        assert small_count <= all_count

--- a/ows_test_cfg.py
+++ b/ows_test_cfg.py
@@ -577,6 +577,7 @@ ows_cfg = {
         # in the GetCapabilities documents based on the requesting url
         "allowed_urls": [
             "http://127.0.0.1:5000/",
+            "http://127.0.0.1:8000/",
             "http://localhost/odc_ows",
             "https://localhost/odc_ows",
             "https://alternateurl.domain.org/odc_ows",

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ pandas==1.0.5
 scikit-image
 gevent==1.4.0
 python-slugify
+geoalchemy2
 eventlet
 gunicorn
 gunicorn[gevent]

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ requirements = [
     'scikit-image',
     'timezonefinderL',
     'python-slugify',
+    'geoalchemy',
     'xarray',
     'pyows',
     'prometheus-flask-exporter'

--- a/tests/test_mv_selopts.py
+++ b/tests/test_mv_selopts.py
@@ -1,28 +1,31 @@
 from datacube_ows.mv_index import MVSelectOpts
 
-def test_all():
-    stv = None
 
-    assert MVSelectOpts.ALL.sel(stv) == [None]
+def test_all():
+    assert MVSelectOpts.ALL.sel("Ni!!") == ["Ni!!"]
+
 
 class MockSTV:
     def __init__(self, id):
         self.id = id
         self.c = self
 
+
 def test_ids_datasets():
     class MockSTV:
         def __init__(self, id):
             self.id = id
             self.c = self
-    stv = MockSTV(72)
-    assert MVSelectOpts.IDS.sel(stv) == [72]
-    assert MVSelectOpts.DATASETS.sel(stv) == [72]
+    stv = MockSTV(42)
+    assert MVSelectOpts.IDS.sel(stv) == [42]
+    assert MVSelectOpts.DATASETS.sel(stv) == [42]
+
 
 def test_extent():
     sel= MVSelectOpts.EXTENT.sel(None)
     assert len(sel) == 1
     assert str(sel[0]) == "ST_AsGeoJSON(ST_Union(spatial_extent))"
+
 
 def test_count():
     from sqlalchemy import text

--- a/tests/test_mv_selopts.py
+++ b/tests/test_mv_selopts.py
@@ -1,0 +1,32 @@
+from datacube_ows.mv_index import MVSelectOpts
+
+def test_all():
+    stv = None
+
+    assert MVSelectOpts.ALL.sel(stv) == [None]
+
+class MockSTV:
+    def __init__(self, id):
+        self.id = id
+        self.c = self
+
+def test_ids_datasets():
+    class MockSTV:
+        def __init__(self, id):
+            self.id = id
+            self.c = self
+    stv = MockSTV(72)
+    assert MVSelectOpts.IDS.sel(stv) == [72]
+    assert MVSelectOpts.DATASETS.sel(stv) == [72]
+
+def test_extent():
+    sel= MVSelectOpts.EXTENT.sel(None)
+    assert len(sel) == 1
+    assert str(sel[0]) == "ST_AsGeoJSON(ST_Union(spatial_extent))"
+
+def test_count():
+    from sqlalchemy import text
+    stv = MockSTV(id=text("foo"))
+    sel = MVSelectOpts.COUNT.sel(stv)
+    assert len(sel) == 1
+    assert str(sel[0]) == "count(foo)"


### PR DESCRIPTION
Second attempt at using materialised views in OWS searches.

There is a simple flexible search API in `datacube_ows.mv_index`.  For a given product/spatio-temporal query, it can return either:

1) A simple count of number of matching datasets.
2) A list of IDs of the matching datasets.
3) The extent geometry for which there is data within the search spatial window.
4) A list of ODC dataset objects.

Edit: I'm using the views throughout WMS and WCS now.