### PR TITLE
Fix mask flag in value map

### DIFF
--- a/datacube_ows/styles/colormap.py
+++ b/datacube_ows/styles/colormap.py
@@ -47,14 +47,6 @@ class ValueMapRule(OWSConfigEntry):
         else:
             self.alpha = cfg.get("alpha", 1.0)
 
-    def label(self):
-        if self.title and self.abstract:
-            return f"{self.title} - {self.abstract}"
-        elif self.title:
-            return self.title
-        elif self.abstract:
-            return self.abstract
-
     def create_mask(self, data):
         if self.or_flags:
             mask = None

--- a/docs/cfg_colourmap_styles.rst
+++ b/docs/cfg_colourmap_styles.rst
@@ -68,8 +68,14 @@ match the rule.  The ``color`` entry is in html RGB hex format.
 The ``alpha`` and ``mask`` entries are optional and allow transparency.  ``alpha`` should
 be a floating point number between 0.0 (fully transparent) and 1.0 (fully opaque)
 and defaults to 1.0 (i.e. fully transparent).  The ``mask`` entry is boolean (default
-False).  Setting ``mask`` to true is functionally equivalent to setting ``alpha`` to
-0.0, but uses a more efficient implementation.
+False).  Setting ``mask`` to true is the same equivalent to setting ``alpha`` to
+0.0.  (A third option would be to use the standard style
+`pq_masks <https://datacube-ows.readthedocs.io/en/latest/cfg_styling.html#bit-flag-masks-pq-masks>`_.
+Bit-flag Masks (pq_masks)
+
+syntax.)
+
+to achieve the same effect
 
 ``color`` is still required when mask is True, but is not used in this case.
 

--- a/tests/test_styles.py
+++ b/tests/test_styles.py
@@ -466,33 +466,34 @@ def style_cfg_map_mask():
                     "color": "#FFFFFF",
                 },
                 {
-                    "title": "Non-Transparent",
-                    "abstract": "A Non-Transparent Value",
+                    "title": "Impossible",
+                    "abstract": "Will already have matched a previous rule",
                     "flags": {
                         "bar": 1,
                     },
-                    "color": "#111111",
+                    "color": "#54d56f",
                 }
             ]
         }
     }
     return cfg
 
-def test_RBGAMapped_Masking(product_layer_mask_map, style_cfg_map_mask):
+def test_RGBAMapped_Masking(product_layer_mask_map, style_cfg_map_mask):
     def fake_make_mask(data, **kwargs):
         val = kwargs["bar"]
         return data == val
 
 
+    dim = np.array([0, 1, 2, 3, 4, 5])
     band = np.array([0, 0, 1, 1, 2, 2])
     timarray = [np.datetime64(datetime.date.today())]
     times = DataArray(timarray, coords=[timarray], dims=["time"], name="time")
-    da = DataArray(band, name='foo')
+    da = DataArray(band, name='foo', coords={"dim": dim}, dims=["dim"])
     dst = Dataset(data_vars={'foo': da})
     ds = concat([dst], times)
 
     npmap = np.array([True, True, True, True, True, True])
-    damap = DataArray(npmap)
+    damap = DataArray(npmap, coords={"dim": dim}, dims=["dim"])
 
     with patch('datacube_ows.styles.colormap.make_mask', new_callable=lambda: fake_make_mask) as fmm:
         style_def = datacube_ows.styles.StyleDef(product_layer_mask_map, style_cfg_map_mask)
@@ -502,14 +503,14 @@ def test_RBGAMapped_Masking(product_layer_mask_map, style_cfg_map_mask):
         b = data["blue"]
         a = data["alpha"]
 
-        assert (r[2:3:1] == 0)
-        assert (g[2:3:1] == 0)
-        assert (b[2:3:1] == 0)
-        assert (a[2:3:1] == 0)
-        assert (r[4:5:1] == 255)
-        assert (g[4:5:1] == 255)
-        assert (b[4:5:1] == 255)
-        assert (a[4:5:1] == 255)
+        assert (r.values[2] == 17)
+        assert (g.values[2] == 17)
+        assert (b.values[2] == 17)
+        assert (a.values[2] == 0)
+        assert (r.values[4] == 255)
+        assert (g.values[4] == 255)
+        assert (b.values[4] == 255)
+        assert (a.values[4] == 255)
 
 
 def test_reint():


### PR DESCRIPTION
1. `"mask": True` in a colourmap style is now exactly equivalent to `"alpha": 0.0`.

2. Colour map legends now include only rules that have a (non-blank) title and abstract; AND have alpha != 0.

3. Colour map legends are now rendered in the *REVERSE* of the rule order.

4. Colour map legend labels now omit the dash if the rule only one of title and abstract is non-blank.

5. Titles are now required (but may be blank and need not be unique).  Abstracts are now optional.

6. General cleanup and refactor.