### PR TITLE
WCS Config tests

### DIFF
--- a/datacube_ows/ows_configuration.py
+++ b/datacube_ows/ows_configuration.py
@@ -440,7 +440,7 @@ class OWSNamedLayer(OWSExtensibleConfigEntry, OWSLayer):
                 if pqn is not None:
                     pq_product = dc.index.products.get_by_name(pqn)
                     if pq_product is None:
-                        raise ConfigException(f"Could not find flags product {pqn} for layer {self.name} in datacube")
+                        raise ConfigException(f"Could not find flags low_res product {pqn} for layer {self.name} in datacube")
                     self.pq_low_res_products.append(pq_product)
 
         self.info_mask = ~0

--- a/datacube_ows/ows_configuration.py
+++ b/datacube_ows/ows_configuration.py
@@ -605,7 +605,7 @@ class OWSNamedLayer(OWSExtensibleConfigEntry, OWSLayer):
                                            native_bounding_box["top"] - native_bounding_box["bottom"]) / self.resolution_y)
 
             if self.grid_high_x == 0:
-                err_str = f"Grid High X is zero on layer {self.name}: native ({self.native_CRS}) extent: {native_bounding_box['left']},{native_bounding_box['right']}: x_res={self.resolution_x}"
+                err_str = f"Grid High x is zero on layer {self.name}: native ({self.native_CRS}) extent: {native_bounding_box['left']},{native_bounding_box['right']}: x_res={self.resolution_x}"
                 raise ConfigException(err_str)
             if self.grid_high_y == 0:
                 err_str = f"Grid High y is zero on layer {self.name}: native ({self.native_CRS}) extent: {native_bounding_box['bottom']},{native_bounding_box['top']}: x_res={self.resolution_y}"
@@ -671,20 +671,14 @@ class OWSNamedLayer(OWSExtensibleConfigEntry, OWSLayer):
         bboxes = {}
         for crs_id, bbox in self._ranges["bboxes"].items():
             if crs_id in self.global_cfg.published_CRSs:
-                if self.global_cfg.published_CRSs[crs_id].get("vertical_coord_first"):
-                    bboxes[crs_id] = {
-                        "right": bbox["bottom"],
-                         "left": bbox["top"],
-                         "top": bbox["left"],
-                         "bottom": bbox["right"]
-                     }
-                else:
-                    bboxes[crs_id] = {
-                        "right": bbox["right"],
-                        "left": bbox["left"],
-                        "top": bbox["top"],
-                        "bottom": bbox["bottom"]
-                    }
+                # Assume we've already handled coordinate swapping for
+                # Vertical-coord first CRSs.   Top is top, left is left.
+                bboxes[crs_id] = {
+                    "right": bbox["right"],
+                    "left": bbox["left"],
+                    "top": bbox["top"],
+                    "bottom": bbox["bottom"]
+                }
         return bboxes
 
     def layer_count(self):

--- a/datacube_ows/ows_configuration.py
+++ b/datacube_ows/ows_configuration.py
@@ -530,9 +530,7 @@ class OWSNamedLayer(OWSExtensibleConfigEntry, OWSLayer):
             if not self.native_CRS:
                 raise ConfigException(f"No native CRS could be found for layer {self.name}")
             if self.native_CRS not in self.global_cfg.published_CRSs:
-                raise ConfigException("Native CRS for product %s (%s) not in published CRSs" % (
-                    self.product_name,
-                    self.native_CRS))
+                raise ConfigException(f"Native CRS for product {self.product_name} in layer {self.name} ({self.native_CRS}) not in published CRSs")
             self.native_CRS_def = self.global_cfg.published_CRSs[self.native_CRS]
             # Prepare Rectified Grids
             try:
@@ -661,7 +659,6 @@ class OWSNamedLayer(OWSExtensibleConfigEntry, OWSLayer):
         finally:
             if not ext_dc:
                 release_cube(dc)
