### PR TITLE
Readthedocs internal links

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -179,7 +179,8 @@ Local Postgres database
 1. create an empty database and db_user
 2. run `datacube system init` after creating a datacube config file
 3. A product added to your datacube `datacube product add url` some examples are here: https://github.com/GeoscienceAustralia/dea-config/tree/master/dev/products
-4. Index datasets into your product for example refer to https://github.com/opendatacube/datacube-ows/blob/master/docs/usage.rst ::
+4. Index datasets into your product for example refer to https://datacube-ows.readthedocs.io/en/latest/usage.html
+::
   aws s3 ls s3://deafrica-data/jaxa/alos_palsar_mosaic/2017/ --recursive \
   | grep yaml | awk '{print $4}' \
   | xargs -n1 -I {} datacube dataset add s3://deafrica-data/{}

--- a/docs/cfg_colourmap_styles.rst
+++ b/docs/cfg_colourmap_styles.rst
@@ -7,12 +7,12 @@ OWS Configuration
 Colour-Map Styles
 -----------------
 
-Colour-map Styles are `styles <cfg_styling.rst>`_ where
+Colour-map Styles are `styles <https://datacube-ows.readthedocs.io/en/latest/cfg_styling.html>`_ where
 each pixel is mapped to one particular colour from a fixed pallet
 by applying a logical decision tree to the flag data for that pixel.
 
 Colour-map styles support the
-`elements common to all styles <cfg_styling.rst#common-elements>`_.
+`elements common to all styles <https://datacube-ows.readthedocs.io/en/latest/cfg_styling.html#common-elements>`_.
 
 Colour-map styles also have `value_map <#value_map>`_ entry that describes
 how the colour of individual pixels is determined.
@@ -201,7 +201,7 @@ Colour map styles support automatic legend configuration.
 
 Automatic legend generation can be deactivated using the
 ``show_legend`` and ``url`` legend elements
-`common to all styles <cfg_styling.rst#legend>`_.
+`common to all styles <https://datacube-ows.readthedocs.io/en/latest/cfg_styling.html#legend>`_.
 (``show_legend`` is ``True`` by default for colour-map styles.)
 
 A patch and label is added to the legend for each value rule in the

--- a/docs/cfg_colourramp_styles.rst
+++ b/docs/cfg_colourramp_styles.rst
@@ -8,13 +8,13 @@ OWS Configuration
 Colour-Ramp Styles
 ------------------
 
-Colour-ramp Styles are `styles <cfg_styling.rst>`_ where
+Colour-ramp Styles are `styles <https://datacube-ows.readthedocs.io/en/latest/cfg_styling.html>`_ where
 a single continuous index value is calculated from the raw data for
 each pixel, and that index value is mapped to a graduated colour ramp
 for display.
 
 Colour-ramp styles support the
-`elements common to all styles <cfg_styling.rst#common-elements>`_.
+`elements common to all styles <https://datacube-ows.readthedocs.io/en/latest/cfg_styling.html#common-elements>`_.
 
 Colour-ramp styles support automatic legend generation. Specialised
 legend configuration is described `below <#legend-configuration>`__.
@@ -39,14 +39,14 @@ index_function
 
 The `index_function` allows the user to declare a callback function
 to calculate the index value using OWS's
-`function configuration format <cfg_functions.rst>`_.
+`function configuration format <https://datacube-ows.readthedocs.io/en/latest/cfg_functions.html>`_.
 The function is expected to take an xarray Dataset containing all the
 bands in the `needed_bands list <needed-bands-list>`__ (plus any additional
 arguments handled by the
-`function configuration format <cfg_functions.rst>`_); and returns
+`function configuration format <https://datacube-ows.readthedocs.io/en/latest/cfg_functions.html>`_); and returns
 an xarray Dataset containing the index value.
 
-A `small library <cfg_functions.rst#band-utils-functions>`_
+A `small library <https://datacube-ows.readthedocs.io/en/latest/cfg_functions.html#band-utils-functions>`_
 of general purpose band math functions
 are provided in `datacube_ows.band_utils`.
 
@@ -191,7 +191,7 @@ Colour-ramp styles support automatic legend generation.
 
 Automatic legend generation can be deactivated using the
 `show_legend` and `url` legend elements
