### PR TITLE
WMS BoundingBox uses "X" to mean "first coordinate"

### DIFF
--- a/datacube_ows/ows_configuration.py
+++ b/datacube_ows/ows_configuration.py
@@ -677,7 +677,8 @@ class OWSNamedLayer(OWSExtensibleConfigEntry, OWSLayer):
                     "right": bbox["right"],
                     "left": bbox["left"],
                     "top": bbox["top"],
-                    "bottom": bbox["bottom"]
+                    "bottom": bbox["bottom"],
+                    "vertical_coord_first": self.global_cfg.published_CRSs[crs_id]["vertical_coord_first"]
                 }
         return bboxes
 

--- a/datacube_ows/templates/wms_capabilities.xml
+++ b/datacube_ows/templates/wms_capabilities.xml
@@ -54,6 +54,18 @@
         </EX_GeographicBoundingBox>
         {% for crsid, bbox in lyr.bboxes.items() %}
             <BoundingBox CRS="{{ crsid }}"
+                 {% if bbox.vertical_coord_first %}
+                     {% if bbox.bottom < bbox.top %}
+                         minx="{{ bbox.bottom }}" maxx="{{ bbox.top }}"
+                     {% else %}
+                         minx="{{ bbox.top }}" maxx="{{ bbox.bottom }}"
+                     {% endif %}
+                     {% if bbox.left < bbox.right %}
+                         miny="{{ bbox.left }}" maxy="{{ bbox.right }}"
+                     {% else %}
+                         miny="{{ bbox.right }}" maxy="{{ bbox.left }}"
+                     {% endif %}
+                 {% else %}
                     {% if bbox.left < bbox.right %}
                          minx="{{ bbox.left }}" maxx="{{ bbox.right }}"
                     {% else %}
@@ -64,6 +76,7 @@
                     {% else %}
                          miny="{{ bbox.top }}" maxy="{{ bbox.bottom }}"
                     {% endif %}
+                {% endif %}
             />
         {% endfor %}
         {% if lyr_ranges.times|length > 1 %}

--- a/integration_tests/test_wms_server.py
+++ b/integration_tests/test_wms_server.py
@@ -60,6 +60,22 @@ def test_getcap(ows_server):
     assert gc_xds.validate(resp_xml)
 
 
+def test_getcap_coord_order(ows_server):
+    resp = request.urlopen(ows_server.url + "/wms?request=GetCapabilities&service=WMS&version=1.3.0", timeout=10)
+
+    # Confirm success
+    assert resp.code == 200
+
+    # Validate XML Schema
+    resp_xml = etree.parse(resp.fp)
+    root = resp_xml.getroot()
+    layers = root.findall(".//{http://www.opengis.net/wms}Layer[@queryable='1']")
+    for layer in layers:
+        wLong = layer.findall(".//{http://www.opengis.net/wms}westBoundLongitude")[0]
+        geo_bbox = layer.findall("./{http://www.opengis.net/wms}BoundingBox[@CRS='EPSG:4326']")[0]
+        assert wLong.text == geo_bbox.attrib["miny"]
+
+
 def test_wms_server(ows_server):
     # Use owslib to confirm that we have a somewhat compliant WMS service
     wms = WebMapService(url=ows_server.url+"/wms", version="1.3.0")


### PR DESCRIPTION
 so that bbox terminology bug I fixed recently was actually a feature.

Fixes #477 