### PR TITLE
Make calculating tiff statistics optional

### DIFF
--- a/datacube_ows/ows_configuration.py
+++ b/datacube_ows/ows_configuration.py
@@ -1252,16 +1252,13 @@ class OWSConfig(OWSMetadataConfig):
             self.native_wcs_format = cfg["native_format"]
             if self.native_wcs_format not in self.wcs_formats_by_name:
                 raise ConfigException(f"Configured native WCS format ({self.native_wcs_format}) not a supported format.")
+            self.wcs_tiff_statistics = cfg.get("calculate_tiff_statistics", True)
         else:
-            self.default_geographic_CRS = None
-            self.default_geographic_CRS_def = None
             self.wcs_formats = []
             self.wcs_formats_by_name = {}
             self.wcs_formats_by_mime = {}
             self.native_wcs_format = None
-        # shouldn't need to keep these?
-        # self.dummy_wcs_grid = False
-        # self.create_wcs_grid = False
+            self.wcs_tiff_statistics = False
 
     def parse_wmts(self, cfg):
         tms_cfgs = TileMatrixSet.default_tm_sets.copy()

--- a/datacube_ows/wcs1_utils.py
+++ b/datacube_ows/wcs1_utils.py
@@ -404,10 +404,11 @@ def get_tiff(req, data):
             for idx, band in enumerate(data.data_vars, start=1):
                 dst.write(data[band].values, idx)
                 dst.set_band_description(idx, req.product.band_idx.band_label(band))
-                dst.update_tags(idx, STATISTICS_MINIMUM=data[band].values.min())
-                dst.update_tags(idx, STATISTICS_MAXIMUM=data[band].values.max())
-                dst.update_tags(idx, STATISTICS_MEAN=data[band].values.mean())
-                dst.update_tags(idx, STATISTICS_STDDEV=data[band].values.std())
+                if cfg.wcs_tiff_statistics:
+                    dst.update_tags(idx, STATISTICS_MINIMUM=data[band].values.min())
+                    dst.update_tags(idx, STATISTICS_MAXIMUM=data[band].values.max())
+                    dst.update_tags(idx, STATISTICS_MEAN=data[band].values.mean())
+                    dst.update_tags(idx, STATISTICS_STDDEV=data[band].values.std())
         return memfile.read()
 
 

--- a/datacube_ows/wcs2_utils.py
+++ b/datacube_ows/wcs2_utils.py
@@ -307,6 +307,7 @@ def get_tiff(request, data, crs, product, width, height, affine):
 
     # TODO: convert other parameters as-well
     gtiff = request.geotiff_encoding_parameters
+    cfg = get_config()
 
     data = data.squeeze(dim="time", drop=True)
     data = data.astype(dtype)
@@ -345,10 +346,11 @@ def get_tiff(request, data, crs, product, width, height, affine):
             for idx, band in enumerate(data.data_vars, start=1):
                 dst.write(data[band].values, idx)
                 dst.set_band_description(idx, product.band_idx.band_label(band))
-                dst.update_tags(idx, STATISTICS_MINIMUM=data[band].values.min())
-                dst.update_tags(idx, STATISTICS_MAXIMUM=data[band].values.max())
-                dst.update_tags(idx, STATISTICS_MEAN=data[band].values.mean())
-                dst.update_tags(idx, STATISTICS_STDDEV=data[band].values.std())
+                if cfg.wcs_tiff_statistics:
+                    dst.update_tags(idx, STATISTICS_MINIMUM=data[band].values.min())
+                    dst.update_tags(idx, STATISTICS_MAXIMUM=data[band].values.max())
+                    dst.update_tags(idx, STATISTICS_MEAN=data[band].values.mean())
+                    dst.update_tags(idx, STATISTICS_STDDEV=data[band].values.std())
         return memfile.read()
 
 

