### PR TITLE
Wms default time

### DIFF
--- a/datacube_ows/ows_configuration.py
+++ b/datacube_ows/ows_configuration.py
@@ -782,8 +782,9 @@ class OWSNamedLayer(OWSExtensibleConfigEntry, OWSLayer):
                 self.default_time = self.default_time_rule
             elif isinstance(self.default_time_rule, datetime.date):
                 _LOG.warning("default_time for named_layer %s is explicit date (%s) that is "
-                             " not available for the layer. Using most recent available date instead." % (
-                                    self.name, self.default_time_rule.isoformat())
+                             " not available for the layer. Using most recent available date instead.",
+                                    self.name,
+                                    self.default_time_rule.isoformat()
                 )
                 self.default_time = self._ranges["end_time"]
             else:

--- a/datacube_ows/ows_configuration.py
+++ b/datacube_ows/ows_configuration.py
@@ -412,6 +412,7 @@ class OWSNamedLayer(OWSExtensibleConfigEntry, OWSLayer):
 
         self.dynamic = cfg.get("dynamic", False)
 
+        self.declare_unready("default_time")
         self.declare_unready("_ranges")
         self.declare_unready("bboxes")
         # TODO: sub-ranges
@@ -763,6 +764,7 @@ class OWSNamedLayer(OWSExtensibleConfigEntry, OWSLayer):
             if self._ranges is None:
                 raise Exception("Null product range")
             self.bboxes = self.extract_bboxes()
+            self.default_time = self._ranges["time"][-1]
         # pylint: disable=broad-except
         except Exception as a:
             if not self.global_cfg.called_from_update_ranges:

--- a/datacube_ows/styles/hybrid.py
+++ b/datacube_ows/styles/hybrid.py
@@ -23,7 +23,7 @@ class HybridStyleDef(ColorRampDef, ComponentStyleDef):
     def transform_single_date_data(self, data):
         #pylint: disable=too-many-locals
         if self.index_function is not None:
-            data['index_function'] = (data.dims, self.index_function(data))
+            data['index_function'] = (data.dims, self.index_function(data).data)
 
         imgdata = Dataset(coords=data)
 

--- a/datacube_ows/styles/hybrid.py
+++ b/datacube_ows/styles/hybrid.py
@@ -47,7 +47,7 @@ class HybridStyleDef(ColorRampDef, ComponentStyleDef):
                                  + self.component_ratio * component_band_data)
             else:
                 img_band_data = rampdata * 255.0
-            imgdata[band] = (d.dims, img_band_data.astype("uint8"))
+            imgdata[band] = (d.dims, img_band_data.astype("uint8").data)
 
         return imgdata
 

--- a/datacube_ows/styles/ramp.py
+++ b/datacube_ows/styles/ramp.py
@@ -557,7 +557,7 @@ class ColorRampDef(StyleDefBase):
 
     def apply_index(self, data):
         index_data = self.index_function(data)
-        data['index_function'] = (index_data.dims, index_data)
+        data['index_function'] = (index_data.dims, index_data.data)
         return data["index_function"]
 
     def transform_single_date_data(self, data):

--- a/datacube_ows/templates/wms_capabilities.xml
+++ b/datacube_ows/templates/wms_capabilities.xml
@@ -85,7 +85,7 @@
             />
         {% endfor %}
         {% if lyr.regular_time_axis %}
-        <Dimension name="time" units="ISO8601" default="{{ lyr_ranges.times[-1].isoformat() }}">{{ lyr.time_axis_representation() }}</Dimension>
+        <Dimension name="time" units="ISO8601" default="{{ lyr.default_time.isoformat() }}">{{ lyr.time_axis_representation() }}</Dimension>
         {% elif lyr_ranges.times|length > 1 %}
         <Dimension name="time" units="ISO8601" default="{{ lyr_ranges.times[-1].isoformat() }}">
             {% for t in lyr_ranges.times %}{{ t }}{% if not loop.last %},{% endif %}{% endfor %}

