### PR TITLE
removes the codecov token from ows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,7 +54,6 @@ jobs:
       - name: Upload All coverage to Codecov (stage 1 - upload coverage result)
         uses: codecov/codecov-action@v1
         with:
-          token: ${{ secrets.CodeCovToken }}
           file: ./artifacts/*.xml
           fail_ci_if_error: false
 


### PR DESCRIPTION
### Reason for this pull request

A CodeCov token not required for public repositories uploading from Travis, CircleCI, AppVeyor, Azure Pipelines or GitHub Actions

The existing CodeCov token will be regenerated


### Proposed changes
Remove the CodeCov secret and remove from the codecov-action
 - [x] Fixes a security compromise

