### PR TITLE
Allow looping over a dimension to do bulk processing in API.

### DIFF
--- a/datacube_ows/ogc_utils.py
+++ b/datacube_ows/ogc_utils.py
@@ -331,7 +331,12 @@ def create_geobox(
     return geometry.GeoBox(width, height, affine, crs)
 
 
-def xarray_image_as_png(img_data, mask=None):
+def xarray_image_as_png(img_data, mask=None, loop_over=None):
+    if loop_over:
+        return [
+            xarray_image_as_png(img_data.sel(**{loop_over: coord}), mask=mask)
+            for coord in img_data.coords[loop_over].values
+        ]
     band_index = {
         "red": 1,
         "green": 2,
@@ -379,3 +384,5 @@ def xarray_image_as_png(img_data, mask=None):
                     alpha_mask = numpy.where(mask, 255, 0).astype('uint8')
                 thing.write_band(4, alpha_mask)
         return memfile.read()
+
+

--- a/datacube_ows/styles/api/base.py
+++ b/datacube_ows/styles/api/base.py
@@ -53,12 +53,12 @@ def apply_ows_style(style, data, loop_over=None, valid_data_mask=None):
         )
     image_slices = []
     for coord in data[loop_over].values:
-        slice = data.sel(**{loop_over: coord})
+        d_slice = data.sel(**{loop_over: coord})
         image_slices.append(
             style.transform_data(
-                slice,
+                d_slice,
                 style.to_mask(
-                    slice,
+                    d_slice,
                     valid_data_mask
                 )
             )

--- a/datacube_ows/styles/base.py
+++ b/datacube_ows/styles/base.py
@@ -146,7 +146,10 @@ class StyleDefBase(OWSExtensibleConfigEntry, OWSMetadataConfig):
             odc_mask = odc_mask.squeeze(dim="time", drop=True)
             return odc_mask
 
-        date_count = len(data.coords["time"])
+        if not data.coords["time"].shape:
+            date_count = 1
+        else:
+            date_count = len(data.coords["time"])
         if date_count > 1:
             # TODO multidate
             mdh = self.get_multi_date_handler(date_count)
@@ -187,9 +190,14 @@ class StyleDefBase(OWSExtensibleConfigEntry, OWSMetadataConfig):
         return img_data
 
     def transform_data(self, data, mask):
-        date_count = len(data.coords["time"])
+        if not data.time.shape:
+            date_count = 1
+        else:
+            date_count = len(data.coords["time"])
+            if date_count == 1:
+                data = data.squeeze(dim="time", drop=True)
         if date_count == 1:
-            img_data = self.transform_single_date_data(data.squeeze(dim="time", drop=True))
+            img_data = self.transform_single_date_data(data)
         else:
             mdh = self.get_multi_date_handler(date_count)
             img_data = mdh.transform_data(data)

--- a/docs/cfg_style_api.rst
+++ b/docs/cfg_style_api.rst
@@ -135,6 +135,41 @@ For more detailed examples,
 refer to the
 `styling how-to guide <https://datacube-ows.readthedocs.io/en/latest/styling_howto.html>`_.
 
+Bulk Processing
+---------------
+
+Bulk processing over a non-spatial dimension of the input data (usually time) is supported via the
+optional ``loop_over`` parameter to ``apply_ows_style``, ``apply_ows_style_cfg``, and
+``xarray_image_as_png``:
+
+::
+
+    from datacube import Datacube
+    from datacube_ows.styles.api import StandaloneStyle
+    from datacube_ows.styles.api import apply_ows_style, apply_ows_style_cfg
+    from datacube_ows.styles.api import xarray_image_as_png
+
+    cfg = {
+        # Some style config ...
+    }
+    style = StandaloneStyle(cfg)
+
+    # This ODC query returns data for multiple dates.
+    dc = Datacube()
+    data = dc.load( ...query parameters... )
+
+    # images is an xarray.Dataset with same time dimension coordinates as the input data.
+    # Each time slice is styled independently.
+    images = apply_ows_style(style, data, loop_over="time")
+
+    # This code will write out the images to the local filesystem as `filename00.png`, `filename01.png`, etc.
+
+    pngs = xarray_image_as_png(images, loop_over="time")
+    for i, png in enumerate(pngs):
+        with open(f"filename{i:02}.png", "wb") as fp:
+            fp.write(xarray_image_as_png(image)
+
+
 Auto-generating a legend image
 ------------------------------
 
@@ -173,3 +208,4 @@ to the Apply OWS Style methods described above.
     # Write out as PNG:
     with open("filename.png", "wb") as fp:
         image.save(fp)
+

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1040,3 +1040,50 @@ def configs_for_combined_fc_wofs():
         }
     ]
 
+@pytest.fixture
+def multi_date_cfg():
+   return  {
+       "index_function": {
+           "function": "datacube_ows.band_utils.norm_diff",
+           "kwargs": {"band1": "nir", "band2": "red"},
+       },
+       "color_ramp": [
+           {"value": -1.0, "color": "#0000FF"},
+           {"value": -0.2, "color": "#005050", },
+           {"value": -0.1, "color": "#505050", },
+           {"value": -0.01, "color": "#303030", },
+           {"value": 0.0, "color": "black", },
+           {"value": 0.01, "color": "#303000", },
+           {"value": 0.5, "color": "#707030", },
+           {"value": 1.0, "color": "#FF9090", },
+       ],
+       "multi_date": [
+           {
+               "allowed_count_range": [2, 2],
+               "preserve_user_date_order": True,
+               "aggregator_function": {
+                   "function": "datacube_ows.band_utils.multi_date_delta"
+               },
+               "mpl_ramp": "RdYlBu",
+               "range": [-1.0, 1.0],
+           }
+       ]
+   }
+
+xyt_coords = [
+    ("x", [-1.0, -0.5, 0.0, 0.5, 1.0]),
+    ("y", [-1.0, -0.5, 0.0, 0.5, 1.0]),
+    ("time", [
+                datetime.datetime(2021, 1, 1, 22, 44, 5),
+                datetime.datetime.now()
+              ])
+]
+
+@pytest.fixture
+def xyt_dummydata():
+    return xarray.Dataset({
+            "red": dummy_da(1400, "red", xyt_coords, dtype="int16"),
+            "green": dummy_da(700, "green", xyt_coords, dtype="int16"),
+            "blue": dummy_da(1500, "blue", xyt_coords, dtype="int16"),
+            "nir": dummy_da(2000, "nir", xyt_coords, dtype="int16"),
+        })

--- a/tests/test_ogc_utils.py
+++ b/tests/test_ogc_utils.py
@@ -1,6 +1,7 @@
 import datetime
 
 import pytest
+import xarray
 
 import datacube_ows.ogc_utils
 
@@ -196,3 +197,22 @@ def test_day_summary_date_range():
     start, end = datacube_ows.ogc_utils.day_summary_date_range(datetime.date(2015, 5, 12))
     assert start == datetime.datetime(2015, 5, 12, 0, 0, 0)
     assert end == datetime.datetime(2015, 5, 12, 23, 59, 59)
+
+xyt_coords = [
+    ("x", [-1.0, -0.5, 0.0, 0.5, 1.0]),
+    ("y", [-1.0, -0.5, 0.0, 0.5, 1.0]),
+    ("time", [
+                datetime.datetime(2021, 1, 1, 22, 44, 5),
+                datetime.datetime.now()
+              ])
+]
+
+def test_png_loop_over():
+    data = xarray.Dataset({
+            "red": dummy_da(100, "red", xyt_coords, dtype="uint8"),
+            "green": dummy_da(70, "green", xyt_coords, dtype="uint8"),
+            "blue": dummy_da(150, "blue", xyt_coords, dtype="uint8"),
+            "alpha": dummy_da(200, "alpha", xyt_coords, dtype="uint8"),
+        })
+    imgs = datacube_ows.ogc_utils.xarray_image_as_png(data, None, loop_over="time")
+    assert len(imgs) == 2

--- a/tests/test_style_api.py
+++ b/tests/test_style_api.py
@@ -398,3 +398,17 @@ def test_fc_wofs_like_configs(dummy_raw_fc_plus_wo, configs_for_combined_fc_wofs
         result = style.transform_data(dummy_raw_fc_plus_wo, mask)
         assert result
 
+
+def test_multidate(xyt_dummydata, multi_date_cfg):
+    image = apply_ows_style_cfg(multi_date_cfg, xyt_dummydata)
+    assert len(image.x) == len(xyt_dummydata.x)
+    assert len(image.y) == len(xyt_dummydata.y)
+    assert "time" not in image
+
+
+def test_loopover(xyt_dummydata, multi_date_cfg):
+    image = apply_ows_style_cfg(multi_date_cfg, xyt_dummydata, loop_over="time")
+    assert len(image.x) == len(xyt_dummydata.x)
+    assert len(image.y) == len(xyt_dummydata.y)
+    assert len(image.time) == len(xyt_dummydata.time)
+

--- a/tests/test_style_api.py
+++ b/tests/test_style_api.py
@@ -211,7 +211,7 @@ def rgb_style_with_masking_cfg():
 
 
 def test_component_style_with_masking(dummy_raw_calc_data, raw_calc_null_mask, rgb_style_with_masking_cfg):
-    result = apply_ows_style_cfg(rgb_style_with_masking_cfg, dummy_raw_calc_data, raw_calc_null_mask)
+    result = apply_ows_style_cfg(rgb_style_with_masking_cfg, dummy_raw_calc_data, valid_data_mask=raw_calc_null_mask)
     for channel in ("red", "green", "blue", "alpha"):
         assert channel in result.data_vars.keys()
     alphas = result["alpha"].values
@@ -267,7 +267,7 @@ def simple_colormap_style_cfg():
 
 
 def test_colormap_style(dummy_col_map_data, raw_calc_null_mask, simple_colormap_style_cfg):
-    result = apply_ows_style_cfg(simple_colormap_style_cfg, dummy_col_map_data, raw_calc_null_mask)
+    result = apply_ows_style_cfg(simple_colormap_style_cfg, dummy_col_map_data, valid_data_mask=raw_calc_null_mask)
     for channel in ("red", "green", "blue", "alpha"):
         assert channel in result.data_vars.keys()
     # point 0 fall through - transparent
@@ -328,7 +328,7 @@ def enum_colormap_style_cfg():
 
 
 def test_enum_colormap_style(dummy_col_map_data, raw_calc_null_mask, enum_colormap_style_cfg):
-    result = apply_ows_style_cfg(enum_colormap_style_cfg, dummy_col_map_data, raw_calc_null_mask)
+    result = apply_ows_style_cfg(enum_colormap_style_cfg, dummy_col_map_data, valid_data_mask=raw_calc_null_mask)
     for channel in ("red", "green", "blue", "alpha"):
         assert channel in result.data_vars.keys()
     # point 0 (8) Blah - red
@@ -368,7 +368,7 @@ def test_ramp_legend(simple_colormap_style_cfg):
 
 
 def test_api_none_mask(dummy_col_map_data, raw_calc_null_mask, simple_colormap_style_cfg):
-    null_mask = apply_ows_style_cfg(simple_colormap_style_cfg, dummy_col_map_data, raw_calc_null_mask)
+    null_mask = apply_ows_style_cfg(simple_colormap_style_cfg, dummy_col_map_data, valid_data_mask=raw_calc_null_mask)
     none_mask = apply_ows_style_cfg(simple_colormap_style_cfg, dummy_col_map_data)
     for i in range(6):
         for c in ("red", "green", "blue", "alpha"):


### PR DESCRIPTION
For #590 

```

    # images is an xarray.Dataset with same time dimension coordinates as the input data.
    # Each time slice is styled independently.
    images = apply_ows_style(style, data, loop_over="time")

    # This code will write out the images to the local filesystem as `filename00.png`, `filename01.png`, etc.

    pngs = xarray_image_as_png(images, loop_over="time")
    for i, png in enumerate(pngs):
        with open(f"filename{i:02}.png", "wb") as fp:
            fp.write(xarray_image_as_png(image)

```