-
     @property
     def ranges(self):
         if self.dynamic:

--- a/datacube_ows/ows_configuration.py
+++ b/datacube_ows/ows_configuration.py
@@ -284,7 +284,6 @@ class OWSNamedLayer(OWSExtensibleConfigEntry, OWSLayer):
 
         self.declare_unready("_ranges")
         self.declare_unready("bboxes")
-        self.declare_unready("hide")
         # TODO: sub-ranges
         self.band_idx = BandIndex(self, cfg.get("bands"))
         self.parse_resource_limits(cfg.get("resource_limits", {}))
@@ -357,7 +356,8 @@ class OWSNamedLayer(OWSExtensibleConfigEntry, OWSLayer):
         if not self.multi_product:
             self.global_cfg.native_product_index[self.product_name] = self
 
-        super().make_ready(dc, *args, **kwargs)
+        if not self.hide:
+            super().make_ready(dc, *args, **kwargs)
 
     # pylint: disable=attribute-defined-outside-init
     def parse_resource_limits(self, cfg):
@@ -513,7 +513,7 @@ class OWSNamedLayer(OWSExtensibleConfigEntry, OWSLayer):
 
     # pylint: disable=attribute-defined-outside-init
     def ready_wcs(self, dc):
-        if self.wcs:
+        if self.global_cfg.wcs and self.wcs:
             # Native CRS
             try:
                 self.native_CRS = self.product.definition["storage"]["crs"]

--- a/integration_tests/test_mv_index.py
+++ b/integration_tests/test_mv_index.py
@@ -27,10 +27,10 @@ def test_time_search():
     lyr = list(cfg.product_index.values())[0]
     time = lyr.ranges["times"][-1]
     geom = box(
-        lyr.bboxes["EPSG:4326"]["bottom"],
         lyr.bboxes["EPSG:4326"]["left"],
-        lyr.bboxes["EPSG:4326"]["top"],
+        lyr.bboxes["EPSG:4326"]["bottom"],
         lyr.bboxes["EPSG:4326"]["right"],
+        lyr.bboxes["EPSG:4326"]["top"],
         "EPSG:4326")
 
     time_rng = local_solar_date_range(MockGeobox(geom), time)
@@ -66,10 +66,10 @@ def test_extent_and_spatial():
     cfg = get_config()
     lyr = list(cfg.product_index.values())[0]
     layer_ext_bbx = (
-        lyr.bboxes["EPSG:4326"]["bottom"],
         lyr.bboxes["EPSG:4326"]["left"],
-        lyr.bboxes["EPSG:4326"]["top"],
+        lyr.bboxes["EPSG:4326"]["bottom"],
         lyr.bboxes["EPSG:4326"]["right"],
+        lyr.bboxes["EPSG:4326"]["top"],
         )
     small_bbox = pytest.helpers.enclosed_bbox(layer_ext_bbx)
     layer_ext_geom = box(layer_ext_bbx[0],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,6 +24,7 @@ def minimal_dc():
     }
     lmo = MagicMock()
     lmo.loc = {
+        "foo_badnativecrs": nb,
         "foo_nativecrs": nb,
         "foo_nonativecrs": nb,
         "foo": nb,
@@ -51,6 +52,12 @@ def minimal_dc():
         if 'nonativecrs' in s:
             mprod.definition = {
                 "storage": {
+                }
+            }
+        elif 'badnativecrs' in s:
+            mprod.definition = {
+                "storage": {
+                    "crs": "EPSG:9999"
                 }
             }
         elif 'nativecrs' in s:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import datetime
 from unittest.mock import MagicMock
 
 import pytest
@@ -23,6 +24,8 @@ def minimal_dc():
     }
     lmo = MagicMock()
     lmo.loc = {
+        "foo_nativecrs": nb,
+        "foo_nonativecrs": nb,
         "foo": nb,
         "bar": nb,
     }
