### PR TITLE
Handle eo_s2_nrt metadata type in materialised views

### DIFF
--- a/datacube_ows/sql/extent_views/create/010_create_new_time_view.sql
+++ b/datacube_ows/sql/extent_views/create/010_create_new_time_view.sql
@@ -27,7 +27,7 @@ select
       )
   end as temporal_extent
 from agdc.dataset where
-  metadata_type_ref in (select id from metadata_lookup where name in ('eo','eo_s2_nrt', 'gqa_eo','eo_plus')
+  metadata_type_ref in (select id from metadata_lookup where name in ('eo','eo_s2_nrt', 'gqa_eo','eo_plus'))
   and archived is null
 UNION
 -- This is the eo3 variant of the temporal extent, the sample eo3 dataset uses a singleton

--- a/datacube_ows/sql/extent_views/create/010_create_new_time_view.sql
+++ b/datacube_ows/sql/extent_views/create/010_create_new_time_view.sql
@@ -27,7 +27,7 @@ select
       )
   end as temporal_extent
 from agdc.dataset where
-  metadata_type_ref in (select id from metadata_lookup where name in ('eo','gqa_eo','eo_plus'))
+  metadata_type_ref in (select id from metadata_lookup where name in ('eo','eo_s2_nrt', 'gqa_eo','eo_plus')
   and archived is null
 UNION
 -- This is the eo3 variant of the temporal extent, the sample eo3 dataset uses a singleton

--- a/datacube_ows/sql/extent_views/create/011_create_new_space_view_raw.sql
+++ b/datacube_ows/sql/extent_views/create/011_create_new_space_view_raw.sql
@@ -32,7 +32,7 @@ corners as
   (metadata #>> '{extent, coord, ur, lat}') as ur_lat,
   (metadata #>> '{extent, coord, ur, lon}') as ur_lon
    from agdc.dataset where
-        metadata_type_ref in (select id from metadata_lookup where name in ('eo','gqa_eo','eo_plus'))
+        metadata_type_ref in (select id from metadata_lookup where name in ('eo','eo_s2_nrt','gqa_eo','eo_plus'))
         and archived is null
     )
 select id,format('POLYGON(( %s %s, %s %s, %s %s, %s %s, %s %s))',


### PR DESCRIPTION
Fix for #415

I'm just assuming the new metadata type is the same as eo as far as space and time extents go.

@pindge could you try regenerating the materialised views for the new data with this branch?