### PR TITLE
Enable ows_config from AWS S3

### DIFF
--- a/datacube_ows/config_utils.py
+++ b/datacube_ows/config_utils.py
@@ -64,7 +64,6 @@ def load_json_obj(path):
     with open(path) as json_file:
         return json.load(json_file)
 
-# pylint: disable=raise-missing-from
 def fetch_from_s3(uri):
     """Fetches ows_cfg from S3"""
     dst = os.path.dirname(__file__) + "/ows_cfg.py"

--- a/datacube_ows/ows_configuration.py
+++ b/datacube_ows/ows_configuration.py
@@ -21,7 +21,7 @@ from datacube_ows.config_utils import (FlagProductBands, OWSConfigEntry,
                                        OWSEntryNotFound,
                                        OWSExtensibleConfigEntry, OWSFlagBand,
                                        cfg_expand, import_python_obj,
-                                       load_json_obj)
+                                       load_json_obj, fetch_from_s3)
 from datacube_ows.cube_pool import cube, get_cube, release_cube
 from datacube_ows.ogc_utils import (ConfigException, FunctionWrapper,
                                     create_geobox, local_solar_date_range,
@@ -41,6 +41,8 @@ def read_config(path=None):
         cfg_env = os.environ.get("DATACUBE_OWS_CFG")
     if not cfg_env:
         from datacube_ows.ows_cfg import ows_cfg as cfg
+    elif cfg_env.startswith("s3://") and cfg_env.endswith(".py"):
+        cfg = fetch_from_s3(cfg_env)
     elif "/" in cfg_env or cfg_env.endswith(".json"):
         cfg = load_json_obj(cfg_env)
         abs_path =  os.path.abspath(cfg_env)


### PR DESCRIPTION
This PR enables fetching the OWS config file from AWS S3 on startup.

As described [in the docs](https://datacube-ows.readthedocs.io/en/latest/configuration.html#where-is-configuration-read-from) the default behavior of reading the OWS config can be overridden by setting the `$DATACUBE_OWS_CFG` environment variable.

If a `.py` file with a `s3://` prefix is passed to `$DATACUBE_OWS_CFG`, the linked file is fetched (if possible) and dumped to `ows_cfg.py` in the `datacube_ows` directory. Subsequently the config object is loaded from the python module.

**Currently this has the limitation that only python files will work and the config object within the file has to be `ows_cfg`** (which is the standard).

If a value with `s3://` prefix but an other extension than `.py` is supplied to `$DATACUBE_OWS_CFG`, then the expression in [line 44](https://github.com/valpesendorfer/datacube-ows/blob/79b2882094f0c922dac06c25a88c677fd0dcb1db/datacube_ows/ows_configuration.py#L44) won't evaluate to `True` and the next `elif` block will be evaluated. In this specific case, it'll evaluate `True` and will most likely raise a `FileNotFoundError`.

Notes:

- This basically covers my use-case, but ideally we could generalize this to also load `.json` and be less restrictive to the naming of the config object. But I wasn't sure what would be the straight forward way to do so with the way the object needs to be loaded. So I've settled on the minimum for a start.
- As discussed on Slack, originally we wanted to add another env var to control if the config from S3 should be accepted (e.g. `$DATACUBE_OWS_CFG_ALLOW_S3` - but I didn't see the immediate upside. When an `s3://` uri is specified, it already signals the intent. IMO having another env variable doesn't add any security, just another stumbling step and one more variable to set in an already long list.
- Currently the `s3://` config would be the first one evaluated if the config var is set in the environment. It needed to be ahead of `elif "/" in cfg_env or cfg_env.endswith(".json")` [in line 46](https://github.com/valpesendorfer/datacube-ows/blob/79b2882094f0c922dac06c25a88c677fd0dcb1db/datacube_ows/ows_configuration.py#L46) and having them evaluated together felt less clean.
- I haven't updated the docs ... will do when I know how this shakes out.

