### PR TITLE
Fixes for datacube AWS configuration

### DIFF
--- a/datacube_ows/startup_utils.py
+++ b/datacube_ows/startup_utils.py
@@ -73,18 +73,22 @@ def initialise_aws_credentials(log=None):
         unsigned = bool(env_nosign)
         if not unsigned or env_nosign.lower() in ("n", "f", "no", "false", "0"):
             unsigned = False
-            # set env variable to comply with gdal
-            os.environ["AWS_NO_SIGN_REQUEST"] = "NO"
+            # delete env variable
+            del os.environ["AWS_NO_SIGN_REQUEST"]
         else:
             # Workaround for rasterio bug
             os.environ["AWS_ACCESS_KEY_ID"] = "fake"
             os.environ["AWS_SECRET_ACCESS_KEY"] = "fake"
+        env_requester_pays = os.environ.get("AWS_REQUEST_PAYER", "")
+        requester_pays = False
+        if env_requester_pays.lower() == "requester":
+            requester_pays = True
         if log:
             if unsigned:
                 log.info("S3 access configured with unsigned requests")
             else:
                 log.info("S3 access configured with signed requests")
-        credentials = configure_s3_access(aws_unsigned=unsigned)
+        credentials = configure_s3_access(aws_unsigned=unsigned, requester_pays=requester_pays)
     elif log:
         log.warning("Environment variable $AWS_DEFAULT_REGION not set.  (This warning can be ignored if all data is stored locally.)")
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -14,6 +14,9 @@ services:
     network_mode: host
     environment:
       # Defaults are defined in .env file
+      AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
+      AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}
+      AWS_REQUEST_PAYER: ${AWS_REQUEST_PAYER}
       DB_HOSTNAME: ${DB_HOSTNAME}
       DB_PORT: ${DB_PORT}
       DB_USERNAME: ${DB_USERNAME}

--- a/docs/environment_variables.rst
+++ b/docs/environment_variables.rst
@@ -49,14 +49,18 @@ AWS_DEFAULT_REGION:
     S3 access by datacube_ows will be disabled unless this is set.
 
 AWS_NO_SIGN_REQUEST:
-    If this environment variable is set to a non-empty value then
-    S3 access will be unsigned.
+    S3 access will be unsigned if this environment variable is set
+    to a non-empty value other than "n", "f", "no", "false" or "0".
 
     N.B. Unsigned requests is the default behaviour - explicitly
     set ``$AWS_NO_SIGN_REQUEST`` to an empty string to sign requests
     (and set the ``$AWS_ACCESS_KEY_ID`` and
     ``$AWS_SECRET_ACCESS_KEY`` environment variables - refer to
     the boto3 documentation for more information).
+
+AWS_REQUEST_PAYER:
+    Set to "requester" if accessing requester-pays S3 buckets.
+    Default behaviour is to prevent access to requester-pays buckets.
 
 Configuring Flask
 -----------------

--- a/tests/test_startup.py
+++ b/tests/test_startup.py
@@ -3,6 +3,7 @@ import pytest
 from unittest.mock import patch
 import os
 
+
 def test_fake_creds(monkeypatch):
     from datacube_ows.startup_utils import initialise_aws_credentials
     monkeypatch.setenv("AWS_DEFAULT_REGION", "")
@@ -12,7 +13,7 @@ def test_fake_creds(monkeypatch):
     with patch("datacube_ows.startup_utils.configure_s3_access") as s3a:
         s3a.return_value = None
         initialise_aws_credentials()
-        assert os.getenv("AWS_NO_SIGN_REQUEST") == "NO"
+        assert os.getenv("AWS_NO_SIGN_REQUEST") is None
         monkeypatch.setenv("AWS_NO_SIGN_REQUEST", "indubitably")
         initialise_aws_credentials()
         assert os.getenv("AWS_ACCESS_KEY_ID") == "fake"
@@ -60,4 +61,3 @@ def test_supported_version():
     from datacube_ows.protocol_versions import supported_versions
     supported = supported_versions()
     assert supported["wms"].versions[0].service == "wms"
-


### PR DESCRIPTION
Pass AWS credentials from local environment variables to datacube-ows.
Check AWS_REQUEST_PAYER environment variable and call
datacube.utils.rio.configure_s3_access accordingly.
Delete AWS_NO_SIGN_REQUEST environment variable if set to "no". GDAL
seems to always use unsigned requests if this variable is present, even if
set to "no" or "".