### PR TITLE
Product products checks

### DIFF
--- a/datacube_ows/ows_configuration.py
+++ b/datacube_ows/ows_configuration.py
@@ -800,6 +800,10 @@ class OWSProductLayer(OWSNamedLayer):
             self.low_res_product_names = [self.low_res_product_name]
         else:
             self.low_res_product_names = []
+        if "product_names" in cfg:
+            raise ConfigException("'product_names' entry in non-multi-product layer - use 'product_name' only")
+        if "low_res_product_names":
+            raise ConfigException("'low_res_product_names' entry in non-multi-product layer - use 'low_res_product_name' only")
 
     def parse_pq_names(self, cfg):
         # pylint: disable=attribute-defined-outside-init
@@ -821,6 +825,10 @@ class OWSProductLayer(OWSNamedLayer):
             self.pq_low_res_names = [self.pq_low_res_name]
         else:
             self.pq_low_res_names = self.low_res_product_names
+        if "products" in cfg:
+            raise ConfigException("'products' entry in flags section of non-multi-product layer - use 'product' only")
+        if "low_res_products" in cfg:
+            raise ConfigException("'low_res_products' entry in flags section of non-multi-product layer - use 'low_res_product' only")
 
 
 class OWSMultiProductLayer(OWSNamedLayer):
@@ -834,6 +842,10 @@ class OWSMultiProductLayer(OWSNamedLayer):
             self.low_res_product_name = self.low_res_product_names[0]
         else:
             self.low_res_product_name = None
+        if "product_name" in cfg:
+            raise ConfigException("'product_name' entry in multi-product layer - use 'product_names' only")
+        if "low_res_product_name":
+            raise ConfigException("'low_res_product_name' entry in product layer - use 'low_res_product_names' only")
 
     def parse_pq_names(self, cfg):
         # pylint: disable=attribute-defined-outside-init
@@ -856,6 +868,10 @@ class OWSMultiProductLayer(OWSNamedLayer):
         else:
             self.pq_low_res_names = list(self.low_res_product_names)
             self.pq_low_res_name = self.low_res_product_name
+        if "product" in cfg:
+            raise ConfigException("'product' entry in flags section of multi-product layer - use 'products' only")
+        if "low_res_product" in cfg:
+            raise ConfigException("'low_res_product' entry in flags section of multi-product layer - use 'low_res_products' only")
 
 
 def parse_ows_layer(cfg, global_cfg, parent_layer=None):

--- a/datacube_ows/ows_configuration.py
+++ b/datacube_ows/ows_configuration.py
@@ -801,9 +801,9 @@ class OWSProductLayer(OWSNamedLayer):
         else:
             self.low_res_product_names = []
         if "product_names" in cfg:
-            raise ConfigException("'product_names' entry in non-multi-product layer - use 'product_name' only")
-        if "low_res_product_names":
-            raise ConfigException("'low_res_product_names' entry in non-multi-product layer - use 'low_res_product_name' only")
+            raise ConfigException(f"'product_names' entry in non-multi-product layer {self.name} - use 'product_name' only")
+        if "low_res_product_names" in cfg:
+            raise ConfigException(f"'low_res_product_names' entry in non-multi-product layer {self.name} - use 'low_res_product_name' only")
 
     def parse_pq_names(self, cfg):
         # pylint: disable=attribute-defined-outside-init
@@ -826,9 +826,9 @@ class OWSProductLayer(OWSNamedLayer):
         else:
             self.pq_low_res_names = self.low_res_product_names
         if "products" in cfg:
-            raise ConfigException("'products' entry in flags section of non-multi-product layer - use 'product' only")
+            raise ConfigException(f"'products' entry in flags section of non-multi-product layer {self.name} - use 'product' only")
         if "low_res_products" in cfg:
-            raise ConfigException("'low_res_products' entry in flags section of non-multi-product layer - use 'low_res_product' only")
+            raise ConfigException(f"'low_res_products' entry in flags section of non-multi-product layer {self.name}- use 'low_res_product' only")
 
 
 class OWSMultiProductLayer(OWSNamedLayer):
@@ -843,9 +843,9 @@ class OWSMultiProductLayer(OWSNamedLayer):
         else:
             self.low_res_product_name = None
         if "product_name" in cfg:
-            raise ConfigException("'product_name' entry in multi-product layer - use 'product_names' only")
-        if "low_res_product_name":
-            raise ConfigException("'low_res_product_name' entry in product layer - use 'low_res_product_names' only")
+            raise ConfigException(f"'product_name' entry in multi-product layer {self.name} - use 'product_names' only")
+        if "low_res_product_name" in cfg:
+            raise ConfigException(f"'low_res_product_name' entry in multi-product layer {self.name} - use 'low_res_product_names' only")
 
     def parse_pq_names(self, cfg):
         # pylint: disable=attribute-defined-outside-init
@@ -869,9 +869,9 @@ class OWSMultiProductLayer(OWSNamedLayer):
             self.pq_low_res_names = list(self.low_res_product_names)
             self.pq_low_res_name = self.low_res_product_name
         if "product" in cfg:
-            raise ConfigException("'product' entry in flags section of multi-product layer - use 'products' only")
+            raise ConfigException(f"'product' entry in flags section of multi-product layer {self.name} - use 'products' only")
         if "low_res_product" in cfg:
-            raise ConfigException("'low_res_product' entry in flags section of multi-product layer - use 'low_res_products' only")
+            raise ConfigException(f"'low_res_product' entry in flags section of multi-product layer {self.name} - use 'low_res_products' only")
 
 
 def parse_ows_layer(cfg, global_cfg, parent_layer=None):

