### PR TITLE
Generalise handing of wmts tile matrix sets

### DIFF
--- a/datacube_ows/ows_configuration.py
+++ b/datacube_ows/ows_configuration.py
@@ -23,6 +23,7 @@ from datacube_ows.cube_pool import cube, get_cube, release_cube
 from datacube_ows.styles import StyleDef
 from datacube_ows.ogc_utils import ConfigException, FunctionWrapper, month_date_range, local_solar_date_range, \
     year_date_range
+from datacube_ows.tile_matrix_sets import supported_tile_matrix_sets
 
 import logging
 
@@ -966,6 +967,12 @@ class OWSConfig(OWSConfigEntry):
             self.published_CRSs[alias] = target_def.copy()
             self.published_CRSs[alias]["gml_name"] = make_gml_name(alias)
             self.published_CRSs[alias]["alias_of"] = target_crs
+
+        self.supported_tile_matrix_sets = []
+        if self.wmts:
+            for tms in supported_tile_matrix_sets:
+                if tms.crs_name in self.published_CRSs:
+                    self.supported_tile_matrix_sets.append(tms)
 
     def parse_wms(self, cfg):
         if not self.wms and not self.wmts:

--- a/datacube_ows/ows_configuration.py
+++ b/datacube_ows/ows_configuration.py
@@ -23,7 +23,7 @@ from datacube_ows.cube_pool import cube, get_cube, release_cube
 from datacube_ows.styles import StyleDef
 from datacube_ows.ogc_utils import ConfigException, FunctionWrapper, month_date_range, local_solar_date_range, \
     year_date_range
-from datacube_ows.tile_matrix_sets import supported_tile_matrix_sets
+from datacube_ows.tile_matrix_sets import supportable_tile_matrix_sets
 
 import logging
 
@@ -970,7 +970,7 @@ class OWSConfig(OWSConfigEntry):
 
         self.supported_tile_matrix_sets = []
         if self.wmts:
-            for tms in supported_tile_matrix_sets:
+            for tms in supportable_tile_matrix_sets:
                 if tms.crs_name in self.published_CRSs:
                     self.supported_tile_matrix_sets.append(tms)
 

--- a/datacube_ows/templates/wmts_capabilities.xml
+++ b/datacube_ows/templates/wmts_capabilities.xml
@@ -126,24 +126,24 @@
 
 {% if show_contents %}
     <Contents>
-        {% for product in cfg.product_index.values() %}
-        {% set product_ranges = product.ranges %}
-        {% if product_ranges and not product.hide %}
+        {% for layer in cfg.product_index.values() %}
+        {% set product_ranges = layer.ranges %}
+        {% if product_ranges and not layer.hide %}
         <Layer>
-            <ows:Title>{{ product.title }}</ows:Title>
-            <ows:Abstract>{{ product.abstract }}</ows:Abstract>
+            <ows:Title>{{ layer.title }}</ows:Title>
+            <ows:Abstract>{{ layer.abstract }}</ows:Abstract>
             <ows:WGS84BoundingBox>
                 <ows:LowerCorner>{{ product_ranges.lon.min }} {{ product_ranges.lat.min }}</ows:LowerCorner>
                 <ows:UpperCorner>{{ product_ranges.lon.max }} {{ product_ranges.lat.max }}</ows:UpperCorner>
             </ows:WGS84BoundingBox>
-            <ows:Identifier>{{ product.name }}</ows:Identifier>
-            {% for style in product.styles %}
-            <Style{% if style == product.default_style %} isDefault="true"{% endif %}>
+            <ows:Identifier>{{ layer.name }}</ows:Identifier>
+            {% for style in layer.styles %}
+            <Style{% if style == layer.default_style %} isDefault="true"{% endif %}>
                 <ows:Identifier>{{ style.name }}</ows:Identifier>
                 <ows:Title>{{ style.title }}</ows:Title>
                 <ows:Abstract>{{ style.abstract }}</ows:Abstract>
                 <LegendURL format="image/png"
-                        xlink:href="{{ base_url }}/legend/{{ product.name }}/{{ style.name }}/legend.png"/>
+                        xlink:href="{{ base_url }}/legend/{{ layer.name }}/{{ style.name }}/legend.png"/>
             </Style>
             {% endfor %}
             <Format>image/png</Format>
@@ -155,28 +155,34 @@
                 <Value>{{ t }}</Value>
                 {% endfor %}
             </Dimension>