-`common to all styles <cfg_styling.rst#legend>`_.
+`common to all styles <https://datacube-ows.readthedocs.io/en/latest/cfg_styling.html#legend>`_.
 (`show_legend` is `True` by default for colour-ramp styles.)
 
 Legend Title
@@ -504,7 +504,7 @@ Multi-Date Requests
 -------------------
 
 Colour Ramp Styles support customised handlers for
-`multi-date requests <cfg_styling.rst#multi-date>`_.
+`multi-date requests <https://datacube-ows.readthedocs.io/en/latest/cfg_styling.html#multi-date>`_.
 
 An aggregator function is defined that takes
 
@@ -513,7 +513,7 @@ aggregator_function
 
 The `aggegator_function` entry is required for colour ramp style
 multi-date handlers.  It is a function defined using OWS's
-`function configuration format <cfg_functions.rst>`_.
+`function configuration format <https://datacube-ows.readthedocs.io/en/latest/cfg_functions.html>`_.
 
 The function is assumed to take a single xarray Dataset with a time dimension.
 The value at each time slice is the output of the `index function <#index-function>`__

--- a/docs/cfg_component_styles.rst
+++ b/docs/cfg_component_styles.rst
@@ -7,12 +7,12 @@ OWS Configuration
 Component Styles
 ----------------
 
-Component Styles are `styles <cfg_styling.rst>`_ where
+Component Styles are `styles <https://datacube-ows.readthedocs.io/en/latest/cfg_styling.html>`_ where
 each component channel of the image (red, green, blue and optionally
 alpha) is calculated independently from the data for that pixel.
 
 Component styles support the
-`elements common to all styles <cfg_styling.rst#common-elements>`_.
+`elements common to all styles <https://datacube-ows.readthedocs.io/en/latest/cfg_styling.html#common-elements>`_.
 
 There are three additional settings specific to component styles:
 `scale_range <#style-scale-range>`, `components <#components>`
@@ -20,7 +20,7 @@ and `additional_bands <#additional-bands>`_.
 
 Component styles do NOT support automatic legend generation. If you
 want a legend you must provide an external
-`url <cfg_styling.rst#url>`__ to a pre-prepared image.
+`url <https://datacube-ows.readthedocs.io/en/latest/cfg_styling.html#url>`__ to a pre-prepared image.
 
 ----------
 components
@@ -37,8 +37,8 @@ component channel of the output image::
 Alpha is the opacity of each pixel.  When alpha is 0 the image pixel is
 fully transparent, when 255 fully opaque.  If not provided, the alpha channel
 is assumed to be always fully opaque (unless otherwise masked, e.g. by
-the `extent mask <cfg_layers.rst#extent-mask-function-extent-mask-func>`_
-or `style masking <cfg_styling.rst#bit-flag-masks-pq-masks>`_).
+the `extent mask <https://datacube-ows.readthedocs.io/en/latest/cfg_layers.html#extent-mask-function-extent-mask-func>`_
+or `style masking <https://datacube-ows.readthedocs.io/en/latest/cfg_styling.html#bit-flag-masks-pq-masks>`_).
 
 Calculating the value for each pixel has two steps:
 
@@ -63,7 +63,7 @@ Linear Combination Components
 
 In a linear combination component, every entry (apart from
 `scale_range <#component-scale-range>`__) maps a band name or
-alias from the `band dictionary <cfg_layers.rst#bands-dictionary-bands>`_
+alias from the `band dictionary <https://datacube-ows.readthedocs.io/en/latest/cfg_layers.html#bands-dictionary-bands>`_
 to a floating point multiplier.  The pixel data values from these bands
 are then multiplied by these multipliers and summed to produce the
 unscaled channel value.
@@ -198,7 +198,7 @@ If you are unfortunate enough to have raw data with a band named "scale_range"
 (or "function" which would cause the component to be treated as a
 `callback function component <#callback-function-components>`_), you can
 still access it here by defining an alias for the band in the
-`band dictionary <cfg_layers.rst#bands-dictionary-bands>`_.
+`band dictionary <https://datacube-ows.readthedocs.io/en/latest/cfg_layers.html#bands-dictionary-bands>`_.
 
 E.g.::
 
@@ -228,7 +228,7 @@ Callback Function Components
 +++++++++++++++++++++++++++++
 
 In a callback function component, the user declares a callback function
