### PR TITLE
Remove "plus one day" bug for scalar-timed EO3 datasets.

### DIFF
--- a/datacube_ows/sql/extent_views/create/010_create_new_time_view.sql
+++ b/datacube_ows/sql/extent_views/create/010_create_new_time_view.sql
@@ -39,7 +39,7 @@ select
   dataset_type_ref, id,tstzrange(
     coalesce(metadata->'properties'->>'dtr:start_datetime', metadata->'properties'->>'datetime'):: timestamp,
     coalesce((metadata->'properties'->>'dtr:end_datetime'):: timestamp,(metadata->'properties'->>'datetime'):: timestamp),
-    []
+    '[]'
    ) as temporal_extent
 from agdc.dataset where
     metadata_type_ref in (select id from metadata_lookup where name in ('eo3_landsat_ard','eo3'))

--- a/datacube_ows/sql/extent_views/create/010_create_new_time_view.sql
+++ b/datacube_ows/sql/extent_views/create/010_create_new_time_view.sql
@@ -38,7 +38,8 @@ UNION
 select
   dataset_type_ref, id,tstzrange(
     coalesce(metadata->'properties'->>'dtr:start_datetime', metadata->'properties'->>'datetime'):: timestamp,
-    coalesce((metadata->'properties'->>'dtr:end_datetime'):: timestamp,(metadata->'properties'->>'datetime'):: timestamp + interval '1 day')
+    coalesce((metadata->'properties'->>'dtr:end_datetime'):: timestamp,(metadata->'properties'->>'datetime'):: timestamp),
+    []
    ) as temporal_extent
 from agdc.dataset where
     metadata_type_ref in (select id from metadata_lookup where name in ('eo3_landsat_ard','eo3'))


### PR DESCRIPTION
EO3 products with a single timestamp were being represented as [time, time+1 day] 24 hour range.  Now a [time, time] instantaneous time range, as for EO products.  Should fix #416