### PR TITLE
Optionally display layer/style lists with cfg_parser.

### DIFF
--- a/datacube_ows/cfg_parser.py
+++ b/datacube_ows/cfg_parser.py
@@ -26,6 +26,10 @@ def main(version, parse_only, folders, styles, paths):
                )
         return 0
 
+    if parse_only and (folders or styles):
+        print("The --folders (-f) and --styles (-s) flags cannot be used in conjunction with the --parser-only (-p) flag.")
+        return 1
+
     if not paths:
         if parse_path(None, parse_only, folders, styles):
             return 0

--- a/datacube_ows/cfg_parser.py
+++ b/datacube_ows/cfg_parser.py
@@ -55,19 +55,38 @@ def parse_path(path, parse_only, folders, styles):
         print()
         print("Folder/Layer Hierarchy")
         print("======================")
-        print_layers(cfg.layers, depth=0)
+        print_layers(cfg.layers, styles, depth=0)
+        print()
+    elif styles:
+        print()
+        print("Layers and Styles")
+        print("=================")
+        for lyr in cfg.product_index.values():
+            print(lyr.name, f"[{','.join(lyr.product_names)}]")
+            print_styles(lyr)
         print()
 
-def print_layers(layers, depth):
+def print_layers(layers, styles, depth):
     for lyr in layers:
         if isinstance(lyr, OWSFolder):
             indent(depth)
             print("*", lyr.title)
-            print_layers(lyr.child_layers, depth+1)
+            print_layers(lyr.child_layers, styles, depth+1)
         else:
             indent(depth)
             print(lyr.name, f"[{','.join(lyr.product_names)}]")
+            if styles:
+                print_styles(lyr, depth)
 
-def indent(depth):
+
+def print_styles(lyr, depth=0):
+    for styl in lyr.styles:
+        indent(0, for_styles=True)
+        print(".", styl.name)
+
+
+def indent(depth, for_styles=False):
     for i in range(depth):
         print("  ", end="")
+    if for_styles:
+        print("      ", end="")

--- a/datacube_ows/cfg_parser.py
+++ b/datacube_ows/cfg_parser.py
@@ -31,18 +31,18 @@ def main(version, parse_only, folders, styles, paths):
         print("The --folders (-f) and --styles (-s) flags cannot be used in conjunction with the --parser-only (-p) flag.")
         sys.exit(1)
 
+    all_ok = True
     if not paths:
         if parse_path(None, parse_only, folders, styles):
             return 0
         else:
             sys.exit(1)
-    all_ok = True
     for path in paths:
         if not parse_path(path, parse_only, folders, styles):
             all_ok = False
 
 
-    if all_ok:
+    if not all_ok:
         sys.exit(1)
     return 0
 
@@ -55,6 +55,7 @@ def parse_path(path, parse_only, folders, styles):
                 cfg.make_ready(dc)
     except ConfigException as e:
         print("Config exception for path", str(e))
+        return False
     print("Configuration parsed OK")
     if folders:
         print()
@@ -70,6 +71,7 @@ def parse_path(path, parse_only, folders, styles):
             print(lyr.name, f"[{','.join(lyr.product_names)}]")
             print_styles(lyr)
         print()
+    return True
 
 def print_layers(layers, styles, depth):
     for lyr in layers:

--- a/datacube_ows/cfg_parser.py
+++ b/datacube_ows/cfg_parser.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import sys
 import click
 
 from datacube_ows import __version__
@@ -28,13 +29,13 @@ def main(version, parse_only, folders, styles, paths):
 
     if parse_only and (folders or styles):
         print("The --folders (-f) and --styles (-s) flags cannot be used in conjunction with the --parser-only (-p) flag.")
-        return 1
+        sys.exit(1)
 
     if not paths:
         if parse_path(None, parse_only, folders, styles):
             return 0
         else:
-            return 1
+            sys.exit(1)
     all_ok = True
     for path in paths:
         if not parse_path(path, parse_only, folders, styles):
@@ -42,7 +43,7 @@ def main(version, parse_only, folders, styles, paths):
 
 
     if all_ok:
-        return 1
+        sys.exit(1)
     return 0
 
 def parse_path(path, parse_only, folders, styles):

--- a/integration_tests/test_cfg_parser.py
+++ b/integration_tests/test_cfg_parser.py
@@ -10,6 +10,26 @@ def test_cfg_parser_parse_only(runner):
     result = runner.invoke(main, ["-p"])
     assert result.exit_code == 0
 
+def test_cfg_parser_parse_only(runner):
+    result = runner.invoke(main, ["-p"])
+    assert result.exit_code == 0
+
+def test_cfg_parser_folder_hierarchy(runner):
+    result = runner.invoke(main, ["-f"])
+    assert result.exit_code == 0
+
+def test_cfg_parser_styles(runner):
+    result = runner.invoke(main, ["-s"])
+    assert result.exit_code == 0
+
+def test_cfg_parser_folder_hierarchy_and_styles(runner):
+    result = runner.invoke(main, ["-f", "-s"])
+    assert result.exit_code == 0
+
+def test_cfg_parser_folders_parse_only(runner):
+    result = runner.invoke(main, ["-f", "-p"])
+    assert result.exit_code == 1
+
 
 def test_cfg_parser_version(runner):
     result = runner.invoke(main, ["--version"])


### PR DESCRIPTION
In response to #492

New behaviour:

`datacube-ows-cfg-parse -f`

Pretty-print the folder/layer hierarchy (without styles).

`datacube-ows-cfg-parse -s`

Pretty-print a list of named layers and their styles.  Does not include the folder hierarchy or non-named folder-layers.

`datacube-ows-cfg-parse -s -f`

Pretty-print the folder/layer hierarchy, with styles for each named layer.

Folder titles are printed with a prefixed "*".  Style names are printed with a prefixed ".".  Layer names are printed with no prefix, but with the ODC product names in brackets as a suffix.

`--styles` is equivalent to `-s` and `--folders` is equivalent to `-f`.  The `-s` and `-f` flags are NOT compatible with the `-p/--parse-only` flag.