### PR TITLE
Progressive cache control

### DIFF
--- a/datacube_ows/data.py
+++ b/datacube_ows/data.py
@@ -323,13 +323,16 @@ def get_map(args):
     if params.ows_stats:
         return json_response(qprof.profile())
     else:
-        return png_response(body)
+        return png_response(body, extra_headers=params.product.wms_cache_rules.cache_headers(n_datasets))
 
 
-def png_response(body, cfg=None):
+def png_response(body, cfg=None, extra_headers={}):
     if not cfg:
         cfg = get_config()
-    return body, 200, cfg.response_headers({"Content-Type": "image/png"})
+    headers = {"Content-Type": "image/png"}
+    headers.update(extra_headers)
+    headers = cfg.response_headers(headers)
+    return body, 200, cfg.response_headers(headers)
 
 
 @log_call

--- a/datacube_ows/data.py
+++ b/datacube_ows/data.py
@@ -326,9 +326,11 @@ def get_map(args):
         return png_response(body, extra_headers=params.product.wms_cache_rules.cache_headers(n_datasets))
 
 
-def png_response(body, cfg=None, extra_headers={}):
+def png_response(body, cfg=None, extra_headers=None):
     if not cfg:
         cfg = get_config()
+    if extra_headers is None:
+        extra_headers = {}
     headers = {"Content-Type": "image/png"}
     headers.update(extra_headers)
     headers = cfg.response_headers(headers)

--- a/datacube_ows/ows_cfg_example.py
+++ b/datacube_ows/ows_cfg_example.py
@@ -1203,12 +1203,12 @@ standard_resource_limits = {
                 # less than the min_datasets of the next rule (4-7 in this example)
                 "min_datasets": 4, # Must be greater than zero.  Blank tiles (0 datasets) are NEVER cached
                 # The cache-control max-age for this rule, in seconds.
-                "max-age": 86400,  # 86400 seconds = 24 hours
+                "max_age": 86400,  # 86400 seconds = 24 hours
             },
             {
                 # Rules must be sorted in ascending order of min_datasets values.
                 "min_datasets": 8,
-                "max-age": 604800,  # 604800 seconds = 1 week
+                "max_age": 604800,  # 604800 seconds = 1 week
             },
             # If a resource limit is exceeded, no-cache applies.
             # Summarising the cache-control results for this example:

--- a/datacube_ows/ows_configuration.py
+++ b/datacube_ows/ows_configuration.py
@@ -278,12 +278,13 @@ class CacheControlRules(OWSConfigEntry):
     def cache_headers(self, n_datasets):
         if not self.use_caching:
             return {}
+        assert n_datasets >= 0
         if n_datasets == 0 or n_datasets > self.max_datasets:
             return {"cache-control": "no-cache"}
         rule = None
         for r in self.rules:
             if n_datasets < r["min_datasets"]:
-                return rule
+                break
             rule = r
         if rule:
             return {"cache-control": f"max-age={rule['max_age']}"}

--- a/datacube_ows/ows_configuration.py
+++ b/datacube_ows/ows_configuration.py
@@ -241,6 +241,56 @@ class OWSFolder(OWSLayer):
         super().make_ready(dc, *args, **kwargs)
 
 