--- a/tests/test_cfg_layer.py
+++ b/tests/test_cfg_layer.py
@@ -211,6 +211,82 @@ def test_bad_lowres_product_name(minimal_layer_cfg, minimal_global_cfg, minimal_
     assert "a_layer" in str(excinfo.value)
 
 
+def test_plural_in_nonmultiproduct(minimal_layer_cfg, minimal_global_cfg):
+    minimal_layer_cfg["low_res_product_names"] = "smolfoolookupfail"
+    with pytest.raises(ConfigException) as excinfo:
+        lyr = parse_ows_layer(minimal_layer_cfg,
+                              global_cfg=minimal_global_cfg)
+    assert "a_layer" in str(excinfo.value)
+    assert "'low_res_product_names' entry in non-multi-product layer" in str(excinfo.value)
+    assert "use 'low_res_product_name' only" in str(excinfo.value)
+    del minimal_layer_cfg["low_res_product_names"]
+    minimal_layer_cfg["product_names"] = ["foo", "bar"]
+    with pytest.raises(ConfigException) as excinfo:
+        lyr = parse_ows_layer(minimal_layer_cfg,
+                              global_cfg=minimal_global_cfg)
+    assert "a_layer" in str(excinfo.value)
+    assert "'product_names' entry in non-multi-product layer" in str(excinfo.value)
+    assert "use 'product_name' only" in str(excinfo.value)
+
+def test_flag_plural_in_nonmultiproduct(minimal_layer_cfg, minimal_global_cfg):
+    minimal_layer_cfg["flags"] = {
+        "band": "foo",
+        "products": ["prod1", "prod2"],
+    }
+    with pytest.raises(ConfigException) as excinfo:
+        lyr = parse_ows_layer(minimal_layer_cfg,
+                              global_cfg=minimal_global_cfg)
+    assert "a_layer" in str(excinfo.value)
+    assert "'products' entry in flags section of non-multi-product layer" in str(excinfo.value)
+    assert "use 'product' only" in str(excinfo.value)
+    del minimal_layer_cfg["flags"]["products"]
+    minimal_layer_cfg["flags"]["low_res_products"] = ["smolfoo", "smolbar"]
+    with pytest.raises(ConfigException) as excinfo:
+        lyr = parse_ows_layer(minimal_layer_cfg,
+                              global_cfg=minimal_global_cfg)
+    assert "'low_res_products' entry in flags section of non-multi-product layer" in str(excinfo.value)
+    assert "use 'low_res_product' only" in str(excinfo.value)
+    assert "a_layer" in str(excinfo.value)
+
+
+def test_singular_in_multiproduct(minimal_multiprod_cfg, minimal_global_cfg):
+    minimal_multiprod_cfg["low_res_product_name"] = "smolfoolookupfail"
+    with pytest.raises(ConfigException) as excinfo:
+        lyr = parse_ows_layer(minimal_multiprod_cfg,
+                              global_cfg=minimal_global_cfg)
+    assert "'low_res_product_name' entry in multi-product layer" in str(excinfo.value)
+    assert "use 'low_res_product_names' only" in str(excinfo.value)
+    assert "a_layer" in str(excinfo.value)
+    del minimal_multiprod_cfg["low_res_product_name"]
+    minimal_multiprod_cfg["product_name"] = "foo"
+    with pytest.raises(ConfigException) as excinfo:
+        lyr = parse_ows_layer(minimal_multiprod_cfg,
+                              global_cfg=minimal_global_cfg)
+    assert "'product_name' entry in multi-product layer" in str(excinfo.value)
+    assert "use 'product_names' only" in str(excinfo.value)
+    assert "a_layer" in str(excinfo.value)
+
+
+def test_flag_singular_in_multiproduct(minimal_multiprod_cfg, minimal_global_cfg):
+    minimal_multiprod_cfg["flags"] = {
+        "band": "foo",
+        "product": "goo",
+    }
+    with pytest.raises(ConfigException) as excinfo:
+        lyr = parse_ows_layer(minimal_multiprod_cfg,
+                          global_cfg=minimal_global_cfg)
+    assert "'product' entry in flags section of multi-product layer" in str(excinfo.value)
+    assert "use 'products' only" in str(excinfo.value)
+    assert "a_layer" in str(excinfo.value)
+    del minimal_multiprod_cfg["flags"]["product"]
+    minimal_multiprod_cfg["flags"]["low_res_product"] = "smolfoo"
+    with pytest.raises(ConfigException) as excinfo:
+        lyr = parse_ows_layer(minimal_multiprod_cfg,
+                              global_cfg=minimal_global_cfg)
+    assert "'low_res_product' entry in flags section of multi-product layer" in str(excinfo.value)
+    assert "use 'low_res_products' only" in str(excinfo.value)
+    assert "a_layer" in str(excinfo.value)
+
 def test_noprod_multiproduct(minimal_multiprod_cfg, minimal_global_cfg, minimal_dc):
     minimal_multiprod_cfg["product_names"] = []
     with pytest.raises(ConfigException) as excinfo:
@@ -244,7 +320,7 @@ def test_multi_product_lowres(minimal_multiprod_cfg, minimal_global_cfg, minimal
 
 def test_multi_product_pq(minimal_multiprod_cfg, minimal_global_cfg, minimal_dc):
     minimal_multiprod_cfg["flags"] = {
-        "product": ["flag_foo", "flag_bar"],
+        "products": ["flag_foo", "flag_bar"],
         "band": "band4",
     }
     lyr = parse_ows_layer(minimal_multiprod_cfg,


### PR DESCRIPTION
Various combinations of using single-product configs in a multi-product layer and vice versa were failing silently, leading to unhelpful error messages.  This should now be addressed.