-using OWS's `function configuration format <cfg_functions.rst>`_.
+using OWS's `function configuration format <https://datacube-ows.readthedocs.io/en/latest/cfg_functions.html>`_.
 
 The function must take an xarray Dataset containing the raw band data
 and return a xarray DataArray containing the channel data.  It is
@@ -289,7 +289,7 @@ components), then these additional required bands must be declared
 with the `additional_bands` list.
 
 The `additional_bands` should be a list of band names or aliases from
-the `band dictionary <cfg_layer.rst#band-dictionary-bands>`__.  It is
+the `band dictionary <https://datacube-ows.readthedocs.io/en/latest/cfg_layer.html#band-dictionary-bands>`__.  It is
 optional (defaults to an empty list).  It is safe (but not
 necessary) to declare bands in `additional_bands` that are used
 directly by a linear combination component in the style.

--- a/docs/cfg_functions.rst
+++ b/docs/cfg_functions.rst
@@ -64,8 +64,8 @@ for some layers/styles by passing optional arguments
 to the function.
 
 This technique is particularly useful for
-`style index functions <cfg_colourramp_styles.rst#index-function>`__
-and `component callback functions <cfg_component_styles.rst#callback-function-components>`_,
+`style index functions <https://datacube-ows.readthedocs.io/en/latest/cfg_colourramp_styles.html#index-function>`__
+and `component callback functions <https://datacube-ows.readthedocs.io/en/latest/cfg_component_styles.html#callback-function-components>`_,
 but will work for any function in the configuration format.
 
 args and kwargs
@@ -80,11 +80,11 @@ pass_product_cfg
 
 A common use case passing band names to generic band-math
 functions for
-`component callback functions <cfg_component_styles.rst#callback-function-components>`_
+`component callback functions <https://datacube-ows.readthedocs.io/en/latest/cfg_component_styles.html#callback-function-components>`_
 and
-`style index functions <cfg_colourramp_styles.rst#index-function>`__.
+`style index functions <https://datacube-ows.readthedocs.io/en/latest/cfg_colourramp_styles.html#index-function>`__.
 In order for this to work with
-`band aliases <cfg_layers.rst#band-dictionary-bands>`_,
+`band aliases <https://datacube-ows.readthedocs.io/en/latest/cfg_layers.html#band-dictionary-bands>`_,
 it it necessary for the function
 to have access to the band alias dictionary to convert aliases
 to native band names.  This can be accomplished with the

--- a/docs/cfg_global.rst
+++ b/docs/cfg_global.rst
@@ -8,7 +8,7 @@ Global Section
 --------------
 
 The "global" section of the `root configuration object
-<configuration.rst>`_
+<https://datacube-ows.readthedocs.io/en/latest/configuration.html>`_
 contains config entries that apply
 to all services and all layers/coverages.
 

--- a/docs/cfg_hybrid_styles.rst
+++ b/docs/cfg_hybrid_styles.rst
@@ -7,7 +7,7 @@ OWS Configuration
 Hybrid Styles
 -------------
 
-Hybrid styles are an experimental type of `style <cfg_styling.rst>`_ that
+Hybrid styles are an experimental type of `style <https://datacube-ows.readthedocs.io/en/latest/cfg_styling.html>`_ that
 return a linear combination of a component style and a colour ramp style.
 
 This can allow for a more easily visually interpreted image, but
@@ -15,8 +15,8 @@ there are usually better ways to achieve the same effect on the
 client side.
 
 Hybrid styles support most [*]_ elements supported by either
-`component styles <cfg_component_styles.rst>`_ or
-`colour ramp styles <cfg_colourramp_styles.rst>`_ and
+`component styles <https://datacube-ows.readthedocs.io/en/latest/cfg_component_styles.html>`_ or
+`colour ramp styles <https://datacube-ows.readthedocs.io/en/latest/cfg_colourramp_styles.html>`_ and
 define two indepenent styles (one of each type) that
 are then blended according to the required `component_ratio` entry.
 

--- a/docs/cfg_layers.rst
+++ b/docs/cfg_layers.rst
@@ -8,7 +8,7 @@ Layers Section
 --------------
 
 The "layers" section of the `root configuration object
-<configuration.rst>`_
+<https://datacube-ows.readthedocs.io/en/latest/configuration.html>`_
 contains definitions of the various layers (WMS/WMTS)
 and coverages (WCS) that installation serves.
 
