### PR TITLE
#431 Create new docker push workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,101 @@
+---
+name: Docker
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - "**"
+
+  release:
+    types: [created, edited, published]
+
+env:
+  ORG: opendatacube
+  IMAGE: ows
+  DB_USERNAME: opendatacubeusername
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/master' || github.event_name == 'release'
+
+    steps:
+      - name: Login to DockerHub
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+        run: |
+          echo "${{ secrets.DockerPassword }}" | docker login -u "${{ secrets.DockerUser }}" --password-stdin
+
+      # Build prod image and tag as latest, connect to pre-indexed database
+      - name: Build and run prod OWS images (stage 2)
+        run: |
+          docker-compose -f docker-compose.yaml -f docker-compose.db.yaml -f docker-compose.prod.yaml up --build --force-recreate -d
+
+      - name: Sleep for 10 seconds
+        uses: whatnick/wait-action@master
+        with:
+          time: '10s'
+
+      # Run some tests on the images
+      # These tests require a working database
+      - name: Test ping
+        run: |
+          curl --show-error --fail \
+          --connect-timeout 5 \
+          --max-time 10 \
+          --retry 5 \
+          --retry-delay 0 \
+          --retry-max-time 40 \
+          "localhost:8000/ping" \
+          > /dev/null
+
+      - name: Test datacube-ows-update
+        run: |
+          docker-compose exec -T ows datacube-ows-update --schema --role ${DB_USERNAME}
+          docker-compose exec -T ows datacube-ows-update
+
+      - name: Test WMS GetCapabilities
+        run: |
+          curl --silent --show-error --fail \
+          "localhost:8000/?service=WMS&version=1.3.0&request=GetCapabilities" \
+
+      - name: Test WMTS GetCapabilities
+        run: |
+          curl --silent --show-error --fail \
+          "localhost:8000/?service=WMS&version=1.0.0&request=GetCapabilities" \
+          > /dev/null
+
+      - name: Test WCS1 GetCapabilities
+        run: |
+          curl --silent --show-error --fail \
+          "localhost:8000/?service=WCS&version=1.0.0&request=GetCapabilities"
+          > /dev/null
+
+      - name: Test WCS2 GetCapabilities
+        run: |
+          curl --silent --show-error --fail \
+          "localhost:8000/?service=WCS&version=2.0.1&request=GetCapabilities"
+          > /dev/null
+
+      - name: Test Prometheus Metrics
+        run: |
+          curl --silent --show-error --fail \
+          "localhost:8000/metrics"
+          > /dev/null
+
+      # Tag image if this is a tagged build
+      # if not use a pseudo tag based on current tag,
+      # number of commits since last tag and git hash
+      - name: Push to DockerHub (master branch or tagged release only)
+        if: github.ref == 'refs/heads/master' || github.event_name == 'release'
+        run: |
+          # figure out extra tag
+          git fetch --prune --unshallow 2> /dev/null || true
+          tag=$(git describe --tags)
+          # tag and push images
+          docker tag ${ORG}/${IMAGE}:latest ${ORG}/${IMAGE}:${tag}
+          docker push ${ORG}/${IMAGE}:latest
+          docker push ${ORG}/${IMAGE}:${tag}


### PR DESCRIPTION
Addresses Functional tests and Docker push section of the CI workflow and accesses dockerhub secrets only from master in main repo preventing PR's from fork blocking.