### PR TITLE
Fix flag output in GetFeatureInfo

### DIFF
--- a/datacube_ows/data.py
+++ b/datacube_ows/data.py
@@ -597,7 +597,7 @@ def get_s3_browser_uris(datasets, pt=None, s3url="", s3bucket=""):
 
 
 @log_call
-def _make_band_dict(prod_cfg, pixel_dataset, band_list, flag_bands):
+def _make_band_dict(prod_cfg, pixel_dataset):
     band_dict = {}
     for k,v in pixel_dataset.data_vars.items():
         band_val = pixel_dataset[k].item()
@@ -608,15 +608,16 @@ def _make_band_dict(prod_cfg, pixel_dataset, band_list, flag_bands):
             except TypeError as te:
                 logging.warning('Working around for float bands')
                 flag_dict = mask_to_dict(flag_def, int(band_val))
-            try:
-                ret_val = [flag_def[flag]['description'] for flag, val in flag_dict.items() if val]
-            except KeyError:
-                # Weirdly formatted flag definition.  Hacky workaround for USGS data in DEAfrica demo.
-                ret_val = [val for flag, val in flag_dict.items() if val]
+            ret_val = {}
+            for flag, val in flag_dict.items():
+                if not val:
+                    continue
+                if val == True:
+                    ret_val[flag_def[flag]['description']] = True
+                else:
+                    ret_val[flag_def[flag]['description']] = val
             band_dict[k] = ret_val
         else:
-            if k in prod_cfg.ignore_info_flags:
-                continue
             try:
                 band_lbl = prod_cfg.band_idx.band_label(k)
                 if band_val == pixel_dataset[k].nodata or numpy.isnan(band_val):
@@ -735,8 +736,7 @@ def feature_info(args):
                 else:
                     date_info["time"] = ds.time.begin.strftime("%Y-%m-%d")
                 # Collect raw band values for pixel and derived bands from styles
-                date_info["bands"] = _make_band_dict(params.product, pixel_ds, stacker.needed_bands(),
-                                                     params.product.all_flag_band_names)
+                date_info["bands"] = _make_band_dict(params.product, pixel_ds)
                 derived_band_dict = _make_derived_band_dict(pixel_ds, params.product.style_index)
                 if derived_band_dict:
                     date_info["band_derived"] = derived_band_dict

--- a/datacube_ows/data.py
+++ b/datacube_ows/data.py
@@ -614,8 +614,9 @@ def _make_band_dict(prod_cfg, pixel_dataset, band_list, flag_bands):
                 # Weirdly formatted flag definition.  Hacky workaround for USGS data in DEAfrica demo.
                 ret_val = [val for flag, val in flag_dict.items() if val]
             band_dict[k] = ret_val
-            pass
         else:
+            if k in prod_cfg.ignore_info_flags:
+                continue
             try:
                 band_lbl = prod_cfg.band_idx.band_label(k)
                 if band_val == pixel_dataset[k].nodata or numpy.isnan(band_val):
@@ -624,36 +625,6 @@ def _make_band_dict(prod_cfg, pixel_dataset, band_list, flag_bands):
                     band_dict[band_lbl] = band_val
             except ConfigException:
                 pass
-    return band_dict
-    band_dict = {}
-    for band in band_list:
-        if band in flag_bands:
-            continue
-        try:
-            band_lbl = prod_cfg.band_idx.band_label(band)
-            band_val = pixel_dataset[band].item()
-            if band_val == pixel_dataset[band].nodata or numpy.isnan(band_val):
-                band_dict[band_lbl] = "n/a"
-            else:
-                band_dict[band_lbl] = band_val
-        except ConfigException:
-            pass
-    for band in flag_bands:
-        band_val = pixel_dataset[band].item()
-        flag_def = pixel_dataset[band].attrs['flags_definition']
-        # HACK: Work around bands with floating point values
-        try:
-            flag_dict = mask_to_dict(flag_def, band_val)
-        except TypeError as te:
-            logging.warning('Working around for float bands')
-            flag_dict = mask_to_dict(flag_def, int(band_val))
-        try:
-            ret_val = [flag_def[flag]['description'] for flag, val in flag_dict.items() if val]
-        except KeyError:
-            # Weirdly formatted flag definition.  Hacky workaround for USGS data in DEAfrica demo.
-            ret_val = [val for flag, val in flag_dict.items() if val]
-        band_dict[band] = ret_val
-
     return band_dict
 
 