@@ -45,6 +48,17 @@ def minimal_dc():
                 "flags_definition": flag_def
             }
         }
+        if 'nonativecrs' in s:
+            mprod.definition = {
+                "storage": {
+                }
+            }
+        elif 'nativecrs' in s:
+            mprod.definition = {
+                "storage": {
+                    "crs": "EPSG:4326"
+                }
+            }
         return mprod
     dc.index.products.get_by_name = product_by_name
     return dc
@@ -58,6 +72,48 @@ def minimal_global_cfg():
     global_cfg.authorities = {
         "auth0": "http://test.url/auth0",
         "auth1": "http://test.url/auth1",
+    }
+    global_cfg.published_CRSs = {
+        "EPSG:3857": {  # Web Mercator
+            "geographic": False,
+            "horizontal_coord": "x",
+            "vertical_coord": "y",
+            "vertical_coord_first": False,
+            "gml_name": "http://www.opengis.net/def/crs/EPSG/0/3857",
+            "alias_of": None,
+        },
+        "EPSG:4326": {  # WGS-84
+            "geographic": True,
+            "vertical_coord_first": True,
+            "horizontal_coord": "longitude",
+            "vertical_coord": "latitude",
+            "gml_name": "http://www.opengis.net/def/crs/EPSG/0/4326",
+            "alias_of": None,
+        },
+        "EPSG:3577": {
+            "geographic": False,
+            "horizontal_coord": "x",
+            "vertical_coord": "y",
+            "vertical_coord_first": False,
+            "gml_name": "http://www.opengis.net/def/crs/EPSG/0/3577",
+            "alias_of": None,
+        },
+        "TEST:CRS": {
+            "geographic": False,
+            "horizontal_coord": "horrible_zonts",
+            "vertical_coord": "vertex_calories",
+            "vertical_coord_first": False,
+            "gml_name": "TEST/CRS",
+            "alias_of": None,
+        },
+        "TEST:NATIVE_CRS": {
+            "geographic": False,
+            "horizontal_coord": "hortizonal_cults",
+            "vertical_coord": "verbal_tics",
+            "vertical_coord_first": False,
+            "gml_name": "TEST/NATIVE_CRS",
+            "alias_of": None,
+        },
     }
     return global_cfg
 
@@ -126,5 +182,29 @@ def minimal_multiprod_cfg():
                     "scale_range": [0, 1024]
                 }
             ]
+        }
+    }
+
+@pytest.fixture
+def mock_range():
+    times = [datetime.datetime(2010, 1, 1), datetime.datetime(2010, 1, 2)]
+    return {
+        "lat": {
+            "min": -0.1,
+            "max": 0.1,
+        },
+        "lon": {
+            "min": -0.1,
+            "max": 0.1,
+        },
+        "times": times,
+        "start_time": times[0],
+        "end_time": times[-1],
+        "time_set": set(times),
+        "bboxes": {
+            "top": 0.1,
+            "bottom": -0.1,
+            "left": 0.1,
+            "right": -0.1,
         }
     }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -49,3 +49,82 @@ def minimal_dc():
     dc.index.products.get_by_name = product_by_name
     return dc
 