+class CacheControlRules(OWSConfigEntry):
+    def __init__(self, cfg, layer_cfg, max_datasets):
+        super().__init__(cfg)
+        self.rules = cfg
+        self.use_caching = self.rules is not None
+        self.max_datasets = max_datasets
+        if not self.use_caching:
+            return
+        min_so_far = 0
+        max_max_age_so_far = 0
+        for rule in self.rules:
+            if "min_datasets" not in rule:
+                raise ConfigException(f"Dataset cache rule does not contain a 'min_datasets' element in layer {layer_cfg.name}")
+            if "max_age" not in rule:
+                raise ConfigException(f"Dataset cache rule does not contain a 'max_age' element in layer {layer_cfg.name}")
+            min_datasets = rule["min_datasets"]
+            max_age = rule["max_age"]
+            if not isinstance(min_datasets, int):
+                raise ConfigException(f"Dataset cache rule has non-integer 'min_datasets' element in layer {layer_cfg.name}")
+            if not isinstance(max_age, int):
+                raise ConfigException(f"Dataset cache rule has non-integer 'max_age' element in layer {layer_cfg.name}")
+            if min_datasets <= 0:
+                raise ConfigException(f"Invalid dataset cache rule in layer {layer_cfg.name}: min_datasets must be greater than zero.")
+            if min_datasets <= min_so_far:
+                raise ConfigException(f"Dataset cache rules must be sorted by ascending min_datasets values.  In layer {layer_cfg.name}.")
+            if max_datasets > 0 and min_datasets > max_datasets:
+                raise ConfigException(f"Dataset cache rule min_datasets value exceeds the max_datasets limit in layer {layer_cfg.name}.")
+            min_so_far = min_datasets
+            if max_age <= 0:
+                raise ConfigException(f"Dataset cache rule max_age value must be greater than zero in layer {layer_cfg.name}.")
+            if max_age <= max_max_age_so_far:
+                raise ConfigException(f"max_age values in dataset cache rules must increase monotonically in layer {layer_cfg.name}.")
+            max_max_age_so_far = max_age
+
+    def cache_headers(self, n_datasets):
+        if not self.use_caching:
+            return {}
+        if n_datasets == 0 or n_datasets > self.max_datasets:
+            return {"cache-control": "no-cache"}
+        rule = None
+        for r in self.rules:
+            if n_datasets < r["min_datasets"]:
+                return rule
+            rule = r
+        if rule:
+            return {"cache-control": f"max-age={rule['max_age']}"}
+        else:
+            return {"cache-control": "no-cache"}
+
+
 TIMERES_RAW = "raw"
 TIMERES_MON = "month"
 TIMERES_YR  = "year"
@@ -367,6 +417,8 @@ class OWSNamedLayer(OWSExtensibleConfigEntry, OWSLayer):
         self.min_zoom = wms_cfg.get("min_zoom_factor", 300.0)
         self.max_datasets_wms = wms_cfg.get("max_datasets", 0)
         self.max_datasets_wcs = wcs_cfg.get("max_datasets", 0)
+        self.wms_cache_rules = CacheControlRules(wms_cfg.get("dataset_cache_rules"), self, self.max_datasets_wms)
+        self.wcs_cache_rules = CacheControlRules(wcs_cfg.get("dataset_cache_rules"), self, self.max_datasets_wcs)
 
     # pylint: disable=attribute-defined-outside-init
     def parse_image_processing(self, cfg):

--- a/datacube_ows/wcs1.py
+++ b/datacube_ows/wcs1.py
@@ -113,7 +113,12 @@ def get_coverage(args):
         raise WCS1Exception("Multi-time requests are not currently supported for WCS1",
                             WCS1Exception.INVALID_PARAMETER_VALUE,
                             locator="Time parameter")
-    data = get_coverage_data(req)
+    n_datasets, data = get_coverage_data(req)
+    headers = {
+        "Content-Type": req.format.mime,
+        'content-disposition': 'attachment; filename=%s.%s' % (req.product_name, req.format.extension)
+    }
+    headers.update(req.product.wcs_cache_rules.cache_headers(n_datasets))
     return (
         req.format.renderer(req.version)(req, data),
         200,

--- a/datacube_ows/wcs1_utils.py
+++ b/datacube_ows/wcs1_utils.py
@@ -350,7 +350,7 @@ def get_coverage_data(req):
                               req.times,
                               bands=req.bands)
         output = stacker.data(datasets, skip_corrections=True)
-        return output
+        return n_datasets, output
 
 
 def get_tiff(req, data):

--- a/datacube_ows/wcs1_utils.py
+++ b/datacube_ows/wcs1_utils.py
@@ -338,7 +338,7 @@ def get_coverage_data(req):
                 }
             ).astype("int16")
 