--- a/docs/cfg_wcs.rst
+++ b/docs/cfg_wcs.rst
@@ -81,3 +81,20 @@ activated (specified in the `global services <https://datacube-ows.readthedocs.i
 section) and must contain the name of one of the formats in
 defined in the
 `formats <#supported-output-formats-formats>`_ section.
+
+GEOTiff Statistics (calculate_tiff_statistics)
+==============================================
+
+An optional boolean (defaults to True) that only applies for geotiff coverage responses.
+
+It specifies whether or not channel statistics (max/min/avg/stddev) are calculated and stored
+in TIFF metadata.  Calculating statistics results in better interoperability with some clients
+(e.g. QGIS) but results in increased memory usage when generating very large coverage files.
+
+We recommend leaving this setting false (the default) unless you particularly need to
+support very large coverage files.
+
+::
+
+    # Suppress tiff statistics to support very large geotiff responses
+    "calculate_tiff_statistics": False,

--- a/tests/test_cfg_global.py
+++ b/tests/test_cfg_global.py
@@ -15,6 +15,7 @@ def test_minimal_global(minimal_global_raw_cfg, minimal_dc):
     cfg.make_ready(minimal_dc)
     assert cfg.ready
     assert cfg.initialised
+    assert cfg.wcs_tiff_statistics
 
 
 def test_global_no_title(minimal_global_raw_cfg):
@@ -150,6 +151,14 @@ def test_bad_wcs_format(minimal_global_raw_cfg, wcs_global_cfg):
     assert "jpeg2000" in str(excinfo.value)
     assert "not a supported format" in str(excinfo.value)
 
+
+def test_tiff_stats(minimal_global_raw_cfg, wcs_global_cfg)
+    OWSConfig._instance = None
+    minimal_global_raw_cfg["global"]["services"] = {"wcs": True}
+    minimal_global_raw_cfg["wcs"] = wcs_global_cfg
+    minimal_global_raw_cfg["wcs"]["calculate_tiff_statistics"] = False
+    cfg = OWSConfig(cfg=minimal_global_raw_cfg)
+    assert not cfg.wcs_tiff_statistics
 
 def test_crs_lookup_fail(minimal_global_raw_cfg, minimal_dc):
     OWSConfig._instance = None

--- a/tests/test_cfg_global.py
+++ b/tests/test_cfg_global.py
@@ -15,7 +15,7 @@ def test_minimal_global(minimal_global_raw_cfg, minimal_dc):
     cfg.make_ready(minimal_dc)
     assert cfg.ready
     assert cfg.initialised
-    assert cfg.wcs_tiff_statistics
+    assert not cfg.wcs_tiff_statistics
 
 
 def test_global_no_title(minimal_global_raw_cfg):
@@ -40,6 +40,7 @@ def test_wcs_only(minimal_global_raw_cfg, wcs_global_cfg, minimal_dc):
     assert cfg.wcs
     assert not cfg.wms
     assert not cfg.wmts
+    assert cfg.wcs_tiff_statistics
 
 
 def test_contact_details_parse(minimal_global_cfg):

--- a/tests/test_cfg_global.py
+++ b/tests/test_cfg_global.py
@@ -152,7 +152,7 @@ def test_bad_wcs_format(minimal_global_raw_cfg, wcs_global_cfg):
     assert "not a supported format" in str(excinfo.value)
 
 
-def test_tiff_stats(minimal_global_raw_cfg, wcs_global_cfg)
+def test_tiff_stats(minimal_global_raw_cfg, wcs_global_cfg):
     OWSConfig._instance = None
     minimal_global_raw_cfg["global"]["services"] = {"wcs": True}
     minimal_global_raw_cfg["wcs"] = wcs_global_cfg


### PR DESCRIPTION
Global config option to deactivate tiff statistics.

Tradeoff is that statistics improve interoperability with some GIS clients (e.g. QGIS), but calculating statistics uses additional memory usage on large coverage requests.

Default is to calculate statistics. If you want to maximise the size of the GeoTIFF coverages that you can serve for a given memory allocation, you can set "calculate_tiff_statistics" in the global "wcs" section to False.

Addresses issue #653 for @valpesendorfer 