+            {% for tms in cfg.supported_tile_matrix_sets %}
             <TileMatrixSetLink>
-                <TileMatrixSet>WholeWorld_WebMercator</TileMatrixSet>
+                <TileMatrixSet>{{ tms.identifier }}</TileMatrixSet>
             </TileMatrixSetLink>
+            {% endfor %}
         </Layer>
         {% endif %}
         {% endfor %}
+        {% for tms in cfg.supported_tile_matrix_sets %}
         <TileMatrixSet>
-            <ows:Identifier>WholeWorld_WebMercator</ows:Identifier>
-            <ows:SupportedCRS>urn:ogc:def:crs:EPSG::3857</ows:SupportedCRS>
-            <WellKnownScaleSet>urn:ogc:def:wkss:OGC:1.0:GoogleMapsCompatible</WellKnownScaleSet>
-            {% for denom in webmerc_ss %}
-            <TileMatrix>
-                <ows:Identifier>{{ loop.index0 }}</ows:Identifier>
-                <ScaleDenominator>{{ denom }}</ScaleDenominator>
-                <TopLeftCorner>-20037508.3427892 20037508.3427892</TopLeftCorner>
-                <TileWidth>256</TileWidth>
-                <TileHeight>256</TileHeight>
-                <MatrixWidth>{{ 2 ** loop.index0 }}</MatrixWidth>
-                <MatrixHeight>1</MatrixHeight>
-            </TileMatrix>
+            <ows:Identifier>{{ tms.identifier }}</ows:Identifier>
+            <ows:SupportedCRS>{{ tms.crs_display }}</ows:SupportedCRS>
+            {% if tms.wkss %}
+                <WellKnownScaleSet>{{ tms.wkss }}</WellKnownScaleSet>
+            {% endif %}
+            {% for denom in tms.scale_set %}
+                <TileMatrix>
+                    <ows:Identifier>{{ loop.index0 }}</ows:Identifier>
+                    <ScaleDenominator>{{ denom }}</ScaleDenominator>
+                    <TopLeftCorner>{{ tms.top_left[0] }} {{ tms.top_left[1] }}</TopLeftCorner>
+                    <TileWidth>{{ tms.tile_size[0] }}</TileWidth>
+                    <TileHeight>{{ tms.tile_size[1] }}</TileHeight>
+                    <MatrixWidth>{{ 2 ** tms.width_exponent(loop.index0) }}</MatrixWidth>
+                    <MatrixHeight>{{ 2 ** tms.height_exponent(loop.index0) }}</MatrixHeight>
+                </TileMatrix>
             {% endfor %}
         </TileMatrixSet>
+        {% endfor %}
     </Contents>
 {% endif %}
 

--- a/datacube_ows/tile_matrix_sets.py
+++ b/datacube_ows/tile_matrix_sets.py
@@ -1,0 +1,64 @@
+
+
+class TileMatrixSet:
+    def __init__(self, identifier, crs_name,
+                 top_left, tile_size,
+                 scale_set,
+                 layer_suffix,
+                 initial_matrix_exponents=(0,0),
+                 wkss=None,
+                 force_raw_crs_name=False,):
+        self.identifier = identifier
+        self.crs_name = crs_name
+        self.force_raw_crs_name = force_raw_crs_name
+        self.wkss = wkss
+        self.top_left = top_left
+        self.scale_set = scale_set
+        self.tile_size = tile_size
+        self.initial_matrix_exponents = initial_matrix_exponents
+        self.layer_suffix = layer_suffix
+
+    @property
+    def crs_display(self):
+        if self.force_raw_crs_name:
+            return self.crs_name
+        if self.crs_name[:5] == "EPSG:":
+            return f"urn:ogc:def:crs:EPSG::{self.crs_name[5:]}"
+        return self.crs_name
+
+# Scale denominators for WebMercator QuadTree Scale Set, starting from zoom level 0.
+# Currently goes to zoom level 14, where the pixel size at the equator is ~10m (i.e. Sentinel2 resolution)
+# Taken from the WMTS 1.0.0 spec, Annex E.4
+# Don't even think about changing these numbers unless you really, really know what you are doing.
+
+WebMercScaleSet = [
+    559082264.0287178,
+    279541132.0143589,
+    139770566.0071794,
+    69885283.00358972,
+    34942641.50179486,
+    17471320.75089743,
+    8735660.375448715,
+    4367830.187724357,
+    2183915.093862179,
+    1091957.546931089,
+    545978.7734655447,
+    272989.3867327723,
+    136494.6933663862,
+    68247.34668319309,
+    34123.67334159654,
+]
+
+google_web_mercator = TileMatrixSet(
+    "WholeWorld_WebMercator",
+    "EPSG:3857",
+    (-20037508.3427892, 20037508.3427892),
+    (256, 256),
+    WebMercScaleSet,
+    "webmerc",
+    wkss="urn:ogc:def:wkss:OGC:1.0:GoogleMapsCompatible",
+)
+
+supported_tile_matrix_sets = [
+    google_web_mercator,
+]

