### PR TITLE
Materialised views only excluding archived datasets for EO3 

### DIFF
--- a/datacube_ows/sql/extent_views/create/011_create_time_view.sql
+++ b/datacube_ows/sql/extent_views/create/011_create_time_view.sql
@@ -28,6 +28,7 @@ select
   end as temporal_extent
 from agdc.dataset where
   metadata_type_ref in (select id from metadata_lookup where name in ('eo','gqa_eo','eo_plus'))
+  and archived is null
 UNION
 -- This is the eo3 variant of the temporal extent, the sample eo3 dataset uses a singleton
 -- timestamp, some other variants use start/end timestamps. From OWS perspective temporal
@@ -39,4 +40,6 @@ select
     coalesce(metadata->'properties'->>'dtr:start_datetime', metadata->'properties'->>'datetime'):: timestamp,
     coalesce((metadata->'properties'->>'dtr:end_datetime'):: timestamp,(metadata->'properties'->>'datetime'):: timestamp + interval '1 day')
    ) as temporal_extent
-from agdc.dataset where metadata_type_ref in (select id from metadata_lookup where name in ('eo3_landsat_ard','eo3'))
+from agdc.dataset where
+    metadata_type_ref in (select id from metadata_lookup where name in ('eo3_landsat_ard','eo3'))
+    and archived is null

--- a/datacube_ows/sql/extent_views/create/012_create_space_view_raw.sql
+++ b/datacube_ows/sql/extent_views/create/012_create_space_view_raw.sql
@@ -31,7 +31,10 @@ corners as
   (metadata #>> '{extent, coord, ul, lon}') as ul_lon,
   (metadata #>> '{extent, coord, ur, lat}') as ur_lat,
   (metadata #>> '{extent, coord, ur, lon}') as ur_lon
-   from agdc.dataset where metadata_type_ref in (select id from metadata_lookup where name in ('eo','gqa_eo','eo_plus')))
+   from agdc.dataset where
+        metadata_type_ref in (select id from metadata_lookup where name in ('eo','gqa_eo','eo_plus'))
+        and archived is null
+    )
 select id,format('POLYGON(( %s %s, %s %s, %s %s, %s %s, %s %s))',
         lon_begin, lat_begin, lon_end, lat_begin,  lon_end, lat_end,
         lon_begin, lat_end, lon_begin, lat_begin)::geometry
@@ -54,4 +57,6 @@ select id,
         ),
         4326
       ) as spatial_extent
- from agdc.dataset where metadata_type_ref in (select id from metadata_lookup where name in ('eo3_landsat_ard'))
+ from agdc.dataset where
+        metadata_type_ref in (select id from metadata_lookup where name in ('eo3_landsat_ard'))
+        and archived is null


### PR DESCRIPTION
Archived datasets from non-EO3 products were not being excluded from the materialised views.