+
+@pytest.fixture
+def minimal_global_cfg():
+    global_cfg=MagicMock()
+    global_cfg.keywords = {"global"}
+    global_cfg.attribution = "Global Attribution"
+    global_cfg.authorities = {
+        "auth0": "http://test.url/auth0",
+        "auth1": "http://test.url/auth1",
+    }
+    return global_cfg
+
+
+@pytest.fixture
+def minimal_parent():
+    parent = MagicMock()
+    parent.abstract = "Parent Abstract"
+    parent.keywords = {"global", "parent"}
+    parent.attribution = "Parent Attribution"
+    return parent
+
+
+@pytest.fixture
+def minimal_layer_cfg():
+    return {
+        "title": "The Title",
+        "abstract": "The Abstract",
+        "name": "a_layer",
+        "product_name": "foo",
+        "image_processing": {
+            "extent_mask_func": "datacube_ows.ogc_utils.mask_by_val",
+        },
+        "styling": {
+            "default_style": "band1",
+            "styles": [
+                {
+                    "name": "band1",
+                    "title": "Single Band Test Style",
+                    "abstract": "",
+                    "components": {
+                        "red": {"band1": 1.0},
+                        "green": {"band1": 1.0},
+                        "blue": {"band1": 1.0},
+                    },
+                    "scale_range": [0, 1024]
+                }
+            ]
+        }
+    }
+
+
+@pytest.fixture
+def minimal_multiprod_cfg():
+    return {
+        "title": "The Title",
+        "abstract": "The Abstract",
+        "name": "a_layer",
+        "multi_product": True,
+        "product_names": ["foo", "bar"],
+        "image_processing": {
+            "extent_mask_func": "datacube_ows.ogc_utils.mask_by_val",
+        },
+        "styling": {
+            "default_style": "band1",
+            "styles": [
+                {
+                    "name": "band1",
+                    "title": "Single Band Test Style",
+                    "abstract": "",
+                    "components": {
+                        "red": {"band1": 1.0},
+                        "green": {"band1": 1.0},
+                        "blue": {"band1": 1.0},
+                    },
+                    "scale_range": [0, 1024]
+                }
+            ]
+        }
+    }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -212,8 +212,8 @@ def mock_range():
         "end_time": times[-1],
         "time_set": set(times),
         "bboxes": {
-            "EPSG:4326": {"top": 0.1, "bottom": -0.1, "left": 0.1, "right": -0.1,},
-            "EPSG:3577": {"top": 0.1, "bottom": -0.1, "left": 0.1, "right": -0.1,},
-            "EPSG:3857": {"top": 0.1, "bottom": -0.1, "left": 0.1, "right": -0.1,},
+            "EPSG:4326": {"top": 0.1, "bottom": -0.1, "left": -0.1, "right": 0.1,},
+            "EPSG:3577": {"top": 0.1, "bottom": -0.1, "left": -0.1, "right": 0.1,},
+            "EPSG:3857": {"top": 0.1, "bottom": -0.1, "left": -0.1, "right": 0.1,},
         }
     }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,6 +24,8 @@ def minimal_dc():
     }
     lmo = MagicMock()
     lmo.loc = {
+        "foo_nativeres": nb,
+        "foo_nonativeres": nb,
         "foo_badnativecrs": nb,
         "foo_nativecrs": nb,
         "foo_nonativecrs": nb,
@@ -49,23 +51,24 @@ def minimal_dc():
                 "flags_definition": flag_def
             }
         }
+        mprod.definition = {"storage": {}}
         if 'nonativecrs' in s:
-            mprod.definition = {
-                "storage": {
-                }
-            }
+            pass
         elif 'badnativecrs' in s:
-            mprod.definition = {
-                "storage": {
-                    "crs": "EPSG:9999"
-                }
-            }
+            mprod.definition["storage"]["crs"] = "EPSG:9999"
         elif 'nativecrs' in s:
-            mprod.definition = {
-                "storage": {
-                    "crs": "EPSG:4326"
-                }
+            mprod.definition["storage"]["crs"] = "EPSG:4326"
+        else:
+            pass
+        if 'nonativeres' in s:
+            pass
+        elif 'nativeres' in s:
+            mprod.definition["storage"]["resolution"] = {
+                "latitude": 0.001,
+                "longitude": 0.001,
             }
+        else:
+            pass
         return mprod
     dc.index.products.get_by_name = product_by_name
     return dc
@@ -209,9 +212,8 @@ def mock_range():
         "end_time": times[-1],
         "time_set": set(times),
         "bboxes": {
-            "top": 0.1,
-            "bottom": -0.1,
-            "left": 0.1,
-            "right": -0.1,
+            "EPSG:4326": {"top": 0.1, "bottom": -0.1, "left": 0.1, "right": -0.1,},
+            "EPSG:3577": {"top": 0.1, "bottom": -0.1, "left": 0.1, "right": -0.1,},
+            "EPSG:3857": {"top": 0.1, "bottom": -0.1, "left": 0.1, "right": -0.1,},
         }
     }