--- a/datacube_ows/tile_matrix_sets.py
+++ b/datacube_ows/tile_matrix_sets.py
@@ -4,7 +4,9 @@ class TileMatrixSet:
     def __init__(self, identifier, crs_name,
                  top_left, tile_size,
                  scale_set,
-                 layer_suffix,
+                 identifier_suffix,
+                 title_suffix,
+                 unit_coefficients=(1.0, 1.0),
                  initial_matrix_exponents=(0,0),
                  wkss=None,
                  force_raw_crs_name=False,):
@@ -16,7 +18,9 @@ class TileMatrixSet:
         self.scale_set = scale_set
         self.tile_size = tile_size
         self.initial_matrix_exponents = initial_matrix_exponents
-        self.layer_suffix = layer_suffix
+        self.unit_coefficients = unit_coefficients
+        self.identifier_suffix = identifier_suffix
+        self.title_suffix = title_suffix
 
     @property
     def crs_display(self):
@@ -25,6 +29,19 @@ class TileMatrixSet:
         if self.crs_name[:5] == "EPSG:":
             return f"urn:ogc:def:crs:EPSG::{self.crs_name[5:]}"
         return self.crs_name
+
+    def exponent(self, idx, scale_no):
+        init = self.initial_matrix_exponents[idx]
+        exponent = scale_no - init
+        if exponent < 0:
+            return 0
+        return scale_no
+
+    def width_exponent(self, scale_no):
+        return self.exponent(0, scale_no)
+
+    def height_exponent(self, scale_no):
+        return self.exponent(1, scale_no)
 
 # Scale denominators for WebMercator QuadTree Scale Set, starting from zoom level 0.
 # Currently goes to zoom level 14, where the pixel size at the equator is ~10m (i.e. Sentinel2 resolution)
@@ -56,9 +73,10 @@ google_web_mercator = TileMatrixSet(
     (256, 256),
     WebMercScaleSet,
     "webmerc",
+    "",
     wkss="urn:ogc:def:wkss:OGC:1.0:GoogleMapsCompatible",
 )
 
