### PR TITLE
enable docker-compose to mnt external config

### DIFF
--- a/.env_ows_root
+++ b/.env_ows_root
@@ -6,11 +6,11 @@ DB_PORT=5432
 DB_USERNAME=opendatacubeusername
 DB_PASSWORD=opendatacubepassword
 DB_DATABASE=opendatacube
-OWS_CFG_FILE=/env/config/ows_refactored/ows_root_cfg.py
+OWS_CFG_FILE=ows_refactored/ows_root_cfg.py
 # OWS_CFG_FOLDER config enables mounting an external CFG folder
 OWS_CFG_FOLDER=~/dea-config/dev/services/wms/ows_refactored
 # OWS_CFG_CONTAINER_FOLDER defines the mount inside docker container
-OWS_CFG_CONTAINER_FOLDER=/env/config/ows_refactored
+OWS_CFG_COUNTAINER_FOLDER=/env/config/ows_refactored
 AWS_NO_SIGN_REQUEST=yes
 AWS_S3_ENDPOINT=
 # If you want to use pydev for interactive debugging

--- a/.env_ows_root
+++ b/.env_ows_root
@@ -6,11 +6,11 @@ DB_PORT=5432
 DB_USERNAME=opendatacubeusername
 DB_PASSWORD=opendatacubepassword
 DB_DATABASE=opendatacube
-OWS_CFG_FILE=ows_refactored/ows_root_cfg.py
+OWS_CFG_FILE=/env/config/ows_refactored/ows_root_cfg.py
 # OWS_CFG_FOLDER config enables mounting an external CFG folder
 OWS_CFG_FOLDER=~/dea-config/dev/services/wms/ows_refactored
-# OWS_CFG_COUNTAINER_FOLDER defines the mount inside docker container
-OWS_CFG_COUNTAINER_FOLDER=/env/config/ows_refactored
+# OWS_CFG_CONTAINER_FOLDER defines the mount inside docker container
+OWS_CFG_CONTAINER_FOLDER=/env/config/ows_refactored
 AWS_NO_SIGN_REQUEST=yes
 AWS_S3_ENDPOINT=
 # If you want to use pydev for interactive debugging

--- a/.env_ows_root
+++ b/.env_ows_root
@@ -6,7 +6,11 @@ DB_PORT=5432
 DB_USERNAME=opendatacubeusername
 DB_PASSWORD=opendatacubepassword
 DB_DATABASE=opendatacube
-OWS_CFG_FILE=./ows_refactored/dev_af_ows_root_cfg.py
+OWS_CFG_FILE=ows_refactored/ows_root_cfg.py
+# OWS_CFG_FOLDER config enables mounting an external CFG folder
+OWS_CFG_FOLDER=~/dea-config/dev/services/wms/ows_refactored
+# OWS_CFG_COUNTAINER_FOLDER defines the mount inside docker container
+OWS_CFG_COUNTAINER_FOLDER=/env/config/ows_refactored
 AWS_NO_SIGN_REQUEST=yes
 AWS_S3_ENDPOINT=
 # If you want to use pydev for interactive debugging
@@ -14,5 +18,5 @@ PYDEV_DEBUG=
 # Will not work with pydev
 FLASK_ENV=development
 prometheus_multiproc_dir=/tmp
-PYTHONPATH=/code
-DATACUBE_OWS_CFG=ows_refactored.dev_af_ows_root_cfg.ows_cfg
+PYTHONPATH=/env/config
+DATACUBE_OWS_CFG=ows_refactored.ows_root_cfg.ows_cfg

--- a/.env_simple
+++ b/.env_simple
@@ -6,11 +6,11 @@ DB_PORT=5432
 DB_USERNAME=opendatacubeusername
 DB_PASSWORD=opendatacubepassword
 DB_DATABASE=opendatacube
-OWS_CFG_FILE=/env/config/ows_test_cfg.py
+OWS_CFG_FILE=config/ows_test_cfg.py
 # OWS_CFG_FOLDER config enables mounting an external CFG folder
 OWS_CFG_FOLDER=./integration_tests/cfg
-# OWS_CFG_COUNTAINER_FOLDER defines the mount inside docker container
-OWS_CFG_COUNTAINER_FOLDER=/env/config
+# OWS_CFG_CONTAINER_FOLDER defines the mount inside docker container
+OWS_CFG_CONTAINER_FOLDER=/env/config
 AWS_NO_SIGN_REQUEST=yes
 AWS_S3_ENDPOINT=
 # If you want to use pydev for interactive debugging

--- a/.env_simple
+++ b/.env_simple
@@ -6,7 +6,11 @@ DB_PORT=5432
 DB_USERNAME=opendatacubeusername
 DB_PASSWORD=opendatacubepassword
 DB_DATABASE=opendatacube
-OWS_CFG_FILE=./integration_tests/cfg/ows_test_cfg.py
+OWS_CFG_FILE=config/ows_test_cfg.py
+# OWS_CFG_FOLDER config enables mounting an external CFG folder
+OWS_CFG_FOLDER=./integration_tests/cfg
+# OWS_CFG_COUNTAINER_FOLDER defines the mount inside docker container
+OWS_CFG_COUNTAINER_FOLDER=/env/config
 AWS_NO_SIGN_REQUEST=yes
 AWS_S3_ENDPOINT=
 # If you want to use pydev for interactive debugging