@@ -75,7 +75,7 @@ and cumulative.  A layer will advertise all of:
 
 * The keywords defined for all parent folder layers in the layer hierarchy.
 
-* The keywords defined in the `global keywords <cfg_global.rst#optional-metadata>`_ section.
+* The keywords defined in the `global keywords <https://datacube-ows.readthedocs.io/en/latest/cfg_global.html#optional-metadata>`_ section.
 
 E.g.:
 
@@ -94,12 +94,12 @@ Attribution is optional and is used by WMS only.
 
 Attribution is hierarchical - if not supplied the setting from the closest parent
 layer that has an attribution is used.  Or if no parent layers supply an attribution
-either then the default value defined in `the wms section <cfg_wms.rst#default-attribution-attribution>`_
+either then the default value defined in `the wms section <https://datacube-ows.readthedocs.io/en/latest/cfg_wms.html#default-attribution-attribution>`_
 is used.  Or if there is no default value defined either, no attribution will be
 reported.
 
 The structure of the attribution section is the same as described in
-`the wms section <cfg_wms.rst#default-attribution-attribution>`_.
+`the wms section <https://datacube-ows.readthedocs.io/en/latest/cfg_wms.html#default-attribution-attribution>`_.
 
 Folder Layers
 =============
@@ -424,7 +424,7 @@ use:
 
 If this is not appropriate or possible for your data, you can
 set an alternative function using OWS's `function configuration format
-<cfg_functions.rst>`_.  Some sample functions are included in ``datacube_ows.ogc_utils``.
+<https://datacube-ows.readthedocs.io/en/latest/cfg_functions.html>`_.  Some sample functions are included in ``datacube_ows.ogc_utils``.
 
 The function is assumed to take two arguments, data (an xarray Dataset) and
 band (a band name).  (Plus any additional arguments you may be passing in
@@ -463,7 +463,7 @@ Fuse Function (fuse_func)
 
 Determines how multiple dataset arrays are compressed into a
 single time array. Specified using OWS's `function configuration
-format <cfg_functions.rst>`_.
+format <https://datacube-ows.readthedocs.io/en/latest/cfg_functions.html>`_.
 
 The fuse function is passed through to directly to the datacube
 load_data() function - refer to the Open Data Cube documentation
@@ -650,7 +650,7 @@ Sentinel-2 data is usually packaged like this.)  In this case
 you must manually declare a "native" CRS (if WCS is active).
 This can be any CRS
 declared in the `global published_CRSs section
-<cfg_global.rst#co-ordinate-reference-systems-published_CRSs>`_
+<https://datacube-ows.readthedocs.io/en/latest/cfg_global.html#co-ordinate-reference-systems-published_CRSs>`_
 and need not be related to the CRSs that the data is actually
 stored in.
 
@@ -690,7 +690,7 @@ Identifiers Section (identifiers)
 ---------------------------------
 
 The identifiers section is optional.  It is a dictionary mapping names from the
-`WMS authorities section <cfg_wms.rst#identifier-authorities-authorities>`_
+`WMS authorities section <https://datacube-ows.readthedocs.io/en/latest/cfg_wms.html#identifier-authorities-authorities>`_
 to an identifier for this layer, issued by each of those authorities.
 
 E.g.
@@ -766,7 +766,7 @@ Include Custom Info (include_custom)
 
 Determines how multiple dataset arrays are compressed into a
 single time array. Specified using OWS's `function configuration
-format <cfg_functions.rst>`_.
+format <https://datacube-ows.readthedocs.io/en/latest/cfg_functions.html>`_.
 
 "include_custom" allows custom data to be included in GetFeatureInfo responses. It
 is optional and defaults to an empty dictionary (i.e. no custom data.)
@@ -777,7 +777,7 @@ default (e.g. "data", "data_available_for_dates", "data_links") - if you use one
 these keys, the defined custom data will REPLACE the default data for these keys.
 
 The values for the dictionary entries are Python functions specified using
-OWS's `function configuration format <cfg_functions.rst>`_.
+OWS's `function configuration format <https://datacube-ows.readthedocs.io/en/latest/cfg_functions.html>`_.
 
 The specified function(s) are expected to be passed a dictionary of band values
 (as parameter "data") and can return any data that can be serialised to JSON.
