### PR TITLE
Add query profiling tool.

### DIFF
--- a/datacube_ows/query_profiler.py
+++ b/datacube_ows/query_profiler.py
@@ -5,6 +5,8 @@ class QueryProfiler:
         self.active = active
         self._events = {}
         self._stats = {}
+        if active:
+            self.start_event("query")
 
     def start_event(self, name):
         if self.active:
@@ -23,6 +25,7 @@ class QueryProfiler:
     def profile(self):
         result = {}
         if self.active:
+            self.end_event("query")
             result["profile"] = {}
             for name, rng in self._events.items():
                 if rng[0] and rng[1]:

--- a/datacube_ows/query_profiler.py
+++ b/datacube_ows/query_profiler.py
@@ -1,0 +1,31 @@
+from time import time
+
+class QueryProfiler:
+    def __init__(self, active):
+        self.active = active
+        self._events = {}
+        self._stats = {}
+
+    def start_event(self, name):
+        if self.active:
+            self._events[name] = [time(), None]
+
+    def __setitem__(self, name, val):
+        self._stats[name] = val
+
+    def end_event(self, name):
+        if self.active:
+            if name in self._events:
+                self._events[name][1] = time()
+            else:
+                self._events[name] = [None, time()]
+
+    def profile(self):
+        result = {}
+        if self.active:
+            result["profile"] = {}
+            for name, rng in self._events.items():
+                if rng[0] and rng[1]:
+                    result["profile"][name] = rng[1] - rng[0]
+            result["info"] = self._stats
+        return result

--- a/datacube_ows/wms_utils.py
+++ b/datacube_ows/wms_utils.py
@@ -356,6 +356,8 @@ class GetMapParameters(GetParameters):
         # Zoom factor
         self.zf = zoom_factor(args, self.crs)
 
+        self.ows_stats = bool(args.get("ows_stats"))
+
         # TODO: Do we need to make resampling method configurable?
         self.resampling = Resampling.nearest
 

--- a/tests/test_qprof.py
+++ b/tests/test_qprof.py
@@ -1,0 +1,28 @@
+from datacube_ows.query_profiler import QueryProfiler
+
+def test_qpf_inactive():
+    qp = QueryProfiler(False)
+    qp.start_event("foo")
+    qp.end_event("foo")
+    qp["foo"] = "splunge"
+    assert qp.profile() == {}
+
+def test_qpf_active():
+    qp = QueryProfiler(True)
+    prof = qp.profile()
+    assert prof["info"] == {}
+    assert prof["profile"]["query"] is not None
+
+def test_qpf_events():
+    qp = QueryProfiler(True)
+    qp.start_event("foo")
+    qp.end_event("foo")
+    prof = qp.profile()
+    assert prof["profile"]["foo"] is not None
+
+def test_qpf_info():
+    qp = QueryProfiler(True)
+    qp["foo"] = "splunge"
+    prof = qp.profile()
+    assert prof["info"]["foo"] == "splunge"
+


### PR DESCRIPTION
Hopefully useful diagnostic tool.

Whack `&ows_stats=true` on the end of any get map query and the server goes through all the work of loading and transforming the data into an image, but instead of returning that image, returns some profiling data on that specific query.  E.g.:

```
{
  "profile": {
    "query": 0.3746297359466553, 
    "count-datasets": 0.015242815017700195, 
    "fetch-datasets": 0.023380041122436523, 
    "load-data": 0.23415517807006836, 
    "build-masks": 0.020035266876220703, 
    "combine-masks": 0.0010516643524169922, 
    "apply-style": 0.05451154708862305, 
    "write": 0.001939535140991211
  }, 
  "info": {
     "n_dates": 1, 
     "n_datasets": 1, 
     "write_action": "Write Data"
   }
}
```

The `"profile"` section contains real execution times in seconds.  ("query" refers to the (almost) entire processing time - excludes initial parsing of query parameters, flask overhead, and http network I/O.)

Only works for GetMap queries that normally return an image. GetMap queries that normally return an Exception will still return an exception.