### PR TITLE
Complete config tests

### DIFF
--- a/datacube_ows/ows_configuration.py
+++ b/datacube_ows/ows_configuration.py
@@ -883,7 +883,7 @@ class OWSConfig(OWSConfigEntry):
                     "Missing required config entry in 'global' section: %s" % str(e)
                 )
 
-            if self.wms:
+            if self.wms or self.wmts:
                 self.parse_wms(cfg.get("wms", {}))
             else:
                 self.parse_wms({})

--- a/datacube_ows/ows_configuration.py
+++ b/datacube_ows/ows_configuration.py
@@ -890,7 +890,7 @@ class OWSConfig(OWSConfigEntry):
 
             if self.wcs:
                 try:
-                    self.parse_wcs(cfg["wcs"])
+                    self.parse_wcs(cfg.get("wcs"))
                 except KeyError as e:
                     raise ConfigException(
                         "Missing required config entry in 'wcs' section (with WCS enabled): %s" % str(e)
@@ -962,11 +962,11 @@ class OWSConfig(OWSConfigEntry):
             self.published_CRSs[crs_str] = self.internal_CRSs[crs_str]
             if self.published_CRSs[crs_str]["geographic"]:
                 if self.published_CRSs[crs_str]["horizontal_coord"] != "longitude":
-                    raise Exception("Published CRS {} is geographic"
-                                    "but has a horizontal coordinate that is not 'longitude'".format(crs_str))
+                    raise ConfigException(f"Published CRS {crs_str} is geographic"
+                                    "but has a horizontal coordinate that is not 'longitude'")
                 if self.published_CRSs[crs_str]["vertical_coord"] != "latitude":
-                    raise Exception("Published CRS {} is geographic"
-                                    "but has a vertical coordinate that is not 'latitude'".format(crs_str))
+                    raise ConfigException(f"Published CRS {crs_str} is geographic"
+                                    "but has a vertical coordinate that is not 'latitude'")
         for alias, alias_def in CRS_aliases.items():
             target_crs = alias_def["alias"]
             if target_crs not in self.published_CRSs:
@@ -1007,7 +1007,7 @@ class OWSConfig(OWSConfigEntry):
 
             self.native_wcs_format = cfg["native_format"]
             if self.native_wcs_format not in self.wcs_formats_by_name:
-                raise Exception("Configured native WCS format not a supported format.")
+                raise ConfigException(f"Configured native WCS format ({self.native_wcs_format}) not a supported format.")
         else:
             self.default_geographic_CRS = None
             self.default_geographic_CRS_def = None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -217,3 +217,54 @@ def mock_range():
             "EPSG:3857": {"top": 0.1, "bottom": -0.1, "left": -0.1, "right": 0.1,},
         }
     }
+
+
+@pytest.fixture
+def minimal_global_raw_cfg():
+    return {
+        "global": {
+            "title": "Test Title",
+            "info_url": "https://my.domain.com/about_us",
+            "allowed_urls": [
+                "http://localhost",
+                "http://unsecure.domain.com/odc",
+                "https://secure.domain.com/ows",
+            ],
+            "published_CRSs": {
+                "EPSG:3857": {  # Web Mercator
+                     "geographic": False,
+                     "horizontal_coord": "x",
+                     "vertical_coord": "y",
+                },
+                "EPSG:4326": {  # WGS-84
+                    "geographic": True,
+                    "vertical_coord_first": True
+                },
+            },
+        },
+        "layers": []
+    }
+
+@pytest.fixture
+def wcs_global_cfg():
+    return {
+        "formats": {
+            # Key is the format name, as used in DescribeCoverage XML
+            "GeoTIFF": {
+                "renderer": "datacube_ows.wcs_utils.get_tiff",
+                # The MIME type of the image, as used in the Http Response.
+                "mime": "image/geotiff",
+                # The file extension to add to the filename.
+                "extension": "tif",
+                # Whether or not the file format supports multiple time slices.
+                "multi-time": False
+            },
+            "netCDF": {
+                "renderer": "datacube_ows.wcs_utils.get_netcdf",
+                "mime": "application/x-netcdf",
+                "extension": "nc",
+                "multi-time": True,
+            }
+        },
+        "native_format": "GeoTIFF",
+    }

--- a/tests/test_cfg_global.py
+++ b/tests/test_cfg_global.py
@@ -51,6 +51,7 @@ def test_wcs_no_native_format(minimal_global_raw_cfg, wcs_global_cfg):
     assert "wcs" in str(excinfo.value)
 
 def test_no_services(minimal_global_raw_cfg):