@@ -802,7 +802,7 @@ E.g.
 Styling Section (styling)
 -----------------------------------
 
-The `"styling" section <cfg_styling.rst>`_ describes the WMS and WMTS styles for
+The `"styling" section <https://datacube-ows.readthedocs.io/en/latest/cfg_styling.html>`_ describes the WMS and WMTS styles for
 the layer.
 
 

--- a/docs/cfg_styling.rst
+++ b/docs/cfg_styling.rst
@@ -8,7 +8,7 @@ Styling Section
 ---------------
 
 The "styling" sub-section of a `layer configuration section
-<cfg_layers.rst>`_
+<https://datacube-ows.readthedocs.io/en/latest/cfg_layers.html>`_
 contains definitions of the various styles
 that layer supports.
 
@@ -96,30 +96,30 @@ E.g. ::
     ],
 
 Currently multi_date is only supported
-for `Colour Ramp styles <cfg_colourramp_styles.rst#multi-date>`__.
+for `Colour Ramp styles <https://datacube-ows.readthedocs.io/en/latest/cfg_colourramp_styles.html#multi-date>`__.
 
 Style Types
 ===========
 
 There are four distinct possible types of style.
 
-1. `Component Styles <cfg_component_styles.rst>`_
+1. `Component Styles <https://datacube-ows.readthedocs.io/en/latest/cfg_component_styles.html>`_
 
    Each component channel of the image (red, green, blue and optionally
    alpha) is calculated independently from the data for that pixel.
 
-2. `Colour Map Styles <cfg_colourmap_styles.rst>`_
+2. `Colour Map Styles <https://datacube-ows.readthedocs.io/en/latest/cfg_colourmap_styles.html>`_
 
    Each pixel is mapped to one particular colour from a fixed pallet
    by applying a logical decision tree to the date for that pixel.
 
-3. `Colour Ramp Styles <cfg_colourramp_styles.rst>`_
+3. `Colour Ramp Styles <https://datacube-ows.readthedocs.io/en/latest/cfg_colourramp_styles.html>`_
 
    A single continuous index value is calculated from the data for
    each pixel, and that index value mapped to a graduated colour ramp
    for display.
 
-4. `Hybrid Styles <cfg_hybrid_styles.rst>`_
+4. `Hybrid Styles <https://datacube-ows.readthedocs.io/en/latest/cfg_hybrid_styles.html>`_
 
    A linear combination of a component style and a colour ramp style.
 
@@ -186,7 +186,7 @@ Bit-flag Masks (pq_masks)
 +++++++++++++++++++++++++
 
 The "pq_masks" section allows a style to mask the output image
-by the bit flags defined in the `Flag Processing Section <cfg_layers.rst#flag-processing-section-flags>`_ for the layer.
+by the bit flags defined in the `Flag Processing Section <https://datacube-ows.readthedocs.io/en/latest/cfg_layers.html#flag-processing-section-flags>`_ for the layer.
 
 The pq_masks section is a list of mask sections, which are OR'd together.  i.e. A pixel
 becomes transparent if it would be made transparent by any of the masks in the list

--- a/docs/cfg_wcs.rst
+++ b/docs/cfg_wcs.rst
@@ -8,12 +8,12 @@ WCS Section
 --------------
 
 The ``wcs`` section of the `root configuration object
-<configuration.rst>`_
+<https://datacube-ows.readthedocs.io/en/latest/configuration.html>`_
 contains config entries that apply
 to the WCS services for all coverages.
 
 The ``wcs`` section must be supplied if the WCS service is
-activated (specified in the `global services <cfg_global.rst#service-selection-services>`_
+activated (specified in the `global services <https://datacube-ows.readthedocs.io/en/latest/cfg_global.html#service-selection-services>`_
 section).
 
 
@@ -23,7 +23,7 @@ Supported output formats (formats)
 Specifies the supported WCS output formats.
 
 This section must be supplied if the WCS service is
-activated (specified in the `global services <cfg_global.rst#service-selection-services>`_
+activated (specified in the `global services <https://datacube-ows.readthedocs.io/en/latest/cfg_global.html#service-selection-services>`_
 section) and must contain at least one output format.
 
 Support for GeoTIFF and and NetCDF is included in datacube_ows.  Adding
@@ -54,7 +54,7 @@ NetCDF formats and look something like this:
             }
         },
 
