### PR TITLE
Standalone config parser tool for validating config files.

### DIFF
--- a/cfg_parser.py
+++ b/cfg_parser.py
@@ -1,0 +1,4 @@
+from datacube_ows.cfg_parser import main
+
+if __name__ == '__main__':
+    main()

--- a/datacube_ows/band_utils.py
+++ b/datacube_ows/band_utils.py
@@ -68,11 +68,16 @@ def single_band(data, band, band_mapper=None):
     return data[band]
 
 
-def band_quotient(data, band1, band2, band_mapper=None):
+def band_quotient(data, band1, band2, band_mapper=None, scale_from=None, scale_to=[0,255]):
     if band_mapper:
         band1=band_mapper(band1)
         band2=band_mapper(band2)
-    return data[band1] / data[band2]
+    unscaled = data[band1] / data[band2]
+    if scale_from:
+        scaled = scale_data(unscaled, scale_from, scale_to)
+    else:
+        scaled = unscaled
+    return scaled
 
 
 def band_quotient_sum(data, band1a, band1b, band2a, band2b, band_mapper=None):

--- a/datacube_ows/ows_configuration.py
+++ b/datacube_ows/ows_configuration.py
@@ -31,9 +31,12 @@ from datacube_ows.utils import group_by_statistical
 _LOG = logging.getLogger(__name__)
 
 
-def read_config():
-    cfg_env = os.environ.get("DATACUBE_OWS_CFG")
+def read_config(path=None):
     cwd = None
+    if path:
+        cfg_env = path
+    else:
+        cfg_env = os.environ.get("DATACUBE_OWS_CFG")
     if not cfg_env:
         from datacube_ows.ows_cfg import ows_cfg as cfg
     elif "/" in cfg_env or cfg_env.endswith(".json"):
@@ -866,9 +869,10 @@ class OWSConfig(OWSConfigEntry):
             cls._instance = super().__new__(cls)
         return cls._instance
 
-    def __init__(self, refresh=False):
+    def __init__(self, refresh=False, cfg=None):
         if not self.initialised or refresh:
-            cfg = read_config()
+            if not cfg:
+                cfg = read_config()
             super().__init__(cfg)
             self.initialised = True
             try:

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(
     entry_points={
         'console_scripts': [
             'datacube-ows=datacube_ows.wsgi:main',
-            'datacube-ows-update=datacube_ows.update_ranges:main'
+            'datacube-ows-update=datacube_ows.update_ranges:main',
             'datacube-ows-cfg-parse=datacube_ows.cfg_parser:main'
         ]
     },

--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,7 @@ setup(
             'datacube-ows=datacube_ows.wsgi:main',
             'datacube-ows-update-old=datacube_ows.update_ranges_old:main',
             'datacube-ows-update=datacube_ows.update_ranges:main'
+            'datacube-ows-cfg-parse=datacube_ows.cfg_parser:main'
         ]
     },
     packages=find_packages(),

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,6 @@ setup(
     entry_points={
         'console_scripts': [
             'datacube-ows=datacube_ows.wsgi:main',
-            'datacube-ows-update-old=datacube_ows.update_ranges_old:main',
             'datacube-ows-update=datacube_ows.update_ranges:main'
             'datacube-ows-cfg-parse=datacube_ows.cfg_parser:main'
         ]


### PR DESCRIPTION
Useful tool. E.g.

Parse the current config file, as per environment variables:
```
datacube-ows-cfg-parse
```
Parse a particular config file (not the python file name, but the python object FQP):
```
datacube-ows-cfg-parse my_cfg_file.ows_cfg
```
Parse syntax only, do not attempt to validate against the database:
```
datacube-ows-cfg-parse -p my_cfg_file.ows_cfg
```