--- a/datacube_ows/templates/wms_capabilities.xml
+++ b/datacube_ows/templates/wms_capabilities.xml
@@ -87,7 +87,7 @@
         {% if lyr.regular_time_axis %}
         <Dimension name="time" units="ISO8601" default="{{ lyr.default_time.isoformat() }}">{{ lyr.time_axis_representation() }}</Dimension>
         {% elif lyr_ranges.times|length > 1 %}
-        <Dimension name="time" units="ISO8601" default="{{ lyr_ranges.times[-1].isoformat() }}">
+        <Dimension name="time" units="ISO8601" default="{{ lyr.default_time.isoformat() }}">
             {% for t in lyr_ranges.times %}{{ t }}{% if not loop.last %},{% endif %}{% endfor %}
         </Dimension>
         {% endif %}

--- a/datacube_ows/wcs1_utils.py
+++ b/datacube_ows/wcs1_utils.py
@@ -109,8 +109,9 @@ class WCS1GetCoverageRequest():
         #    self.times = [parse(self.product.wcs_sole_time).date()]
         if "time" not in args:
             #      CEOS treats no supplied time argument as all time.
-            # I'm really not sure what the right thing to do is, but QGIS wants us to do SOMETHING - treat it as "now"
-            self.times = [self.product.ranges["times"][-1]]
+            # I'm really not sure what the right thing to do is, but QGIS wants us to do SOMETHING - use configured
+            # default.
+            self.times = [self.product.default_time]
         else:
             # TODO: the min/max/res format option?
             # It's a bit underspeced. I'm not sure what the "res" would look like.

--- a/docs/cfg_layers.rst
+++ b/docs/cfg_layers.rst
@@ -294,6 +294,29 @@ Note that it will usually be necessary to rerun `datacube-ows-update
 <https://datacube-ows.readthedocs.io/en/latest/database.html#updating-range-tables-for-individual-layers>`_
 for the layer after changing the time resolution.
 
+-------------------------------------
+WMS Default Time Value (default_time)
+-------------------------------------
+
+Specifies which time value to use by default if not specified in request.  Applies to WMS, WMTS and WCS1.
+
+Optional (default = "latest")
+
+Allowed values:
+
+1. "latest" (the default).   Use most recent available date.
+2. "earliest".   Use earliest available date.
+3. ISO Format date (e.g. "2021-05-26").  If the specified date is not available, a warning is raised and the latest
+   available date is used instead.
+
+E.g.
+
+::
+
+    "default_time": "latest",
+    # "default_time": "earliest",
+    # "default_time": "2020-07-25",
+
 -----------------------------
 Regular Time Axis (time_axis)
 -----------------------------

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -304,7 +304,7 @@ def minimal_multiprod_cfg():
 
 @pytest.fixture
 def mock_range():
-    times = [datetime.datetime(2010, 1, 1), datetime.datetime(2010, 1, 2)]
+    times = [datetime.date(2010, 1, 1), datetime.date(2010, 1, 2), datetime.date(2010, 1, 3)]
     return {
         "lat": {
             "min": -0.1,


### PR DESCRIPTION
Addresses #673

Can now add to layer config:
```
   "default_time": "latest",    # Default behaviour - use the most recent available date as the default time, OR:
   "default_time": "earliest", # Use the earliest available date as the default time, OR:
   "default_time" : "2020-01-01",   # Use an explicitly defined date as the default time.
                                                # If the explicit date is NOT a valid date for the layer, a warning is raised, and 
                                                # the layer reverts to the default behaviour ("latest").
                                                # Note that this warning will be raised repeatedly on dynamic layers.
```
The default date is only published in metadata by WMS.

The default also applies to WMTS, and WCS1 requests with no user-selected time, but there is no way for a client to know what the default date is.

WCS2 requests with no dates select ALL available dates, as per the spec.