-Renderer is set using OWS's `function configuration format <cfg_functions.rst>`_.
+Renderer is set using OWS's `function configuration format <https://datacube-ows.readthedocs.io/en/latest/cfg_functions.html>`_.
 The function is expected to take:
   * A WCSRequest object
   * An xarray.DataArray to render
@@ -70,7 +70,7 @@ Specifies the default output format to use if the user does not
 specify a format.
 
 This entry must be supplied if the WCS service is
-activated (specified in the `global services <cfg_global.rst#service-selection-services>`_
+activated (specified in the `global services <https://datacube-ows.readthedocs.io/en/latest/cfg_global.html#service-selection-services>`_
 section) and must contain the name of one of the formats in
 defined in the
 `formats <#supported-output-formats-formats>`_ section.

--- a/docs/cfg_wms.rst
+++ b/docs/cfg_wms.rst
@@ -8,7 +8,7 @@ WMS Section
 --------------
 
 The "wms" section of the `root configuration object
-<configuration.rst>`_
+<https://datacube-ows.readthedocs.io/en/latest/configuration.html>`_
 contains config entries that apply
 to the WMS/WMTS services for all layers.
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -208,12 +208,12 @@ activated (specified in the `global services <https://datacube-ows.readthedocs.i
 section), or if the default values for all entries are acceptable.
 
 The `wcs <https://datacube-ows.readthedocs.io/en/latest/cfg_wcs.html>`_ section must be supplied if the WCS service is
-activated (specified in the `global services <https://datacube-ows.readthedocs.io/en/latest/cfg_global.html#service-selection-services>`_
+activated (specified in the `global services <cfg_global#service-selection-services>`_
 section).
 
 There is no separate section for WMTS as WMTS is implemented as a thin wrapper around the WMS implementation.
 
-The `layers <https://datacube-ows.readthedocs.io/en/latest/cfg_layers.html>`_ section contains a list of layer configurations.  The configured layers define the
+The `layers <cfg_layers.html>`_ section contains a list of layer configurations.  The configured layers define the
 layers (in WMS and WMTS) and coverages (in WCS) that the instance serves, and their behaviour. The layers section
 is always required.
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -2,6 +2,18 @@
 OWS Configuration
 =================
 
+.. toctree::
+   :maxdepth: 2
+   :hidden:
+
+   cfg_global
+   cfg_wms
+   cfg_wcs
+   cfg_functions
+   cfg_layers
+   cfg_styling
+   cfg_*_styles.rst
+
 .. contents:: Table of Contents
 
 .. _introduction:

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -197,23 +197,23 @@ At the top level, the Datacube OWS configuration is a single dictionary with the
      ]
   }
 
-The `global <cfg_global.rst>`_ section contains configuration that
+The `global <cfg_global>`_ section contains configuration that
 applies to the whole server across all services and layers.
-The `global <cfg_global.rst>`_ section is always required.
+The `global <cfg_global>`_ section is always required.
 
-The `wms <cfg_wms.rst>`_ section contains configuration that applies to the WMS/WMTS
+The `wms <cfg_wms>`_ section contains configuration that applies to the WMS/WMTS
 services aross all layers.
-The `wms <cfg_wms.rst>`_ section can be omitted if only the WCS service is
-activated (specified in the `global services <cfg_global.rst#service-selection-services>`_
+The `wms <cfg_wms>`_ section can be omitted if only the WCS service is
+activated (specified in the `global services <cfg_global#service-selection-services>`_
 section), or if the default values for all entries are acceptable.
 
-The `wcs <cfg_wcs.rst>`_ section must be supplied if the WCS service is
-activated (specified in the `global services <cfg_global.rst#service-selection-services>`_
+The `wcs <cfg_wcs>`_ section must be supplied if the WCS service is
+activated (specified in the `global services <cfg_global#service-selection-services>`_
 section).
 
 There is no separate section for WMTS as WMTS is implemented as a thin wrapper around the WMS implementation.
 
-The `layers <cfg_layers.rst>`_ section contains a list of layer configurations.  The configured layers define the
+The `layers <cfg_layers>`_ section contains a list of layer configurations.  The configured layers define the
 layers (in WMS and WMTS) and coverages (in WCS) that the instance serves, and their behaviour. The layers section
 is always required.
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -12,7 +12,7 @@ OWS Configuration
    cfg_functions
    cfg_layers
    cfg_styling
-   cfg_*_styles.rst
+   cfg_*_styles
 
 .. contents:: Table of Contents
 
@@ -197,23 +197,23 @@ At the top level, the Datacube OWS configuration is a single dictionary with the
      ]
   }
 
-The `global <cfg_global>`_ section contains configuration that
+The `global <https://datacube-ows.readthedocs.io/en/latest/cfg_global.html>`_ section contains configuration that
 applies to the whole server across all services and layers.
-The `global <cfg_global>`_ section is always required.
+The `global <https://datacube-ows.readthedocs.io/en/latest/cfg_global.html>`_ section is always required.
 
-The `wms <cfg_wms>`_ section contains configuration that applies to the WMS/WMTS
+The `wms <https://datacube-ows.readthedocs.io/en/latest/cfg_wms.html>`_ section contains configuration that applies to the WMS/WMTS
 services aross all layers.
-The `wms <cfg_wms>`_ section can be omitted if only the WCS service is
-activated (specified in the `global services <cfg_global#service-selection-services>`_
+The `wms <https://datacube-ows.readthedocs.io/en/latest/cfg_wms.html>`_ section can be omitted if only the WCS service is
+activated (specified in the `global services <https://datacube-ows.readthedocs.io/en/latest/cfg_global.html#service-selection-services>`_
 section), or if the default values for all entries are acceptable.
 
-The `wcs <cfg_wcs>`_ section must be supplied if the WCS service is
-activated (specified in the `global services <cfg_global#service-selection-services>`_
+The `wcs <https://datacube-ows.readthedocs.io/en/latest/cfg_wcs.html>`_ section must be supplied if the WCS service is
+activated (specified in the `global services <https://datacube-ows.readthedocs.io/en/latest/cfg_global.html#service-selection-services>`_
 section).
 
 There is no separate section for WMTS as WMTS is implemented as a thin wrapper around the WMS implementation.
 
-The `layers <cfg_layers>`_ section contains a list of layer configurations.  The configured layers define the
+The `layers <https://datacube-ows.readthedocs.io/en/latest/cfg_layers.html>`_ section contains a list of layer configurations.  The configured layers define the
 layers (in WMS and WMTS) and coverages (in WCS) that the instance serves, and their behaviour. The layers section
 is always required.
 

--- a/docs/environment_variables.rst
+++ b/docs/environment_variables.rst
@@ -100,5 +100,5 @@ Docker and Docker-compose
 -------------------------
 
 The provided ``Dockerfile`` and ``docker-compose.yaml`` read additional
-environment variables at build time.  Please refer to the `README <readme.rst>`_
+environment variables at build time.  Please refer to the `README <https://datacube-ows.readthedocs.io/en/latest/readme.html>`_
 for further details.

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -70,7 +70,7 @@ To install datacube-ows, run:
 Update_range natively
 ---------------------
 
-Refer to the `database documentation <database.rst>`_ documentation
+Refer to the `database documentation <https://datacube-ows.readthedocs.io/en/latest/database.html>`_ documentation
 for information on how to setup and maintain a Datacube OWS database.
 
 From sources ( within Docker )
@@ -102,7 +102,7 @@ of the config file, and edit it to reflect your requirements.
     $ vi .env
 
 Create an external PostgreSQL Database for OWS use. (See
-the `database documentation <database.rst>`__ for
+the `database documentation <https://datacube-ows.readthedocs.io/en/latest/database.html>`__ for
 more information.)  jUse this as a
 sidecar docker or natively on the host system. The following
 steps assume the database is on the host system for networking
@@ -120,7 +120,7 @@ Update_range via docker
 -----------------------
 
 Connect to the running docker to run datacube-ows-update/update_range.py
-commands (see the `database documentation <database.rst>`__ for more
+commands (see the `database documentation <https://datacube-ows.readthedocs.io/en/latest/database.html>`__ for more
 information).
 
 E.g. to set up a new database:


### PR DESCRIPTION
Readthedocs changes filenames on compile from "*.rst" to "*.html".  Therefore internal relative links like "cfg_styling.rst" will fail on RTD.   I've made all links to be explicit links to RTD latest html files. 

(And I've seeded a couple of alternative forms as temporary tests just in case Sphinx does some sensible link translation I haven't found the documentation for.)