### PR TITLE
add 3111 to cfg example

### DIFF
--- a/datacube_ows/ows_cfg_example.py
+++ b/datacube_ows/ows_cfg_example.py
@@ -1341,6 +1341,11 @@ ows_cfg = {
                 "geographic": True,
                 "vertical_coord_first": True
             },
+            "EPSG:3111": {  # VicGrid94 for delwp.vic.gov.au
+               "geographic": False,
+                "horizontal_coord": "x",
+                "vertical_coord": "y",
+            },
             "EPSG:3577": {  # GDA-94, internal representation
                 "geographic": False,
                 "horizontal_coord": "x",
@@ -1932,7 +1937,3 @@ ows_cfg = {
         } ##### End of mangrove_cover definition
     ]  ##### End of "layers" list.
 } #### End of example configuration object
-
-
-
-


### PR DESCRIPTION
tried to run it ```duct names entry missing in named layer mangrove_cover
[2021-05-20 02:19:14 +0000] [8] [ERROR] Exception in worker process
Traceback (most recent call last):
  File "/env/lib/python3.8/site-packages/gunicorn/arbiter.py", line 589, in spawn_worker
    worker.init_process()
  File "/env/lib/python3.8/site-packages/gunicorn/workers/ggevent.py", line 146, in init_process
    super().init_process()
  File "/env/lib/python3.8/site-packages/gunicorn/workers/base.py", line 134, in init_process
    self.load_wsgi()
  File "/env/lib/python3.8/site-packages/gunicorn/workers/base.py", line 146, in load_wsgi
    self.wsgi = self.app.wsgi()
  File "/env/lib/python3.8/site-packages/gunicorn/app/base.py", line 67, in wsgi
    self.callable = self.load()
  File "/env/lib/python3.8/site-packages/gunicorn/app/wsgiapp.py", line 58, in load
    return self.load_wsgiapp()
  File "/env/lib/python3.8/site-packages/gunicorn/app/wsgiapp.py", line 48, in load_wsgiapp
    return util.import_app(self.app_uri)
  File "/env/lib/python3.8/site-packages/gunicorn/util.py", line 359, in import_app
    mod = importlib.import_module(module)
  File "/usr/lib/python3.8/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1014, in _gcd_import
  File "<frozen importlib._bootstrap>", line 991, in _find_and_load
  File "<frozen importlib._bootstrap>", line 975, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 671, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 783, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/env/lib/python3.8/site-packages/datacube_ows/wsgi.py", line 17, in <module>
    from datacube_ows.ogc import app
  File "/env/lib/python3.8/site-packages/datacube_ows/ogc.py", line 37, in <module>
    parse_config_file()
  File "/env/lib/python3.8/site-packages/datacube_ows/startup_utils.py", line 112, in parse_config_file
    get_config()
  File "/env/lib/python3.8/site-packages/datacube_ows/ows_configuration.py", line 1218, in get_config
    cfg = OWSConfig(refresh=refresh)
  File "/env/lib/python3.8/site-packages/datacube_ows/ows_configuration.py", line 1027, in __init__
    self.parse_wmts(cfg.get("wmts", {}))
  File "/env/lib/python3.8/site-packages/datacube_ows/ows_configuration.py", line 1172, in parse_wmts
    self.tile_matrix_sets[identifier] = TileMatrixSet(identifier, tms, self)
  File "/env/lib/python3.8/site-packages/datacube_ows/tile_matrix_sets.py", line 66, in __init__
    raise ConfigException(f"Tile matrix set {identifier} has unpublished CRS: {self.crs_name}")
datacube_ows.ogc_utils.ConfigException: Tile matrix set vicgrid has unpublished CRS: EPSG:3111```