+    OWSConfig._instance = None
     minimal_global_raw_cfg["global"]["services"] = {
         "wms": False,
         "wmts": False,

--- a/tests/test_cfg_global.py
+++ b/tests/test_cfg_global.py
@@ -1,0 +1,60 @@
+import pytest
+from unittest.mock import MagicMock, patch
+from datacube_ows.ogc_utils import ConfigException
+from datacube_ows.ows_configuration import OWSConfig
+
+
+def test_minimal_global(minimal_global_raw_cfg, minimal_dc):
+    OWSConfig._instance = None
+    cfg = OWSConfig(cfg=minimal_global_raw_cfg)
+    cfg.make_ready(minimal_dc)
+    assert cfg.ready
+
+
+def test_global_no_title(minimal_global_raw_cfg):
+    OWSConfig._instance = None
+    del minimal_global_raw_cfg["global"]["title"]
+    with pytest.raises(ConfigException) as excinfo:
+        cfg = OWSConfig(cfg=minimal_global_raw_cfg)
+    assert "title" in str(excinfo.value)
+    assert "Missing required config entry" in str(excinfo.value)
+    assert "global" in str(excinfo.value)
+
+def test_wcs_only(minimal_global_raw_cfg, wcs_global_cfg, minimal_dc):
+    OWSConfig._instance = None
+    minimal_global_raw_cfg["global"]["services"] = {
+        "wcs": True,
+        "wms": False,
+        "wmts": False,
+    }
+    minimal_global_raw_cfg["wcs"] = wcs_global_cfg
+    cfg = OWSConfig(cfg=minimal_global_raw_cfg)
+    cfg.make_ready(minimal_dc)
+    assert cfg.ready
+    assert cfg.wcs
+    assert not cfg.wms
+    assert not cfg.wmts
+
+def test_wcs_no_native_format(minimal_global_raw_cfg, wcs_global_cfg):
+    OWSConfig._instance = None
+    minimal_global_raw_cfg["global"]["services"] = {
+        "wcs": True,
+        "wms": False,
+        "wmts": False,
+    }
+    del wcs_global_cfg["native_format"]
+    minimal_global_raw_cfg["wcs"] = wcs_global_cfg
+    with pytest.raises(ConfigException) as excinfo:
+        cfg = OWSConfig(cfg=minimal_global_raw_cfg)
+    assert "native_format" in str(excinfo.value)
+    assert "Missing required config entry" in str(excinfo.value)
+    assert "wcs" in str(excinfo.value)
+
+def test_no_services(minimal_global_raw_cfg):
+    minimal_global_raw_cfg["global"]["services"] = {
+        "wms": False,
+        "wmts": False,
+    }
+    with pytest.raises(ConfigException) as excinfo:
+        cfg = OWSConfig(cfg=minimal_global_raw_cfg)
+    assert "At least one service must be active" in str(excinfo.value)

--- a/tests/test_cfg_global.py
+++ b/tests/test_cfg_global.py
@@ -59,3 +59,74 @@ def test_no_services(minimal_global_raw_cfg):
     with pytest.raises(ConfigException) as excinfo:
         cfg = OWSConfig(cfg=minimal_global_raw_cfg)
     assert "At least one service must be active" in str(excinfo.value)
+
+
+def test_bad_geographic_crs(minimal_global_raw_cfg):
+    OWSConfig._instance = None
+    minimal_global_raw_cfg["global"]["published_CRSs"]["EPSG:7777"] = {
+        "geographic": True,
+        "horizontal_coord": "x"
+    }
+    with pytest.raises(ConfigException) as excinfo:
+        cfg = OWSConfig(cfg=minimal_global_raw_cfg)
+    assert "is geographic" in str(excinfo.value)
+    assert "EPSG:7777" in str(excinfo.value)
+    assert "horizontal" in str(excinfo.value)
+    assert "longitude" in str(excinfo.value)
+    OWSConfig._instance = None
+    minimal_global_raw_cfg["global"]["published_CRSs"]["EPSG:7777"] = {
+        "geographic": True,
+        "vertical_coord": "y"
+    }
+    with pytest.raises(ConfigException) as excinfo:
+        cfg = OWSConfig(cfg=minimal_global_raw_cfg)
+    assert "is geographic" in str(excinfo.value)
+    assert "EPSG:7777" in str(excinfo.value)
+    assert "latitude" in str(excinfo.value)
+    assert "vertical" in str(excinfo.value)
+
+
+def test_bad_crs_alias(minimal_global_raw_cfg):
+    OWSConfig._instance = None
+    minimal_global_raw_cfg["global"]["published_CRSs"]["EPSG:7777"] = {
+        "alias": "EPSG:6666",
+    }
+    cfg = OWSConfig(cfg=minimal_global_raw_cfg)
+    assert "EPSG:7777" not in cfg.published_CRSs
+
+def test_no_wcs(minimal_global_raw_cfg):
+    OWSConfig._instance = None
+    minimal_global_raw_cfg["global"]["services"] = {"wcs": True}
+    with pytest.raises(ConfigException) as excinfo:
+        cfg = OWSConfig(cfg=minimal_global_raw_cfg)
+    assert "WCS section missing" in str(excinfo.value)
+    assert "WCS is enabled" in str(excinfo.value)
+
+def test_no_wcs_formats(minimal_global_raw_cfg):
+    OWSConfig._instance = None
+    minimal_global_raw_cfg["global"]["services"] = {"wcs": True}
+    minimal_global_raw_cfg["wcs"] = {
+        "formats": {}
+    }
+    with pytest.raises(ConfigException) as excinfo:
+        cfg = OWSConfig(cfg=minimal_global_raw_cfg)
+    assert "Must configure at least one wcs format" in str(excinfo.value)
+
+def test_bad_wcs_format(minimal_global_raw_cfg, wcs_global_cfg):
+    OWSConfig._instance = None
+    minimal_global_raw_cfg["global"]["services"] = {"wcs": True}
+    minimal_global_raw_cfg["wcs"] = wcs_global_cfg
+    minimal_global_raw_cfg["wcs"]["native_format"] = "jpeg2000"
+    with pytest.raises(ConfigException) as excinfo:
+        cfg = OWSConfig(cfg=minimal_global_raw_cfg)
+    assert "Configured native WCS format" in str(excinfo.value)
+    assert "jpeg2000" in str(excinfo.value)
+    assert "not a supported format" in str(excinfo.value)
+
+def test_crs_lookup_fail(minimal_global_raw_cfg,minimal_dc):
+    OWSConfig._instance = None
+    cfg = OWSConfig(cfg=minimal_global_raw_cfg)
+    with pytest.raises(ConfigException) as excinfo:
+        crs = cfg.crs("EPSG:111")
+    assert "EPSG:111" in str(excinfo.value)
+    assert "is not published" in str(excinfo.value)

--- a/tests/test_cfg_wcs.py
+++ b/tests/test_cfg_wcs.py
@@ -3,7 +3,7 @@ import pytest
 from unittest.mock import MagicMock, patch
 
 from datacube_ows.ogc_utils import ConfigException
-from datacube_ows.ows_configuration import OWSLayer, OWSFolder, parse_ows_layer
+from datacube_ows.ows_configuration import OWSLayer, OWSFolder, parse_ows_layer, WCSFormat
 
 
 def test_native_crs_mismatch(minimal_global_cfg, minimal_layer_cfg, minimal_dc):
@@ -174,3 +174,18 @@ def test_zero_grid(minimal_global_cfg, minimal_layer_cfg, minimal_dc, mock_range
     assert "Grid High x is zero" in str(excinfo.value)
     assert "a_layer" in str(excinfo.value)
     assert "EPSG:4326" in str(excinfo.value)
+
+
+def test_wcs_renderer_detection():
+    fmt = WCSFormat(
+        "GeoTIFF",
+        "image/geotiff",
+        "tif",
+        {
+            "1": "datacube_ows.wcs1_utils.get_tiff",
+            "2": "datacube_ows.wcs2_utils.get_tiff",
+        },
+        False
+    )
+    r = fmt.renderer("2.1.0")
+    assert r == fmt.renderers[2]

--- a/tests/test_cfg_wcs.py
+++ b/tests/test_cfg_wcs.py
@@ -3,7 +3,7 @@ import pytest
 from unittest.mock import MagicMock, patch
 
 from datacube_ows.ogc_utils import ConfigException
-from datacube_ows.ows_configuration import OWSLayer, OWSFolder, parse_ows_layer, WCSFormat
+from datacube_ows.ows_configuration import parse_ows_layer, WCSFormat
 
 
 def test_native_crs_mismatch(minimal_global_cfg, minimal_layer_cfg, minimal_dc):


### PR DESCRIPTION
Opening in draft to track coverage.