### PR TITLE
Expression based ramp styles

### DIFF
--- a/datacube_ows/styles/expr.py
+++ b/datacube_ows/styles/expr.py
@@ -1,5 +1,6 @@
 import lark
 
+
 def formula_parser():
     return lark.Lark("""
                 ?expr: num_expr | bool_expr

--- a/datacube_ows/styles/expr.py
+++ b/datacube_ows/styles/expr.py
@@ -1,0 +1,142 @@
+import lark
+import numpy
+
+from datacube.utils.masking import valid_data_mask
+
+
+# N.B. Copied from datacube.virtual.expr
+# Remove this file and reference core directly after next ODC release.
+
+def formula_parser():
+    return lark.Lark("""
+                ?expr: num_expr | bool_expr
+
+                ?bool_expr: or_clause | comparison_clause
+
+                ?or_clause: or_clause "|" and_clause -> or_
+                          | or_clause "^" and_clause -> xor
+                          | and_clause
+                ?and_clause: and_clause "&" term -> and_
+                           | term
+                ?term: "not" term -> not_
+                     | "(" bool_expr ")"
+
+                ?comparison_clause: eq | ne | le | ge | lt | gt
+
+                eq: num_expr "==" num_expr
+                ne: num_expr "!=" num_expr
+                le: num_expr "<=" num_expr
+                ge: num_expr ">=" num_expr
+                lt: num_expr "<" num_expr
+                gt: num_expr ">" num_expr
+
+
+                ?num_expr: shift
+
+                ?shift: shift "<<" sum -> lshift
+                      | shift ">>" sum -> rshift
+                      | sum
+
+                ?sum: sum "+" product -> add
+                    | sum "-" product -> sub
+                    | product
+
+                ?product: product "*" atom -> mul
+                        | product "/" atom -> truediv
+                        | product "//" atom -> floordiv
+                        | product "%" atom -> mod
+                        | atom
+
+                ?atom: "-" subatom -> neg
+                     | "+" subatom -> pos
+                     | "~" subatom -> inv
+                     | subatom "**" atom -> pow
+                     | subatom
+
+                ?subatom: NAME -> var_name
+                        | FLOAT -> float_literal
+                        | INT -> int_literal
+                        | "(" num_expr ")"
+
+
+                %import common.FLOAT
+                %import common.INT
+                %import common.WS_INLINE
+                %import common.CNAME -> NAME
+
+                %ignore WS_INLINE
+                """, start='expr')
+
+
+@lark.v_args(inline=True)
+class FormulaEvaluator(lark.Transformer):
+    from operator import not_, or_, and_, xor
+    from operator import eq, ne, le, ge, lt, gt
+    from operator import add, sub, mul, truediv, floordiv, neg, pos, inv, mod, pow, lshift, rshift
+
+    float_literal = float
+    int_literal = int
+
+
+@lark.v_args(inline=True)
+class MaskEvaluator(lark.Transformer):
+    # the result of an expression is nodata whenever any of its subexpressions is nodata
+    from operator import or_
+
+    # pylint: disable=invalid-name
+    and_ = _xor = or_
+    eq = ne = le = ge = lt = gt = or_
+    add = sub = mul = truediv = floordiv = mod = pow = lshift = rshift = or_
+
+    def not_(self, value):
+        return value
+
+    neg = pos = inv = not_
+
+    @staticmethod
+    def float_literal(value):
+        return False
+
+    @staticmethod
+    def int_literal(value):
+        return False
+
+
+def evaluate_type(formula, env, parser, evaluator):
+    """
+    Evaluates the type of the output of a formula given a parser,
+    a corresponding evaluator class, and an environment.
+    The environment is a dict-like object (such as an `xarray.Dataset`) that maps variable names to values.
+    """
+    @lark.v_args(inline=True)
+    class TypeEvaluator(evaluator):
+        def var_name(self, key):
+            return numpy.array([], dtype=env[key.value].dtype)
+
+    return TypeEvaluator().transform(parser.parse(formula))
+
+def evaluate_data(formula, env, parser, evaluator):
+    """
+    Evaluates a formula given a parser, a corresponding evaluator class, and an environment.
+    The environment is a dict-like object (such as an `xarray.Dataset`) that maps variable names to values.
+    """
+    @lark.v_args(inline=True)
+    class DataEvaluator(evaluator):
+        def var_name(self, key):
+            return env[key.value]
+
+    return DataEvaluator().transform(parser.parse(formula))
+
+
+def evaluate_nodata_mask(formula, env, parser, evaluator):
+    """
+    Evaluates the nodata mask for a formula given a parser, a corresponding evaluator class, and an environment.
+    The environment is a dict-like object (such as an `xarray.Dataset`) that maps variable names to values.
+    """
+    @lark.v_args(inline=True)
+    class NodataMaskEvaluator(evaluator):
+        def var_name(self, key):
+            # pylint: disable=invalid-unary-operand-type
+            return ~valid_data_mask(env[key.value])
+
+    return NodataMaskEvaluator().transform(parser.parse(formula))

--- a/datacube_ows/styles/expr.py
+++ b/datacube_ows/styles/expr.py
@@ -28,7 +28,6 @@ def formula_parser():
                 ge: num_expr ">=" num_expr
                 lt: num_expr "<" num_expr
                 gt: num_expr ">" num_expr
-`
 
                 ?num_expr: shift
 
@@ -55,7 +54,7 @@ def formula_parser():
                 ?subatom: NAME -> var_name
                         | FLOAT -> float_literal
                         | INT -> int_literal
-`                        | "(" num_expr ")"
+                        | "(" num_expr ")"
 
 
                 %import common.FLOAT

--- a/datacube_ows/styles/expr.py
+++ b/datacube_ows/styles/expr.py
@@ -1,6 +1,5 @@
 import lark
 import numpy
-
 from datacube.utils.masking import valid_data_mask
 
 
@@ -29,7 +28,7 @@ def formula_parser():
                 ge: num_expr ">=" num_expr
                 lt: num_expr "<" num_expr
                 gt: num_expr ">" num_expr
-
+`
 
                 ?num_expr: shift
 
@@ -56,7 +55,7 @@ def formula_parser():
                 ?subatom: NAME -> var_name
                         | FLOAT -> float_literal
                         | INT -> int_literal
-                        | "(" num_expr ")"
+`                        | "(" num_expr ")"
 
 
                 %import common.FLOAT
@@ -70,9 +69,9 @@ def formula_parser():
 
 @lark.v_args(inline=True)
 class FormulaEvaluator(lark.Transformer):
-    from operator import not_, or_, and_, xor
-    from operator import eq, ne, le, ge, lt, gt
-    from operator import add, sub, mul, truediv, floordiv, neg, pos, inv, mod, pow, lshift, rshift
+    from operator import (add, and_, eq, floordiv, ge, gt, inv, le, lshift, lt,
+        mod, mul, ne, neg, not_, or_, pos, pow, rshift, sub,
+        truediv, xor)
 
     float_literal = float
     int_literal = int

--- a/datacube_ows/styles/expr.py
+++ b/datacube_ows/styles/expr.py
@@ -1,9 +1,4 @@
 import lark
-import numpy
-from datacube.utils.masking import valid_data_mask
-
-# N.B. Copied from datacube.virtual.expr
-# Remove this file and reference core directly after next ODC release.
 
 def formula_parser():
     return lark.Lark("""
@@ -63,77 +58,3 @@ def formula_parser():
 
                 %ignore WS_INLINE
                 """, start='expr')
-
-
-@lark.v_args(inline=True)
-class FormulaEvaluator(lark.Transformer):
-    from operator import (add, and_, eq, floordiv, ge, gt, inv, le, lshift, lt,
-                          mod, mul, ne, neg, not_, or_, pos, pow, rshift, sub,
-                          truediv, xor)
-
-    float_literal = float
-    int_literal = int
-
-
-@lark.v_args(inline=True)
-class MaskEvaluator(lark.Transformer):
-    # the result of an expression is nodata whenever any of its subexpressions is nodata
-    from operator import or_
-
-    # pylint: disable=invalid-name
-    and_ = _xor = or_
-    eq = ne = le = ge = lt = gt = or_
-    add = sub = mul = truediv = floordiv = mod = pow = lshift = rshift = or_
-
-    def not_(self, value):
-        return value
-
-    neg = pos = inv = not_
-
-    @staticmethod
-    def float_literal(value):
-        return False
-
-    @staticmethod
-    def int_literal(value):
-        return False
-
-
-def evaluate_type(formula, env, parser, evaluator):
-    """
-    Evaluates the type of the output of a formula given a parser,
-    a corresponding evaluator class, and an environment.
-    The environment is a dict-like object (such as an `xarray.Dataset`) that maps variable names to values.
-    """
-    @lark.v_args(inline=True)
-    class TypeEvaluator(evaluator):
-        def var_name(self, key):
-            return numpy.array([], dtype=env[key.value].dtype)
-
-    return TypeEvaluator().transform(parser.parse(formula))
-
-def evaluate_data(formula, env, parser, evaluator):
-    """
-    Evaluates a formula given a parser, a corresponding evaluator class, and an environment.
-    The environment is a dict-like object (such as an `xarray.Dataset`) that maps variable names to values.
-    """
-    @lark.v_args(inline=True)
-    class DataEvaluator(evaluator):
-        def var_name(self, key):
-            return env[key.value]
-
-    return DataEvaluator().transform(parser.parse(formula))
-
-
-def evaluate_nodata_mask(formula, env, parser, evaluator):
-    """
-    Evaluates the nodata mask for a formula given a parser, a corresponding evaluator class, and an environment.
-    The environment is a dict-like object (such as an `xarray.Dataset`) that maps variable names to values.
-    """
-    @lark.v_args(inline=True)
-    class NodataMaskEvaluator(evaluator):
-        def var_name(self, key):
-            # pylint: disable=invalid-unary-operand-type
-            return ~valid_data_mask(env[key.value])
-
-    return NodataMaskEvaluator().transform(parser.parse(formula))

--- a/datacube_ows/styles/expr.py
+++ b/datacube_ows/styles/expr.py
@@ -2,7 +2,6 @@ import lark
 import numpy
 from datacube.utils.masking import valid_data_mask
 
-
 # N.B. Copied from datacube.virtual.expr
 # Remove this file and reference core directly after next ODC release.
 
@@ -69,8 +68,8 @@ def formula_parser():
 @lark.v_args(inline=True)
 class FormulaEvaluator(lark.Transformer):
     from operator import (add, and_, eq, floordiv, ge, gt, inv, le, lshift, lt,
-        mod, mul, ne, neg, not_, or_, pos, pow, rshift, sub,
-        truediv, xor)
+                          mod, mul, ne, neg, not_, or_, pos, pow, rshift, sub,
+                          truediv, xor)
 
     float_literal = float
     int_literal = int

--- a/datacube_ows/styles/expression.py
+++ b/datacube_ows/styles/expression.py
@@ -19,10 +19,10 @@ def not_supported(op_name):
 
 @lark.v_args(inline=True)
 class ExpressionEvaluator(lark.Transformer):
+    from operator import add, sub, mul, truediv, floordiv, neg, pos, mod, pow
     not_ = inv = or_ = and_ = xor = not_supported("Bitwise logical operators")
     eq = ne = le = ge = lt = gt = not_supported("Comparison operators")
     lshift = rshift = not_supported("Left and right-shift operators")
-    from operator import add, sub, mul, truediv, floordiv, neg, pos, mod, pow
 
     float_literal = float
     int_literal = int

--- a/datacube_ows/styles/expression.py
+++ b/datacube_ows/styles/expression.py
@@ -1,5 +1,4 @@
 import lark
-
 from datacube_ows.ogc_utils import ConfigException
 from datacube_ows.styles.expr import formula_parser
 
@@ -19,7 +18,7 @@ def not_supported(op_name):
 
 @lark.v_args(inline=True)
 class ExpressionEvaluator(lark.Transformer):
-    from operator import add, sub, mul, truediv, floordiv, neg, pos, mod, pow
+    from operator import add, floodiv, mod, mul, neg, pos, pow, sub, truediv
     not_ = inv = or_ = and_ = xor = not_supported("Bitwise logical operators")
     eq = ne = le = ge = lt = gt = not_supported("Comparison operators")
     lshift = rshift = not_supported("Left and right-shift operators")

--- a/datacube_ows/styles/expression.py
+++ b/datacube_ows/styles/expression.py
@@ -18,7 +18,7 @@ def not_supported(op_name):
 
 @lark.v_args(inline=True)
 class ExpressionEvaluator(lark.Transformer):
-    from operator import add, floodiv, mod, mul, neg, pos, pow, sub, truediv
+    from operator import add, floordiv, mod, mul, neg, pos, pow, sub, truediv
     not_ = inv = or_ = and_ = xor = not_supported("Bitwise logical operators")
     eq = ne = le = ge = lt = gt = not_supported("Comparison operators")
     lshift = rshift = not_supported("Left and right-shift operators")

--- a/datacube_ows/styles/expression.py
+++ b/datacube_ows/styles/expression.py
@@ -1,0 +1,70 @@
+import lark
+
+from datacube_ows.ogc_utils import ConfigException
+from datacube_ows.styles.expr import formula_parser
+
+identity = lambda ev, x: x
+
+def empty_gen(ev, a):
+    return set()
+
+def union(ev, a, b):
+    return a.union(b)
+
+def not_supported(op_name):
+    def impl(ev, a=None, b=None, c=None):
+        raise ConfigException(f"{op_name} not supported")
+    return impl
+
+
+@lark.v_args(inline=True)
+class ExpressionEvaluator(lark.Transformer):
+    not_ = inv = or_ = and_ = xor = not_supported("Bitwise logical operators")
+    eq = ne = le = ge = lt = gt = not_supported("Comparison operators")
+    lshift = rshift = not_supported("Left and right-shift operators")
+    from operator import add, sub, mul, truediv, floordiv, neg, pos, mod, pow
+
+    float_literal = float
+    int_literal = int
+
+    def __init__(self, style, *args, **kwargs):
+        self.ows_style = style
+        super().__init__(*args, **kwargs)
+
+
+@lark.v_args(inline=True)
+class BandListEvaluator(ExpressionEvaluator):
+    neg = pos = identity
+    add = sub = mul = truediv = floordiv = mod = pow = union
+
+    float_literal = empty_gen
+    int_literal = empty_gen
+
+    def var_name(self, key):
+        return set([self.ows_style.local_band(key.value)])
+
+
+class Expression:
+    def __init__(self, style, expr_str):
+        self.style = style
+        self.expr_str = expr_str
+        parser = formula_parser()
+        try:
+            self.tree = parser.parse(self.expr_str)
+            self.needed_bands = BandListEvaluator(self.style).transform(self.tree)
+        except lark.LarkError as e:
+            raise ConfigException(f"Invalid expression: {e} {self.expr_str}")
+        except KeyError as e:
+            raise ConfigException(f"Unrecognised band '{e}' in {expr_str}")
+        if len(self.needed_bands) == 0:
+            raise ConfigException(f"Expression references no bands: {self.expr_str}")
+
+
+    def __call__(self, data):
+        @lark.v_args(inline=True)
+        class ExpressionDataEvaluator(ExpressionEvaluator):
+            def var_name(self, key):
+                return data[self.ows_style.local_band(key.value)]
+
+        return ExpressionDataEvaluator(self.style).transform(self.tree)
+

--- a/datacube_ows/styles/expression.py
+++ b/datacube_ows/styles/expression.py
@@ -1,4 +1,5 @@
 import lark
+
 from datacube_ows.ogc_utils import ConfigException
 from datacube_ows.styles.expr import formula_parser
 

--- a/datacube_ows/styles/ramp.py
+++ b/datacube_ows/styles/ramp.py
@@ -14,6 +14,8 @@ matplotlib.use('Agg')
 
 from datacube_ows.ogc_utils import ConfigException, FunctionWrapper
 from datacube_ows.styles.base import StyleDefBase
+from datacube_ows.styles.expression import Expression
+
 
 _LOG = logging.getLogger(__name__)
 
@@ -525,17 +527,20 @@ class ColorRampDef(StyleDefBase):
                            stand_alone=stand_alone, defer_multi_date=defer_multi_date)
         style_cfg = self._raw_cfg
         self.color_ramp = ColorRamp(self, style_cfg)
-
-        if not self.stand_alone:
-            for band in style_cfg["needed_bands"]:
-                self.raw_needed_bands.add(band)
-
         self.include_in_feature_info = style_cfg.get("include_in_feature_info", True)
 
         if "index_function" in style_cfg:
             self.index_function = FunctionWrapper(self,
                                                   style_cfg["index_function"],
                                                   stand_alone=self.stand_alone)
+            if not self.stand_alone:
+                for band in style_cfg["needed_bands"]:
+                    self.raw_needed_bands.add(band)
+        elif "index_expression" in style_cfg:
+            self.index_function = Expression(self, style_cfg["index_expression"])
+            if not self.stand_alone:
+                for band in self.index_function.needed_bands:
+                    self.raw_needed_bands.add(band)
         else:
             raise ConfigException("Index function is required for index and hybrid styles. Style %s in layer %s" % (
                 self.name,

--- a/datacube_ows/styles/ramp.py
+++ b/datacube_ows/styles/ramp.py
@@ -16,7 +16,6 @@ from datacube_ows.ogc_utils import ConfigException, FunctionWrapper
 from datacube_ows.styles.base import StyleDefBase
 from datacube_ows.styles.expression import Expression
 
-
 _LOG = logging.getLogger(__name__)
 
 UNSCALED_DEFAULT_RAMP = [

--- a/docs/cfg_colourramp_styles.rst
+++ b/docs/cfg_colourramp_styles.rst
@@ -29,13 +29,41 @@ of this documentation, I use the UK/Australian spelling.
 Calculating the Index Value
 ---------------------------
 
-The `index_function <#index-function>`__ entry defines how the
-index is calculated at each pixel.  The bands needed for the calculation
-must be declared in the `needed_bands list <#needed-bands-list>`__
+There are two methods to specify the calculation of the index value:
+
+Expressions (simple calculations)
+=================================
+
+index_expression
+++++++++++++++++
+
+The ``index_expression`` entry takes a string written in a simple
+expression language.  Lexical units are floating point or integer
+constants, or band names (alias-aware).  Simple operators (+, -, /, *, **)
+and parentheses work in the usual manner. Note that you
+do NOT need to explicitly specify ``needed_bands`` when using
+an ``index_expression``.
+
+E.g.
+
+::
+
+   # Simple nir/red NDVI
+   "index_expression": "(nir-red)/(nir+red)",
+
+
+Functions (complex calculations)
+=================================
+
+For more complex calculations than are supported by the expression
+syntax, The `index_function <#index-function>`__ entry can define how the
+index is calculated at each pixel using an arbitrary Python function.
+The bands needed for the calculation must be declared in
+the `needed_bands list <#needed-bands-list>`__
 entry.
 
 index_function
-==============
+++++++++++++++
 
 The `index_function` allows the user to declare a callback function
 to calculate the index value using OWS's
@@ -51,7 +79,7 @@ of general purpose band math functions
 are provided in `datacube_ows.band_utils`.
 
 needed_bands list
-=================
++++++++++++++++++
 
 The `needed_bands` entry must list the names (or aliases) of
 all the bands required by the

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,6 +29,7 @@ bottleneck
 sentry-sdk
 blinker
 pyows
+lark-parser
 owslib==0.21.0
 pytest-helpers-namespace
 prometheus-flask-exporter

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ requirements = [
     'timezonefinderL',
     'python-slugify',
     'geoalchemy',
+    'lark-parser',
     'xarray',
     'pyows',
     'prometheus-flask-exporter',


### PR DESCRIPTION
Allow ramp styles to take an "expression" string.  E.g.

```
"index_expression": "(nir-red)/(nir+red)",
```

(`index_expression` can be used instead of `index_function` and `needed_bands`.) 

This is a first step towards user band math. (#491)