### PR TITLE
Rasterio polygons

### DIFF
--- a/datacube_ows/data.py
+++ b/datacube_ows/data.py
@@ -565,8 +565,6 @@ def _write_polygon(geobox, polygon, zoom_fill, layer):
     if geobox_ext.within(polygon):
         data = numpy.full([geobox.height, geobox.width], fill_value=1, dtype="uint8")
     else:
-        if len(zoom_fill) == 3:
-            zoom_fill += ["255"]
         data = numpy.zeros([geobox.height, geobox.width], dtype="uint8")
         data = rasterize(shapes=[polygon],
                           fill=0,

--- a/datacube_ows/data.py
+++ b/datacube_ows/data.py
@@ -19,8 +19,8 @@ import xarray
 from datacube.utils import geometry
 from datacube.utils.masking import mask_to_dict
 from pandas import Timestamp
-from rasterio.io import MemoryFile
 from rasterio.features import rasterize
+from rasterio.io import MemoryFile
 from rasterio.warp import Resampling
 
 from datacube_ows.cube_pool import cube

--- a/datacube_ows/data.py
+++ b/datacube_ows/data.py
@@ -586,32 +586,6 @@ def _write_polygon(geobox, polygon, zoom_fill, layer):
                 thing.write_band(idx, data * fill)
         return memfile.read()
 
-@log_call
-def _skimg_write_polygon(geobox, polygon, zoom_fill, layer):
-    geobox_ext = geobox.extent
-    if geobox_ext.within(polygon):
-        data = numpy.full([geobox.height, geobox.width], fill_value=1, dtype="uint8")
-    else:
-        data = numpy.zeros([geobox.height, geobox.width], dtype="uint8")
-        coordinates_list = get_coordlist(polygon, layer.name)
-        for polygon_coords in coordinates_list:
-            pixel_coords = [~geobox.transform * coords for coords in polygon_coords[0]]
-            rs, cs = skimg_polygon([c[1] for c in pixel_coords], [c[0] for c in pixel_coords],
-                                   shape=[geobox.width, geobox.height])
-            data[rs, cs] = 1
-
-    with MemoryFile() as memfile:
-        with memfile.open(driver='PNG',
-                          width=geobox.width,
-                          height=geobox.height,
-                          count=len(zoom_fill),
-                          transform=None,
-                          nodata=0,
-                          dtype='uint8') as thing:
-            for idx, fill in enumerate(zoom_fill, start=1):
-                thing.write_band(idx, data * fill)
-        return memfile.read()
-
 
 @log_call
 def get_s3_browser_uris(datasets, pt=None, s3url="", s3bucket=""):

--- a/datacube_ows/ows_configuration.py
+++ b/datacube_ows/ows_configuration.py
@@ -506,6 +506,10 @@ class OWSNamedLayer(OWSExtensibleConfigEntry, OWSLayer):
         wms_cfg = cfg.get("wms", {})
         wcs_cfg = cfg.get("wcs", {})
         self.zoom_fill = wms_cfg.get("zoomed_out_fill_colour", [150, 180, 200, 160])
+        if len(self.zoom_fill) == 3:
+            self.zoom_fill += [255]
+        if len(self.zoom_fill) != 4:
+            raise ConfigException("zoomed_out_fill_colour must have 3 or 4 elements")
         self.min_zoom = wms_cfg.get("min_zoom_factor", 300.0)
         self.max_datasets_wms = wms_cfg.get("max_datasets", 0)
         self.max_datasets_wcs = wcs_cfg.get("max_datasets", 0)

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,6 @@ flask
 flask-cors
 colour
 pandas==1.0.5
-scikit-image
 gevent
 python-slugify
 geoalchemy2

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,6 +21,7 @@ flask-log-request-id
 pytest-localserver
 pytest-mock
 requests
+scipy
 watchdog
 timezonefinderL
 python-slugify

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,6 @@ requirements = [
     'rasterio',
     'regex',
     's3fs',
-    'scikit-image',
     'timezonefinderL',
     'python-slugify',
     'geoalchemy',

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ requirements = [
     'lxml',
     'matplotlib',
     'numpy',
+    'scipy',
     'Pillow',
     'Babel',
     'Flask-Babel',

--- a/tests/test_cfg_layer.py
+++ b/tests/test_cfg_layer.py
@@ -366,6 +366,21 @@ def test_multi_product_name_mismatch(minimal_multiprod_cfg, minimal_global_cfg):
     assert "a_layer" in str(excinfo.value)
 
 
+def test_resource_limit_zoomfill(minimal_layer_cfg, minimal_global_cfg):
+    minimal_layer_cfg["resource_limits"] = {
+        "zoomed_out_fill_colour": [128,128,128]
+    }
+    lyr = parse_ows_layer(minimal_layer_cfg,
+                          global_cfg=minimal_global_cfg)
+    assert len(lyr.zoom_fill) == 4
+    assert lyr.zoom_fill[3] == 255
+    minimal_layer_cfg["resource_limits"]["zoomed_out_fill_colour"] = [13, 254]
+    with pytest.raises(ConfigException) as excinfo:
+        lyr = parse_ows_layer(minimal_layer_cfg,
+                              global_cfg=minimal_global_cfg)
+    assert "zoomed_out_fill_colour must have 3 or 4 elements" in str(excinfo.value)
+
+
 def test_manual_merge(minimal_layer_cfg, minimal_global_cfg):
     minimal_layer_cfg["image_processing"]["manual_merge"] = True
     minimal_layer_cfg["image_processing"]["apply_solar_corrections"] = False

--- a/tests/test_cfg_layer.py
+++ b/tests/test_cfg_layer.py
@@ -368,13 +368,13 @@ def test_multi_product_name_mismatch(minimal_multiprod_cfg, minimal_global_cfg):
 
 def test_resource_limit_zoomfill(minimal_layer_cfg, minimal_global_cfg):
     minimal_layer_cfg["resource_limits"] = {
-        "zoomed_out_fill_colour": [128, 128, 128]
+        "wms": {"zoomed_out_fill_colour": [128, 128, 128]}
     }
     lyr = parse_ows_layer(minimal_layer_cfg,
                           global_cfg=minimal_global_cfg)
     assert len(lyr.zoom_fill) == 4
     assert lyr.zoom_fill[3] == 255
-    minimal_layer_cfg["resource_limits"]["zoomed_out_fill_colour"] = [13, 254]
+    minimal_layer_cfg["resource_limits"]["wms"]["zoomed_out_fill_colour"] = [13, 254]
     with pytest.raises(ConfigException) as excinfo:
         lyr = parse_ows_layer(minimal_layer_cfg,
                               global_cfg=minimal_global_cfg)

--- a/tests/test_cfg_layer.py
+++ b/tests/test_cfg_layer.py
@@ -368,7 +368,7 @@ def test_multi_product_name_mismatch(minimal_multiprod_cfg, minimal_global_cfg):
 
 def test_resource_limit_zoomfill(minimal_layer_cfg, minimal_global_cfg):
     minimal_layer_cfg["resource_limits"] = {
-        "zoomed_out_fill_colour": [128,128,128]
+        "zoomed_out_fill_colour": [128, 128, 128]
     }
     lyr = parse_ows_layer(minimal_layer_cfg,
                           global_cfg=minimal_global_cfg)


### PR DESCRIPTION
Addresses #648

Use rasterio to generate shaded extent polygons for resource limit-exceeding WMS/WMTS queries.  This removes scikit-image as a dependency.