### PR TITLE
Fix env-controlled install of pydevd.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN pip install .
 
 ## Only install pydev requirements if arg PYDEV_DEBUG is set to 'yes'
 ARG PYDEV_DEBUG="no"
-RUN if [[ "$PYDEV_DEBUG" == "yes" ]]; then \
+RUN if [ "$PYDEV_DEBUG" = "yes" ]; then \
     pip install pydevd-pycharm~=211.7142.13 \
 ;fi
 


### PR DESCRIPTION
Installation of pydevd is supposed to be dependent on environment.

First, we were always installing pydevd, then we were never installing it.

This combination seems to work both ways.
