### PR TITLE
Documentation not linked from master menu not appearing on readthedocs.

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -2,6 +2,18 @@
 OWS Configuration
 =================
 
+.. toctree::
+   :maxdepth: 2
+   :hidden:
+
+   cfg_global
+   cfg_wms
+   cfg_wcs
+   cfg_functions
+   cfg_layers
+   cfg_styling
+   cfg_*_styles.rst
+
 .. contents:: Table of Contents
 
 .. _introduction:


### PR DESCRIPTION
Half the config documentation is missing from readthedocs.  This might fix it?