### PR TITLE
Remove manual merge

### DIFF
--- a/datacube_ows/ows_cfg_example.py
+++ b/datacube_ows/ows_cfg_example.py
@@ -1480,10 +1480,6 @@ ows_cfg = {
                         # Values of flags listed here are not included in GetFeatureInfo responses.
                         # (defaults to empty list)
                         "ignore_info_flags": [],
-                        # Set to true if the pq product dataset extents include nodata regions.
-                        #
-                        # Default to False.
-                        "manual_merge": False,
                     },
                     # The image_processing section must be supplied.
                     "image_processing": {
@@ -1511,9 +1507,6 @@ ows_cfg = {
                         #
                         # Defaults to None.
                         "fuse_func": None,
-                        # Set to true if the band product dataset extents include nodata regions.
-                        # Defaults to False.
-                        "manual_merge": False,
                         # Apply corrections for solar angle, for "Level 1" products.
                         # (Defaults to false - should not be used for NBAR/NBAR-T or other Analysis Ready products
                         "apply_solar_corrections": False,
@@ -1647,7 +1640,6 @@ ows_cfg = {
                         "band": "quality",
                         "ignore_time": False,
                         "ignore_info_flags": [],
-                        "manual_merge": True,
                     },
                     "image_processing": {
                         # Extent mask function
@@ -1662,7 +1654,6 @@ ows_cfg = {
                         # is the case here.
                         "always_fetch_bands": [ "quality" ],
                         "fuse_func": None,
-                        "manual_merge": True,
                         # Apply corrections for solar angle, for "Level 1" products.
                         # (Defaults to false - should not be used for NBAR/NBAR-T or other Analysis Ready products
                         "apply_solar_corrections": True
@@ -1740,13 +1731,11 @@ ows_cfg = {
                         "band": "quality",
                         "ignore_time": False,
                         "ignore_info_flags": [],
-                        "manual_merge": False,
                     },
                     "image_processing": {
                         "extent_mask_func": "datacube_ows.ogc_utils.mask_by_val",
                         "always_fetch_bands": [ ],
                         "fuse_func": None,
-                        "manual_merge": False,
                         "apply_solar_corrections": False,
                     },
                     "wcs": {
@@ -1792,7 +1781,6 @@ ows_cfg = {
                 "extent_mask_func": "datacube_ows.ogc_utils.mask_by_extent_flag",
                 "always_fetch_bands": [ "extent" ],
                 "fuse_func": None,
-                "manual_merge": False,
                 "apply_solar_corrections": False,
             },
             "wcs": {

--- a/datacube_ows/ows_configuration.py
+++ b/datacube_ows/ows_configuration.py
@@ -392,7 +392,10 @@ class OWSNamedLayer(OWSLayer):
         raw_afb = cfg.get("always_fetch_bands", [])
         self.always_fetch_bands = list([ self.band_idx.band(b) for b in raw_afb ])
         self.solar_correction = cfg.get("apply_solar_corrections", False)
-        self.data_manual_merge = cfg.get("manual_merge", False)
+        if cfg.get("manual_merge", False):
+            _LOG.warning(
+                        "Ignoring image_processing::manual_merge for layer %s.  Manual merge is no longer supported.",
+                        self.name)
         if cfg.get("fuse_func"):
             self.fuse_func = FunctionWrapper(self, cfg["fuse_func"])
         else:
@@ -413,14 +416,16 @@ class OWSNamedLayer(OWSLayer):
                 self.pq_fuse_func = None
             self.pq_ignore_time = cfg.get("ignore_time", False)
             self.ignore_info_flags = cfg.get("ignore_info_flags", [])
-            self.pq_manual_merge = cfg.get("manual_merge", False)
+            if cfg.get("manual_merge", False):
+                _LOG.warning(
+                    "flags::manual_merge for layer %s. Manual Merge no longer supported.",
+                    self.name)
         else:
             self.pq_names = []
             self.pq_name = None
             self.pq_band = None
             self.pq_ignore_time = False
             self.ignore_info_flags = []
-            self.pq_manual_merge = False
         self.pq_products = []
 
         if self.pq_names:

--- a/docs/cfg_layers.rst
+++ b/docs/cfg_layers.rst
@@ -404,7 +404,6 @@ E.g.::
         "extent_mask_func": "datacube_ows.ogc_utils.mask_by_val",
         "always_fetch_bands": "pixel_qa",
         "fuse_func": None,
-        "manual_merge": False,
         "apply_solar_corrections": True
     }
 
@@ -471,13 +470,6 @@ for calling conventions.
 
 Optional - default is to not use a fuse function.
 
-Manual Merge (manual_merge)
-+++++++++++++++++++++++++++
-
-"manual_merge" is an optional boolean flag (defaults to False).  If True,
-data for each dataset is fused in OWS outside of ODC.  This is rarely what
-you want, but may work better for some metadata types.
-
 Apply Solar Corrections (apply_solar_corrections)
 +++++++++++++++++++++++++++++++++++++++++++++++++
 
@@ -517,7 +509,6 @@ E.g.
         "band": "pixelquality",
         "product": "ls8_pq",
         "fuse_func": "datacube.helpers.ga_pq_fuser",
-        "manual_merge": False,
         "ignore_info_flags": ["noisy"],
         "ignore_time": False
     }
@@ -590,14 +581,6 @@ Only applies if the flag band is read from a separate product
 (or product).  Equivalent to the `fuse function in the
 image_processing section <#fuse-function-fuse_func>`_.
 Always optional - defaults to None.
-
-Manual Flag Merge (manual_merge)
-++++++++++++++++++++++++++++++++
-
-Only applies if the flag band is read from a separate product
-(or product).  Equivalent to the `manual merge in the
-image_processing section <#manual-merge-manual_merge>`_.
-Optional - defaults to False.
 
 Ignore Time (ignore_time)
 +++++++++++++++++++++++++

--- a/ows_test_cfg.py
+++ b/ows_test_cfg.py
@@ -966,7 +966,6 @@ ows_cfg = {
                         "band": "quality",
                         "ignore_time": False,
                         "ignore_info_flags": [],
-                        "manual_merge": True,
                     },
                     "image_processing": {
                         # Extent mask function
@@ -981,7 +980,6 @@ ows_cfg = {
                         # is the case here.
                         "always_fetch_bands": [ "quality" ],
                         "fuse_func": None,
-                        "manual_merge": True,
                         # Apply corrections for solar angle, for "Level 1" products.
                         # (Defaults to false - should not be used for NBAR/NBAR-T or other Analysis Ready products
                         "apply_solar_corrections": True
@@ -1034,7 +1032,6 @@ For service status information, see https://status.dea.ga.gov.au
                     "image_processing": {
                         "extent_mask_func": "datacube_ows.ogc_utils.mask_by_val",
                         "always_fetch_bands": [ ],
-                        "manual_merge": False,
                     },
                     "flags": {
                         "band": "water",
@@ -1071,7 +1068,6 @@ For service status information, see https://status.dea.ga.gov.au
                     "image_processing": {
                         "extent_mask_func": "datacube_ows.ogc_utils.mask_by_bitflag",
                         "always_fetch_bands": [ ],
-                        "manual_merge": False,
                         "fuse_func": "datacube_ows.wms_utils.wofls_fuser",
                     },
                     "wcs": {
@@ -1104,7 +1100,6 @@ For service status information, see https://status.dea.ga.gov.au
                     "image_processing": {
                         "extent_mask_func": "datacube_ows.ogc_utils.mask_by_val",
                         "always_fetch_bands": [ ],
-                        "manual_merge": False,
                     },
                     "flags": {
                         "band": "water",
@@ -1142,7 +1137,6 @@ For service status information, see https://status.dea.ga.gov.au
                     "image_processing": {
                         "extent_mask_func": "datacube_ows.ogc_utils.mask_by_val",
                         "always_fetch_bands": [ ],
-                        "manual_merge": False,
                     },
                     "flags": {
                         "band": "water",
@@ -1177,7 +1171,6 @@ Fractional Cover version 2.2.1, 25 metre, 100km tile, Australian Albers Equal Ar
                     "image_processing": {
                         "extent_mask_func": "datacube_ows.ogc_utils.mask_by_val",
                         "always_fetch_bands": [ ],
-                        "manual_merge": False,
                     },
                     "flags": {
                         "band": "water",


### PR DESCRIPTION
Manual merge is a legacy workaround for bugs in the main workflow that have been fixed for quite some time.  The way it works doesn't really fit with recent refactors.  Maintaining it further is more trouble than it's worth.

It generates a "no longer supported - ignoring" warning message if it sees `"manual_merge": True` in the config file.