### PR TITLE
Fix Pillow coordinate order issues.

### DIFF
--- a/datacube_ows/ogc_utils.py
+++ b/datacube_ows/ogc_utils.py
@@ -554,7 +554,10 @@ def xarray_image_as_png(img_data, mask=None, loop_over=None, animate=False):
         img_io.seek(0)
         return img_io.read()
 
-    masked_data = render_frame(img_data, mask, width, height)
+
+    if mask is not None:
+        mask = mask.transpose(xcoord, ycoord)
+    masked_data = render_frame(img_data.transpose(xcoord, ycoord), mask, width, height)
     if not loop_over and animate:
         return masked_data
    

--- a/tests/test_ogc_utils.py
+++ b/tests/test_ogc_utils.py
@@ -251,6 +251,11 @@ def test_day_summary_date_range():
     assert start == datetime.datetime(2015, 5, 12, 0, 0, 0, tzinfo=utc)
     assert end == datetime.datetime(2015, 5, 12, 23, 59, 59, tzinfo=utc)
 
+xy_coords = [
+    ("x", [-1.0, -0.5, 0.0, 0.5, 1.0]),
+    ("y", [-1.0, -0.5]),
+]
+
 xyt_coords = [
     ("x", [-1.0, -0.5, 0.0, 0.5, 1.0]),
     ("y", [-1.0, -0.5, 0.0, 0.5, 1.0]),
@@ -282,6 +287,18 @@ def test_png_loop_over_anim():
     imgs = datacube_ows.ogc_utils.xarray_image_as_png(data, None, loop_over="time", animate=True)
     assert len(imgs) == 173
     assert imgs.find(b"\x89PNG") == 0
+
+
+def test_render_frame():
+    data = xarray.Dataset({
+        "red": dummy_da(100, "red", xy_coords, dtype="uint8"),
+        "green": dummy_da(70, "green", xy_coords, dtype="uint8"),
+        "blue": dummy_da(150, "blue", xy_coords, dtype="uint8"),
+        "alpha": dummy_da(200, "alpha", xy_coords, dtype="uint8"),
+    })
+    png = datacube_ows.ogc_utils.render_frame(data, None, 5, 2)
+    assert png.shape == (2, 5, 4)
+
 
 def test_time_call(monkeypatch):
     class FakeLogger:


### PR DESCRIPTION
Pillow isn't as smart about array coordinate order as Rasterio was.  Tiles were getting coordinate swapped.