--- a/datacube_ows/styles/base.py
+++ b/datacube_ows/styles/base.py
@@ -54,6 +54,7 @@ class StyleDefBase(OWSExtensibleConfigEntry):
         self.flag_products = FlagProductBands.build_list_from_masks(self.masks)
 
         self.raw_needed_bands = set()
+        self.raw_flag_bands = set()
         self.declare_unready("needed_bands")
         self.declare_unready("flag_bands")
 

--- a/docs/cfg_layers.rst
+++ b/docs/cfg_layers.rst
@@ -685,7 +685,6 @@ E.g.
             "product": "ls8_pq",
             "fuse_func": "datacube.helpers.ga_pq_fuser",
             "manual_merge": False,
-            "ignore_info_flags": ["noisy"],
             "ignore_time": False
         },
         {
@@ -693,7 +692,6 @@ E.g.
             "product": "ls8_coast_detection",
             "fuse_func": "datacube.helpers.ga_pq_fuser",
             "manual_merge": False,
-            "ignore_info_flags": ["uncertain"],
             "ignore_time": False
         }
     ]
@@ -795,14 +793,6 @@ the flag band is read from a separate product.
 
 If true, OWS assumes that flag product has no time dimension
 (i.e. the same flags apply to all times).
-
-Ignore Info Flags (ignore_info_flags)
-+++++++++++++++++++++++++++++++++++++
-
-An optional list of flags which should be excluded from
-GetFeatureInfo responses.  Defaults to an empty list, meaning
-all flags defined in the ODC metadata will be included
-in WMS and WMTS GetFeatureInfo responses.
 
 -----------------------
 Layer WCS Section (wcs)

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -152,16 +152,21 @@ def test_make_band_dict_nan(product_layer):
     class fake_data:
         def __init__(self):
             self.nodata = np.nan
+            self.attrs = {}
         def item(self):
             return np.nan
 
     class fake_dataset:
+        def __init__(self):
+            self.data_vars = {
+                "fake": "fake_band"
+            }
         def __getitem__(self, key):
             return fake_data()
 
     bands = ["fake"]
 
-    band_dict = datacube_ows.data._make_band_dict(product_layer, fake_dataset(), bands, set())
+    band_dict = datacube_ows.data._make_band_dict(product_layer, fake_dataset())
     assert band_dict["fake"] == "n/a"
 
 def test_make_band_dict_float(product_layer):
@@ -186,28 +191,33 @@ def test_make_band_dict_float(product_layer):
             return 100
 
     class int_dataset:
+        def __init__(self):
+            self.data_vars = {
+                "fake": "fake_band"
+            }
         def __getitem__(self, key):
             return int_data()
 
-    class float_data:
-        def __init__(self):
-            self.nodata = np.nan
-            self.attrs = yaml.load(flags_yaml, yaml.Loader)
+    class float_data(int_data):
         def item(self):
             return 100.0
 
-    class float_dataset:
+    class float_dataset(int_dataset):
         def __getitem__(self, key):
             return float_data()
 
     bands = ["fake"]
 
-    band_dict = datacube_ows.data._make_band_dict(product_layer, int_dataset(), bands, {"fake"})
-    assert isinstance(band_dict["fake"], list) 
-    assert band_dict["fake"] == ['Mask image as provided by JAXA - Ocean and water, lay over, shadowing, land.']
+    band_dict = datacube_ows.data._make_band_dict(product_layer, int_dataset())
+    assert isinstance(band_dict["fake"], dict)
+    assert band_dict["fake"] == {
+        "Mask image as provided by JAXA - Ocean and water, lay over, shadowing, land.": 'lay_over'
+    }
 
-    band_dict = datacube_ows.data._make_band_dict(product_layer, float_dataset(), bands, {"fake"})
-    assert isinstance(band_dict["fake"], list) 
-    assert band_dict["fake"] == ['Mask image as provided by JAXA - Ocean and water, lay over, shadowing, land.']
+    band_dict = datacube_ows.data._make_band_dict(product_layer, float_dataset())
+    assert isinstance(band_dict["fake"], dict)
+    assert band_dict["fake"] == {
+        "Mask image as provided by JAXA - Ocean and water, lay over, shadowing, land.": 'lay_over'
+    }
 
 


### PR DESCRIPTION
1. Display flag data as flag data for layers with colourmap styles. (bug fix)
2. Remove support for "ignore_info_flags" config element.  After multi-product masking it doesn't work and doesn't even really make sense.
3.  Improve GetFeatureInfo output for flag bands - now more informative and more consistent across metadata types.