@@ -15,4 +19,4 @@ PYDEV_DEBUG=
 FLASK_ENV=development
 prometheus_multiproc_dir=/tmp
 PYTHONPATH=/env
-DATACUBE_OWS_CFG=config.ows_cfg.ows_cfg
+DATACUBE_OWS_CFG=config.ows_test_cfg.ows_cfg

--- a/.env_simple
+++ b/.env_simple
@@ -6,7 +6,7 @@ DB_PORT=5432
 DB_USERNAME=opendatacubeusername
 DB_PASSWORD=opendatacubepassword
 DB_DATABASE=opendatacube
-OWS_CFG_FILE=config/ows_test_cfg.py
+OWS_CFG_FILE=/env/config/ows_test_cfg.py
 # OWS_CFG_FOLDER config enables mounting an external CFG folder
 OWS_CFG_FOLDER=./integration_tests/cfg
 # OWS_CFG_COUNTAINER_FOLDER defines the mount inside docker container

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -24,7 +24,7 @@ services:
       DB_PASSWORD: ${DB_PASSWORD}
       DB_DATABASE: ${DB_DATABASE}
       # Where the config file is (must match the volume mount)
-      WMS_CONFIG_PATH: ${OWS_CFG_FILE}
+      WMS_CONFIG_PATH: /env/config/${OWS_CFG_FILE}
       # Path from the PYTHONPATH to the config object (default PYTHONPATH is /env)
       PYTHONPATH: ${PYTHONPATH}
       DATACUBE_OWS_CFG: ${DATACUBE_OWS_CFG}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -24,7 +24,7 @@ services:
       DB_PASSWORD: ${DB_PASSWORD}
       DB_DATABASE: ${DB_DATABASE}
       # Where the config file is (must match the volume mount)
-      WMS_CONFIG_PATH: /env/config/${OWS_CFG_FILE}
+      WMS_CONFIG_PATH: ${OWS_CFG_FILE}
       # Path from the PYTHONPATH to the config object (default PYTHONPATH is /env)
       PYTHONPATH: ${PYTHONPATH}
       DATACUBE_OWS_CFG: ${DATACUBE_OWS_CFG}
@@ -40,7 +40,7 @@ services:
     ports:
       - "8000:8000"
     volumes:
-      - ${OWS_CFG_FOLDER}:${OWS_CFG_COUNTAINER_FOLDER}
+      - ${OWS_CFG_FOLDER}:${OWS_CFG_CONTAINER_FOLDER}
       - ./docker/ows/wait-for-db:/usr/local/bin/wait-for-db
       - ./:/code/
       - ./artifacts:/mnt/artifacts

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -24,7 +24,7 @@ services:
       DB_PASSWORD: ${DB_PASSWORD}
       DB_DATABASE: ${DB_DATABASE}
       # Where the config file is (must match the volume mount)
-      WMS_CONFIG_PATH: /env/config/ows_cfg.py
+      WMS_CONFIG_PATH: /env/config/${OWS_CFG_FILE}
       # Path from the PYTHONPATH to the config object (default PYTHONPATH is /env)
       PYTHONPATH: ${PYTHONPATH}
       DATACUBE_OWS_CFG: ${DATACUBE_OWS_CFG}
@@ -40,7 +40,7 @@ services:
     ports:
       - "8000:8000"
     volumes:
-      - ${OWS_CFG_FILE}:/env/config/ows_cfg.py
+      - ${OWS_CFG_FOLDER}:${OWS_CFG_COUNTAINER_FOLDER}
       - ./docker/ows/wait-for-db:/usr/local/bin/wait-for-db
       - ./:/code/
       - ./artifacts:/mnt/artifacts

--- a/docs/environment_variables.rst
+++ b/docs/environment_variables.rst
@@ -107,3 +107,18 @@ Docker and Docker-compose
 The provided ``Dockerfile`` and ``docker-compose.yaml`` read additional
 environment variables at build time.  Please refer to the `README <https://datacube-ows.readthedocs.io/en/latest/readme.html>`_
 for further details.
+
+environment variables exclusive for docker-compose
+--------------------------------------------------
+OWS_CFG_FILE:
+    for multiple files ows config structure, the root level ows config file path inside docker container
+    for single file ows config structure, the ows config file path inside docker container
+
+OWS_CFG_FOLDER:
+    path to a folder containing ows config files anywhere on the local machine
+
+OWS_CFG_COUNTAINER_FOLDER:
+    path the OWS_CFG_FOLDER will mount to inside docker container
+
+PYTHONPATH:
+    PYTHONPATH to ows config file


### PR DESCRIPTION
- we have been copying the `ows_refactored` folder into `datacube-ows` to start docker-compose and then copy the changes back to `dea-config` git clone to make the pr, this pr resolves the double handling and mounts external cfg folder directly.