### PR TITLE
Handle case where data extent exceeds time-ignored mask product extent

### DIFF
--- a/datacube_ows/data.py
+++ b/datacube_ows/data.py
@@ -231,6 +231,7 @@ class DataStacker:
                     qry_result["time"] = data.time
                 else:
                     if len(qry_result.time) == 0:
+                        var = "No data vars in result"
                         for var in data.data_vars.variables.keys():
                             break
                         template = getattr(data, var)


### PR DESCRIPTION
Fixes ugly error when the spatial extent of the main data is bigger than the spatial extent of a time-independent mask product.

Will probably incur a coverage hit unfortunately - we don't have a really good solution for testing this part of the codebase yet.