### PR TITLE
delta can now take a kwarg to choose subtraction direction.

### DIFF
--- a/datacube_ows/band_utils.py
+++ b/datacube_ows/band_utils.py
@@ -114,11 +114,14 @@ def sentinel2_ndci(data, b_red_edge, b_red, b_green, b_swir, band_mapper=None):
     return red_delta / red_sum.where(mndwi > 0.1)
 
 
-def multi_date_delta(data):
+def multi_date_delta(data, time_direction=-1):
     data1, data2 = (data.sel(time=dt) for dt in data.coords["time"].values)
 
 #    data1, data2 = data.values.item(0), data.values.item(1)
-    return data2 - data1
+    if time_direction >= 0:
+        return data1 - data2
+    else:
+        return data2 - data1
 
 
 @band_modulator

--- a/tests/test_band_utils.py
+++ b/tests/test_band_utils.py
@@ -104,6 +104,7 @@ def test_single_band(band_mapper):
 
 def test_multidate():
     assert not multi_date_delta(TEST_XARR_T) is None
+    assert not multi_date_delta(TEST_XARR_T, time_direction=1) is None
 
 
 def test_ndci():


### PR DESCRIPTION
Multi-date requests are currently not date-order-sensitive.

Can now flip the delta direction with the `time_direction` kwarg:
```
{
    "function": "datacube_ows.band_utils.multi_date_delta",
    "kwargs": {
           "time_direction": 1,    # Use >0 for earliest - latest, <0 for latest - earliest
                                            # default = -1
    }
```

Means you can at least have separate styles for forward and backwards subtractions.