### PR TITLE
remove eventlet

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,10 +11,8 @@ scikit-image
 gevent
 python-slugify
 geoalchemy2
-eventlet
 gunicorn
 gunicorn[gevent]
-gunicorn[eventlet]
 boto3
 moto
 rasterio>=1.0.9


### PR DESCRIPTION
its faulty 

```
datacube-ows_ows_1 exited with code 1
ows_1       | 
ows_1       | Error: class uri 'eventlet' invalid or not found: 
ows_1       | 
ows_1       | [Traceback (most recent call last):
ows_1       |   File "/env/lib/python3.8/site-packages/gunicorn/util.py", line 99, in load_class
ows_1       |     mod = importlib.import_module('.'.join(components))
ows_1       |   File "/usr/lib/python3.8/importlib/__init__.py", line 127, in import_module
ows_1       |     return _bootstrap._gcd_import(name[level:], package, level)
ows_1       |   File "<frozen importlib._bootstrap>", line 1014, in _gcd_import
ows_1       |   File "<frozen importlib._bootstrap>", line 991, in _find_and_load
ows_1       |   File "<frozen importlib._bootstrap>", line 975, in _find_and_load_unlocked
ows_1       |   File "<frozen importlib._bootstrap>", line 671, in _load_unlocked
ows_1       |   File "<frozen importlib._bootstrap_external>", line 783, in exec_module
ows_1       |   File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
ows_1       |   File "/env/lib/python3.8/site-packages/gunicorn/workers/geventlet.py", line 20, in <module>
ows_1       |     from eventlet.wsgi import ALREADY_HANDLED as EVENTLET_ALREADY_HANDLED
ows_1       | ImportError: cannot import name 'ALREADY_HANDLED' from 'eventlet.wsgi' (/env/lib/python3.8/site-packages/eventlet/wsgi.py)
ows_1       | ]
```