--- a/tests/test_cfg_layer.py
+++ b/tests/test_cfg_layer.py
@@ -4,26 +4,6 @@ from unittest.mock import MagicMock
 from datacube_ows.ogc_utils import ConfigException
 from datacube_ows.ows_configuration import OWSLayer, OWSFolder, parse_ows_layer
 
-@pytest.fixture
-def minimal_global_cfg():
-    global_cfg=MagicMock()
-    global_cfg.keywords = {"global"}
-    global_cfg.attribution = "Global Attribution"
-    global_cfg.authorities = {
-        "auth0": "http://test.url/auth0",
-        "auth1": "http://test.url/auth1",
-    }
-    return global_cfg
-
-
-@pytest.fixture
-def minimal_parent():
-    parent = MagicMock()
-    parent.abstract = "Parent Abstract"
-    parent.keywords = {"global", "parent"}
-    parent.attribution = "Parent Attribution"
-    return parent
-
 def test_minimal_layer_create(minimal_global_cfg):
     lyr = OWSLayer({
             "title": "The Title",
@@ -168,63 +148,6 @@ def test_make_ready_catch_errors(minimal_global_cfg, minimal_dc):
     assert len(lyr.child_layers) == 0
     assert lyr.ready
 
-
-@pytest.fixture
-def minimal_layer_cfg():
-    return {
-        "title": "The Title",
-        "abstract": "The Abstract",
-        "name": "a_layer",
-        "product_name": "foo",
-        "image_processing": {
-            "extent_mask_func": "datacube_ows.ogc_utils.mask_by_val",
-        },
-        "styling": {
-            "default_style": "band1",
-            "styles": [
-                {
-                    "name": "band1",
-                    "title": "Single Band Test Style",
-                    "abstract": "",
-                    "components": {
-                        "red": {"band1": 1.0},
-                        "green": {"band1": 1.0},
-                        "blue": {"band1": 1.0},
-                    },
-                    "scale_range": [0, 1024]
-                }
-            ]
-        }
-    }
-
-@pytest.fixture
-def minimal_multiprod_cfg():
-    return {
-        "title": "The Title",
-        "abstract": "The Abstract",
-        "name": "a_layer",
-        "multi_product": True,
-        "product_names": ["foo", "bar"],
-        "image_processing": {
-            "extent_mask_func": "datacube_ows.ogc_utils.mask_by_val",
-        },
-        "styling": {
-            "default_style": "band1",
-            "styles": [
-                {
-                    "name": "band1",
-                    "title": "Single Band Test Style",
-                    "abstract": "",
-                    "components": {
-                        "red": {"band1": 1.0},
-                        "green": {"band1": 1.0},
-                        "blue": {"band1": 1.0},
-                    },
-                    "scale_range": [0, 1024]
-                }
-            ]
-        }
-    }
 
 def test_minimal_named_layer(minimal_layer_cfg, minimal_global_cfg, minimal_dc):
     lyr = parse_ows_layer(minimal_layer_cfg,

--- a/tests/test_cfg_layer.py
+++ b/tests/test_cfg_layer.py
@@ -1,5 +1,5 @@
 import pytest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from datacube_ows.ogc_utils import ConfigException
 from datacube_ows.ows_configuration import OWSLayer, OWSFolder, parse_ows_layer
@@ -149,13 +149,16 @@ def test_make_ready_catch_errors(minimal_global_cfg, minimal_dc):
     assert lyr.ready
 
 
-def test_minimal_named_layer(minimal_layer_cfg, minimal_global_cfg, minimal_dc):
+def test_minimal_named_layer(minimal_layer_cfg, minimal_global_cfg, minimal_dc, mock_range):
     lyr = parse_ows_layer(minimal_layer_cfg,
                           global_cfg=minimal_global_cfg)
     assert lyr.name == "a_layer"
     assert not lyr.ready
-    lyr.make_ready(minimal_dc)
+    with patch("datacube_ows.product_ranges.get_ranges") as get_rng:
+        get_rng.return_value = mock_range
+        lyr.make_ready(minimal_dc)
     assert lyr.ready
+    assert not lyr.hide
     assert "a_layer" in str(lyr)
     assert len(lyr.low_res_products) == 0
 
@@ -217,13 +220,16 @@ def test_noprod_multiproduct(minimal_multiprod_cfg, minimal_global_cfg, minimal_
     assert "a_layer" in str(excinfo.value)
     assert "No products declared" in str(excinfo.value)
 
-def test_minimal_multiproduct(minimal_multiprod_cfg, minimal_global_cfg, minimal_dc):
+def test_minimal_multiproduct(minimal_multiprod_cfg, minimal_global_cfg, minimal_dc, mock_range):
     lyr = parse_ows_layer(minimal_multiprod_cfg,
                           global_cfg=minimal_global_cfg)
     assert lyr.name == "a_layer"
     assert not lyr.ready
-    lyr.make_ready(minimal_dc)
+    with patch("datacube_ows.product_ranges.get_ranges") as get_rng:
+        get_rng.return_value = mock_range
+        lyr.make_ready(minimal_dc)
     assert lyr.ready
+    assert not lyr.hide
     assert "a_layer" in str(lyr)
 
 

--- a/tests/test_cfg_layer.py
+++ b/tests/test_cfg_layer.py
@@ -396,6 +396,19 @@ def test_flag_bad_prod(minimal_layer_cfg, minimal_global_cfg, minimal_dc):
     assert "a_layer" in str(excinfo.value)
 
 
+def test_flag_bad_lrprod(minimal_layer_cfg, minimal_global_cfg, minimal_dc):
+    minimal_layer_cfg["flags"] = {
+        "product": "foo",
+        "low_res_product": "foolookupfail",
+        "band": "band1"
+    }
+    lyr = parse_ows_layer(minimal_layer_cfg, global_cfg=minimal_global_cfg)
+    with pytest.raises(ConfigException) as excinfo:
+        lyr.make_ready(dc=minimal_dc)
+    assert "foolookupfail" in str(excinfo.value)
+    assert "a_layer" in str(excinfo.value)
+
+
 def test_flag_info_mask(minimal_layer_cfg, minimal_global_cfg, minimal_dc):
     minimal_layer_cfg["flags"] = {
         "product": "foo",

--- a/tests/test_cfg_wcs.py
+++ b/tests/test_cfg_wcs.py
@@ -1,0 +1,44 @@
+import pytest
+from unittest.mock import MagicMock, patch
+
+from datacube_ows.ogc_utils import ConfigException
+from datacube_ows.ows_configuration import OWSLayer, OWSFolder, parse_ows_layer
+
+
+def test_native_crs_mismatch(minimal_global_cfg, minimal_layer_cfg, minimal_dc):
+    minimal_global_cfg.wcs = True
+    minimal_layer_cfg["wcs"] = {
+        "native_crs": "EPSG:1234",
+        "default_bands": ["band1", "band2", "band3"],
+    }
+    minimal_layer_cfg["product_name"] = "foo_nativecrs"
+    lyr = parse_ows_layer(minimal_layer_cfg,
+                          global_cfg=minimal_global_cfg)
+    lyr.extract_bboxes = MagicMock()
+    lyr.extract_bboxes.return_value = {
+        "EPSG": {
+            "top": 1,
+            "bottom": -1,
+            "left": -1,
+            "right": 1,
+        }
+    }
+    lyr.make_ready(minimal_dc)
+    assert lyr.native_CRS == "EPSG:4326"
+
+
+def test_native_crs_none(minimal_global_cfg, minimal_layer_cfg, minimal_dc, mock_range):
+    minimal_global_cfg.wcs = True
+    minimal_layer_cfg["wcs"] = {
+        "default_bands": ["band1", "band2"]
+    }
+    minimal_layer_cfg["product_name"] = "foo_nonativecrs"
+    lyr = parse_ows_layer(minimal_layer_cfg,
+                          global_cfg=minimal_global_cfg)
+    with patch("datacube_ows.product_ranges.get_ranges") as get_rng:
+        get_rng.return_value = mock_range
+        with pytest.raises(ConfigException) as excinfo:
+            lyr.make_ready(minimal_dc)
+    assert "a_layer" in str(excinfo.value)
+    assert "No native CRS" in str(excinfo.value)
+

--- a/tests/test_cfg_wcs.py
+++ b/tests/test_cfg_wcs.py
@@ -42,3 +42,26 @@ def test_native_crs_none(minimal_global_cfg, minimal_layer_cfg, minimal_dc, mock
     assert "a_layer" in str(excinfo.value)
     assert "No native CRS" in str(excinfo.value)
 
+
+def test_native_crs_unpublished(minimal_global_cfg, minimal_layer_cfg, minimal_dc):
+    minimal_global_cfg.wcs = True
+    minimal_layer_cfg["wcs"] = {
+        "default_bands": ["band1", "band2", "band3"],
+    }
+    minimal_layer_cfg["product_name"] = "foo_badnativecrs"
+    lyr = parse_ows_layer(minimal_layer_cfg,
+                          global_cfg=minimal_global_cfg)
+    lyr.extract_bboxes = MagicMock()
+    lyr.extract_bboxes.return_value = {
+        "EPSG": {
+            "top": 1,
+            "bottom": -1,
+            "left": -1,
+            "right": 1,
+        }
+    }
+    with pytest.raises(ConfigException) as excinfo:
+        lyr.make_ready(minimal_dc)
+    assert "EPSG:9999" in str(excinfo.value)
+    assert "a_layer" in str(excinfo.value)
+    assert "not in published CRSs" in str(excinfo.value)

--- a/tests/test_cfg_wcs.py
+++ b/tests/test_cfg_wcs.py
@@ -65,3 +65,21 @@ def test_native_crs_unpublished(minimal_global_cfg, minimal_layer_cfg, minimal_d
     assert "EPSG:9999" in str(excinfo.value)
     assert "a_layer" in str(excinfo.value)
     assert "not in published CRSs" in str(excinfo.value)
+
+
+def test_no_native_resolution(minimal_global_cfg, minimal_layer_cfg, minimal_dc, mock_range):
+    minimal_global_cfg.wcs = True
+    minimal_layer_cfg["wcs"] = {
+        "native_crs": "EPSG:4326",
+        "default_bands": ["band1", "band2", "band3"],
+    }
+    minimal_layer_cfg["product_name"] = "foo_nonativeres"
+    lyr = parse_ows_layer(minimal_layer_cfg,
+                          global_cfg=minimal_global_cfg)
+    with patch("datacube_ows.product_ranges.get_ranges") as get_rng:
+        get_rng.return_value = mock_range
+        with pytest.raises(ConfigException) as excinfo:
+            lyr.make_ready(minimal_dc)
+    assert "a_layer" in str(excinfo.value)
+    assert "No native resolution" in str(excinfo.value)
+


### PR DESCRIPTION
Several old apparently passing tests were actually failing silently.

WCS grids for layers with a native CRS with "vertical coordinate first" (e.g. EPSG:4326) were being coordinate mangled - bug fix.

Haven't quite finished with this chunk of testing work, but I'm finalising the PR because of the major bug fix above.