-            return data
+            return n_datasets, data
 
         if req.product.max_datasets_wcs > 0 and n_datasets > req.product.max_datasets_wcs:
             raise WCS1Exception("This request processes too much data to be served in a reasonable amount of time."

--- a/datacube_ows/wcs2.py
+++ b/datacube_ows/wcs2.py
@@ -277,12 +277,9 @@ _LOG = logging.getLogger(__name__)
 def get_coverage(args):
     request_obj = kvp_decode_get_coverage(args)
 
-    output, mime, filename = get_coverage_data(request_obj)
+    output, headers = get_coverage_data(request_obj)
     return (
         output,
         200,
-        resp_headers({
-            "Content-Type": mime,
-            'content-disposition': 'attachment; filename=%s' % filename
-        })
+        headers
     )

--- a/datacube_ows/wcs2_utils.py
+++ b/datacube_ows/wcs2_utils.py
@@ -279,8 +279,12 @@ def get_coverage_data(request):
     else:
         output = fmt.renderer(request.version)(request, output, output_crs)
 
-    filename = '%s.%s' % (request.coverage_id, fmt.extension)
-    return output, fmt.mime, filename
+    headers = {
+        "Content-Type": fmt.mime,
+        'content-disposition': f'attachment; filename={request.coverage_id}.{fmt.extension}',
+    }
+    headers.update(layer.wcs_cache_rules.cache_headers(n_datasets))
+    return output, headers
 
 
 def get_tiff(request, data, crs, product, width, height, affine):

--- a/docs/cfg_layers.rst
+++ b/docs/cfg_layers.rst
@@ -503,7 +503,7 @@ Note that this is different behaviour to not including a dataset_cache_rules ele
         "dataset_cache_rules": [
             {
                 "min_datasets": 4,
-                "max-age": 86400,  # 86400 seconds = 24 hours
+                "max_age": 86400,  # 86400 seconds = 24 hours
             },
         ]
     }
@@ -522,11 +522,11 @@ Cache-control header is returned according to the number of datasets hit:
         "dataset_cache_rules": [
             {
                 "min_datasets": 4,
-                "max-age": 86400,  # 86400 seconds = 24 hours
+                "max_age": 86400,  # 86400 seconds = 24 hours
             },
             {
                 "min_datasets": 8,
-                "max-age": 604800,  # 604800 seconds = 1 week
+                "max_age": 604800,  # 604800 seconds = 1 week
             },
         ]
     }