-supported_tile_matrix_sets = [
+supportable_tile_matrix_sets = [
     google_web_mercator,
 ]

--- a/datacube_ows/tile_matrix_sets.py
+++ b/datacube_ows/tile_matrix_sets.py
@@ -31,7 +31,7 @@ class TileMatrixSet:
         exponent = scale_no - init
         if exponent < 0:
             return 0
-        return scale_no
+        return exponent
 
     def width_exponent(self, scale_no):
         return self.exponent(0, scale_no)
@@ -44,7 +44,7 @@ class TileMatrixSet:
 # Taken from the WMTS 1.0.0 spec, Annex E.4
 # Don't even think about changing these numbers unless you really, really know what you are doing.
 
-WebMercScaleSet = [
+webmerc_scale_set = [
     559082264.0287178,
     279541132.0143589,
     139770566.0071794,
@@ -62,15 +62,42 @@ WebMercScaleSet = [
     34123.67334159654,
 ]
 
+vicgrid_geocortex_scale_set = [
+    7559538.928601667,
+    3779769.4643008336,
+    1889884.7321504168,
+    944942.3660752084,
+    472471.1830376042,
+    236235.5915188021,
+    94494.23660752083,
+    47247.11830376041,
+    23623.559151880207,
+    9449.423660752083,
+    4724.711830376042,
+    2362.355915188021,
+    1181.1779575940104,
+    755.9538928601667,
+]
+
 google_web_mercator = TileMatrixSet(
     "WholeWorld_WebMercator",
     "EPSG:3857",
     (-20037508.3427892, 20037508.3427892),
     (256, 256),
-    WebMercScaleSet,
+    webmerc_scale_set,
     wkss="urn:ogc:def:wkss:OGC:1.0:GoogleMapsCompatible",
+)
+
+vicgrid_geocortex_compatible = TileMatrixSet(
+    "EPSG:3111",
+    "EPSG:3111",
+    (1786000.0, 3081000.0),
+    (512, 512),
+    vicgrid_geocortex_scale_set,
+    initial_matrix_exponents=(-1, 0),
 )
 
 supportable_tile_matrix_sets = [
     google_web_mercator,
+    vicgrid_geocortex_compatible,
 ]

--- a/datacube_ows/tile_matrix_sets.py
+++ b/datacube_ows/tile_matrix_sets.py
@@ -4,9 +4,7 @@ class TileMatrixSet:
     def __init__(self, identifier, crs_name,
                  top_left, tile_size,
                  scale_set,
-                 identifier_suffix,
-                 title_suffix,
-                 unit_coefficients=(1.0, 1.0),
+                 unit_coefficients=(1.0, -1.0),
                  initial_matrix_exponents=(0,0),
                  wkss=None,
                  force_raw_crs_name=False,):
@@ -19,8 +17,6 @@ class TileMatrixSet:
         self.tile_size = tile_size
         self.initial_matrix_exponents = initial_matrix_exponents
         self.unit_coefficients = unit_coefficients
-        self.identifier_suffix = identifier_suffix
-        self.title_suffix = title_suffix
 
     @property
     def crs_display(self):
@@ -72,8 +68,6 @@ google_web_mercator = TileMatrixSet(
     (-20037508.3427892, 20037508.3427892),
     (256, 256),
     WebMercScaleSet,
-    "webmerc",
-    "",
     wkss="urn:ogc:def:wkss:OGC:1.0:GoogleMapsCompatible",
 )
 

--- a/datacube_ows/wmts.py
+++ b/datacube_ows/wmts.py
@@ -120,7 +120,6 @@ def wmts_args_to_wms(args, cfg):
         "height": 256,
         "format": format_,
         "exceptions": "application/vnd.ogc.se_xml",
-        "crs": "EPSG:3857",
         "requestid": args["requestid"]
     }
 
@@ -133,6 +132,7 @@ def wmts_args_to_wms(args, cfg):
     if tms is None:
         raise WMTSException("Invalid Tile Matrix Set: " + tileMatrixSet)
 
+    wms_args["crs"] = tms.crs_name
     crs_cfg = cfg.published_CRSs[tms.crs_name]
     try:
         tileMatrix = int(tileMatrix)

--- a/datacube_ows/wmts.py
+++ b/datacube_ows/wmts.py
@@ -148,11 +148,11 @@ def wmts_args_to_wms(args, cfg):
         col = int(col)
     except ValueError:
         raise WMTSException("Invalid Tile Col: " + col)
-    pixel = [row, col]
+    pixel = [col, row]
     tile_size = tms.tile_size
     matrix_origin = tms.top_left
     scale_denominator = tms.scale_set[tileMatrix]
-    pixel_span = (scale_denominator * 0.00028 * u for u in tms.unit_coefficients)
+    pixel_span = [scale_denominator * 0.00028 * u for u in tms.unit_coefficients]
     tile_span = [ ps * ts for ps, ts in zip(pixel_span, tile_size)]
 
     mins = [mo + p * ts for mo, p, ts in zip(matrix_origin, pixel, tile_span)]
@@ -160,11 +160,11 @@ def wmts_args_to_wms(args, cfg):
 
     if crs_cfg["vertical_coord_first"]:
         wms_args["bbox"] = "%f,%f,%f,%f" % (
-            mins[0], mins[1], maxs[0], maxs[1]
+            maxs[1], mins[0], mins[1], maxs[0]
         )
     else:
         wms_args["bbox"] = "%f,%f,%f,%f" % (
-            mins[1], mins[0], maxs[1], maxs[0]
+            mins[0], maxs[1], maxs[0], mins[1]
         )
 
     # GetFeatureInfo only args


### PR DESCRIPTION
Draft fix to #451.

This PR now has a tile matrix set that is hopefully VicGrid GeoCortex compatible.   (No specific config change required - you get it automatically if you publish in EPSG:3111).  Let's confirm it works before we go too much further.)

A subsequent PR will add broader unit tests, integration tests and shift the definition of the VicGrid GeoCortex Tile Matrix Set to config instead of having it hard wired into the wmts code.