### PR TITLE
Multiproduct source product determination was broken in C3.

### DIFF
--- a/datacube_ows/data.py
+++ b/datacube_ows/data.py
@@ -694,7 +694,10 @@ def feature_info(args):
                         ds = dss.sel(time=dt).values.tolist()[0]
                         break
                 if params.product.multi_product:
-                    date_info["source_product"] = "%s (%s)" % (ds.type.name, ds.metadata_doc["platform"]["code"])
+                    if "platform" in ds.metadata_doc:
+                        date_info["source_product"] = "%s (%s)" % (ds.type.name, ds.metadata_doc["platform"]["code"])
+                    else:
+                        date_info["source_product"] = ds.type.name
 
                 # Extract data pixel
                 pixel_ds = td.isel(**isel_kwargs)


### PR DESCRIPTION
GetFeatureInfo reports the source product for the clicked pixel.

However, this was using the `platform.code` metadata element that is present on Sentinel-2 products but not C3 Landsat products.

The code now falls back politely and only uses metadata that will always be present if `platform.code` is not available.  Behaviour for Sentinel-2 combined multi-product layers will not change.