--- a/tests/test_cfg_cache_ctrl.py
+++ b/tests/test_cfg_cache_ctrl.py
@@ -1,0 +1,143 @@
+import pytest
+from unittest.mock import MagicMock, patch
+from datacube_ows.ogc_utils import ConfigException
+from datacube_ows.ows_configuration import CacheControlRules
+
+@pytest.fixture
+def ccr_min_layer():
+    lyr = MagicMock()
+    lyr.name = "a_layer"
+    return lyr
+
+
+def test_no_rules(ccr_min_layer):
+    ccr = CacheControlRules(None, ccr_min_layer, 0)
+    assert ccr.rules is None
+    assert not ccr.use_caching
+    assert ccr.cache_headers(0) == {}
+    assert ccr.cache_headers(2) == {}
+    assert ccr.cache_headers(10) == {}
+
+
+def test_never_cache(ccr_min_layer):
+    ccr = CacheControlRules([], ccr_min_layer, 8)
+    assert ccr.rules == []
+    assert ccr.use_caching
+    assert ccr.cache_headers(0) == {"cache-control": "no-cache"}
+    assert ccr.cache_headers(2) == {"cache-control": "no-cache"}
+    assert ccr.cache_headers(10) == {"cache-control": "no-cache"}
+
+
+def test_complex_case(ccr_min_layer):
+    ccr = CacheControlRules([
+        {"min_datasets": 3, "max_age": 10000},
+        {"min_datasets": 8, "max_age": 20000},
+    ], ccr_min_layer, 12)
+    assert ccr.use_caching
+    assert ccr.cache_headers(0) == {"cache-control": "no-cache"}
+    assert ccr.cache_headers(2) == {"cache-control": "no-cache"}
+    assert ccr.cache_headers(3) == {"cache-control": "max-age=10000"}
+    assert ccr.cache_headers(7) == {"cache-control": "max-age=10000"}
+    assert ccr.cache_headers(8) == {"cache-control": "max-age=20000"}
+    assert ccr.cache_headers(12) == {"cache-control": "max-age=20000"}
+    assert ccr.cache_headers(13) == {"cache-control": "no-cache"}
+
+
+def test_no_min_datasets_element(ccr_min_layer):
+    with pytest.raises(ConfigException) as e:
+        ccr = CacheControlRules([
+            {"max_age": 20000},
+        ], ccr_min_layer, 12)
+    assert "Dataset cache rule does not contain" in str(e.value)
+    assert "min_datasets" in str(e.value)
+    assert "a_layer" in str(e.value)
+
+
+def test_no_max_age_element(ccr_min_layer):
+    with pytest.raises(ConfigException) as e:
+        ccr = CacheControlRules([
+            {"min_datasets": 2},
+        ], ccr_min_layer, 12)
+    assert "Dataset cache rule does not contain" in str(e.value)
+    assert "max_age" in str(e.value)
+    assert "a_layer" in str(e.value)
+
+
+def test_nonint_min_ds(ccr_min_layer):
+    with pytest.raises(ConfigException) as e:
+        ccr = CacheControlRules([
+            {"min_datasets": "2", "max_age": 2000},
+        ], ccr_min_layer, 12)
+    assert "Dataset cache rule" in str(e.value)
+    assert "min_datasets" in str(e.value)
+    assert "non-integer" in str(e.value)
+    assert "a_layer" in str(e.value)
+
+
+def test_nonint_max_age(ccr_min_layer):
+    with pytest.raises(ConfigException) as e:
+        ccr = CacheControlRules([
+            {"min_datasets": 2, "max_age": 2000.5},
+        ], ccr_min_layer, 12)
+    assert "Dataset cache rule" in str(e.value)
+    assert "max_age" in str(e.value)
+    assert "non-integer" in str(e.value)
+    assert "a_layer" in str(e.value)
+
+
+def test_negative_min_datasets(ccr_min_layer):
+    with pytest.raises(ConfigException) as e:
+        ccr = CacheControlRules([
+            {"min_datasets": -2, "max_age": 2000},
+        ], ccr_min_layer, 12)
+    assert "Invalid dataset cache rule" in str(e.value)
+    assert "min_datasets" in str(e.value)
+    assert "must be greater than zero" in str(e.value)
+    assert "a_layer" in str(e.value)
+
+
+def test_unsorted_min_datasets(ccr_min_layer):
+    with pytest.raises(ConfigException) as e:
+        ccr = CacheControlRules([
+            {"min_datasets": 4, "max_age": 2000},
+            {"min_datasets": 2, "max_age": 4000},
+        ], ccr_min_layer, 12)
+    assert "Dataset cache rules must be sorted" in str(e.value)
+    assert "ascending" in str(e.value)
+    assert "min_datasets" in str(e.value)
+    assert "a_layer" in str(e.value)
+
+
+def test_min_datasets_max_datasets(ccr_min_layer):
+    with pytest.raises(ConfigException) as e:
+        ccr = CacheControlRules([
+            {"min_datasets": 2, "max_age": 2000},
+            {"min_datasets": 4, "max_age": 4000},
+        ], ccr_min_layer, 2)
+    assert "Dataset cache rule" in str(e.value)
+    assert "min_datasets" in str(e.value)
+    assert "exceeds the max_datasets limit" in str(e.value)
+    assert "a_layer" in str(e.value)
+
+
+def test_non_negative_max_age(ccr_min_layer):
+    with pytest.raises(ConfigException) as e:
+        ccr = CacheControlRules([
+            {"min_datasets": 2, "max_age": -2},
+        ], ccr_min_layer, 12)
+    assert "Dataset cache rule" in str(e.value)
+    assert "max_age" in str(e.value)
+    assert "must be greater than zero" in str(e.value)
+    assert "a_layer" in str(e.value)
+
+
+def test_unsorted_max_age(ccr_min_layer):
+    with pytest.raises(ConfigException) as e:
+        ccr = CacheControlRules([
+            {"min_datasets": 2, "max_age": 4000},
+            {"min_datasets": 4, "max_age": 2000},
+        ], ccr_min_layer, 12)
+    assert "dataset cache rules" in str(e.value)
+    assert "must increase monotonically" in str(e.value)
+    assert "max_age" in str(e.value)
+    assert "a_layer" in str(e.value)


### PR DESCRIPTION
New configuration entries supporting progressive cache control headers, prioritising expensive resource-intensive queries for caching.

See documentation changes for details.
