### PR TITLE
More refactoring.

### DIFF
--- a/datacube_ows/ows_cfg_example.py
+++ b/datacube_ows/ows_cfg_example.py
@@ -8,91 +8,10 @@
 
 # Example configuration file for datacube_ows.
 #
-# For detailed formal documentation see:
+# For detailed and up to date formal documentation see:
 #
 #   https://datacube-ows.readthedocs.io/en/latest/configuration.html
-#
-# OVERVIEW
-#
-# This file forms the primary documentation for the configuration file format at this stage.
-#
-# The actual configuration is held in a single serialisable object that can be directly
-# declared as a python object or imported from JSON.
-#
-# WHERE IS CONFIGURATION READ FROM?
-#
-# Configuration is read by default from the ows_cfg object in datacube_ows/ows_cfg.py
-#
-# but this can be overridden by setting the $DATACUBE_OWS_CFG environment variable.
-#
-# $DATACUBE_OWS_CFG is interpreted as follows (first matching alternative applies):
-#
-# 1. Has a leading slash, e.g. "/opt/odc_ows_cfg/odc_ows_cfg_prod.json"
-#    Config loaded as json from absolute file path.
-#
-# 2. Contains a slash, e.g. "configs/prod.json"
-#    Config loaded as json from relative file path.
-#
-# 3. Begins with an open brace "{", e.g. "{...}"
-#    Config loaded directly from the environment variable as json (not recommended)
-#
-# 4. Ends in ".json", e.g. "cfg_prod.json"
-#    Config loaded as json from file in working directory.
-#
-# 5. Contains a dot (.), e.g. "package.sub_package.module.cfg_object_name"
-#    Imported as python object (expected to be a dictionary).
-#    N.B. It is up to you that the Python file in question is in your Python path.
-#
-# 6. Valid python object name, e.g. "cfg_prod"
-#    Imported as python object from named object in datacube_ows/ows_cfg.py
-#
-# 7. Blank or not set
-#    Default to import ows_cfg object in datacube_ows/ows_cfg.py as described above.
-#
-# REUSING CHUNKS OF CONFIGURATION
-#
-# Often it is desirable to re-use chunks of configuration in multiple places.  E.g. a set
-# of related data products may share a band index or style definition configurations.
-#
-# If you are loading config as a Python object, this is trivial, as demonstrated in this
-# example file.
-#
-# If you want to reuse chunks of config in json, or wish to combine bits of json config
-# with bits of python config, the following convention applies in both Python and JSON
-# configuration:
-#
-# Any JSON or Python element that forms the full configuration tree or a subset of it,
-# can be supplied in any of the following ways:
-#
-# 1. Directly embed the config content:
-#       {
-#           "a_cfg_entry": 1,
-#           "another_entry": "llama",
-#       }
-#
-# 2. Include a python object (by FQN):
-#       {
-#           "include": "path.to.module.object",
-#           "type": "python"
-#       }
-#
-#       N.B. It is up to you to make sure the included Python file is in your Python Path.
-#            Relative Python imports are not supported.
-#
-# 3. Include a JSON file (by absolute or relative file path):
-#       {
-#           "include": "path/to/file.json",
-#           "type": "json"
-#       }
-#
-#       N.B. Resolution of relative file paths is done in the following order:
-#           a) Relative to the working directory of the web app.
-#           b) If a JSON file is being included from another JSON file, relative to
-#              directory in which the including file resides.
-#
-# Note that this does not just apply to dictionaries. Either of the above include dictionaries
-# could expand to an array, or even to single integer or string.
-#
+
 # THIS EXAMPLE FILE
 #
 # In this example file, there are some reusable code chunks defined at the top.  The actual
@@ -1787,6 +1706,18 @@ ows_cfg = {
                     # * "month" (for monthly summary datasets)
                     # * "year" (for annual summary datasets)
                     "time_resolution": "raw",
+                    # The "native" CRS.  (as used for resource management calculations and WCS metadata)
+                    # (Used for resource management calculations and WCS metadata)
+                    # Must be in the global "published_CRSs" list.
+                    # Can be omitted if the product has a single native CRS, as this will be used in preference.
+                    "native_crs": "EPSG:3577",
+                    # The native resolution (x,y)
+                    # (Used for resource management calculations and WCS metadata)
+                    # This is the number of CRS units (e.g. degrees, metres) per pixel in the horizontal
+                    # and vertical directions for the native CRS.
+                    # Can be omitted if the product has a single native resolution, as this will be used in preference.
+                    # E.g. for EPSG:3577; (25.0,25.0) for Landsat-8 and (10.0,10.0 for Sentinel-2)
+                    "native_resolution": [25.0, 25.0],
                     "flags": {
                         # Data may include flags that mark which pixels have missing or poor-quality data,
                         # or contain cloud, or cloud-shadow, etc.  This section describes how
@@ -1875,14 +1806,7 @@ ows_cfg = {
                     # If the WCS section is not supplied, then this named layer will NOT appear as a WCS
                     # coverage (but will still be a layer in WMS and WMTS).
                     "wcs": {
-                        # The "native" CRS for WCS. Must be in the global "published_CRSs" list.
-                        # Can be omitted if the product has a single native CRS, as this will be used in preference.
-                        "native_crs": "EPSG:3577",
-                        # The resolution (x,y) for WCS.  Required for WCS-enabled layers.
-                        # This is the number of CRS units (e.g. degrees, metres) per pixel in the horizontal
-                        # and vertical # directions for the native resolution.
-                        # E.g. for EPSG:3577; (25.0,25.0) for Landsat-8 and (10.0,10.0 for Sentinel-2)
-                        "native_resolution": [25.0, 25.0],
+
                         # The default bands for a WCS request.
                         # 1. Must be provided if WCS is activated.
                         # 2. Must contain at least one band.
@@ -1997,6 +1921,7 @@ ows_cfg = {
                     "product_name": "ls8_level1_usgs",
                     "bands": landsat8_bands,
                     "resource_limits": standard_resource_limits,
+                    # native_crs and native_resolution taken from product meta-data
                     "flags": {
                         "band": "quality",
                         "ignore_time": False,
@@ -2022,8 +1947,6 @@ ows_cfg = {
                         "apply_solar_corrections": True
                     },
                     "wcs": {
-                        "native_crs": "EPSG:3857",
-                        "native_resolution": [25.0, 25.0],
                         "default_bands": ["red", "green", "blue"],
                     },
                     "styling": {
@@ -2050,13 +1973,13 @@ ows_cfg = {
                     "bands": {"frequency": []},
                     "resource_limits": standard_resource_limits,
                     "flags": None,
+                    "native_crs": "EPSG:3857",
+                    "native_resolution": [25.0, 25.0],
                     "image_processing": {
                         "extent_mask_func": "datacube_ows.ogc_utils.mask_by_val",
                         "fuse_func": "datacube_ows.wms_utils.wofls_fuser",
                     },
                     "wcs": {
-                        "native_crs": "EPSG:3857",
-                        "native_resolution": [25.0, 25.0],
                         "default_bands": ["frequency"],
                     },
                     "styling": {
@@ -2090,6 +2013,8 @@ ows_cfg = {
                     "resource_limits": standard_resource_limits,
                     # Near Real Time datasets are being regularly updated - do not cache ranges in memory.
                     "dynamic": True,
+                    "native_crs": "EPSG:3577",
+                    "native_resolution": [10.0, 10.0],
                     "flags": {
                         "band": "quality",
                         "ignore_time": False,
@@ -2104,8 +2029,6 @@ ows_cfg = {
                         "apply_solar_corrections": False,
                     },
                     "wcs": {
-                        "native_crs": "EPSG:3577",
-                        "native_resolution": [10.0, 10.0],
                         "default_bands": ["red", "green", "blue"],
                     },
                     "identifiers": {
@@ -2150,8 +2073,6 @@ ows_cfg = {
                 "apply_solar_corrections": False,
             },
             "wcs": {
-                "native_crs": "EPSG:3577",
-                "native_resolution": [25.0, 25.0],
                 "default_bands": ["canopy_cover_class"],
             },
             "identifiers": {

--- a/datacube_ows/ows_configuration.py
+++ b/datacube_ows/ows_configuration.py
@@ -377,6 +377,10 @@ class OWSNamedLayer(OWSExtensibleConfigEntry, OWSLayer):
         self.declare_unready("bboxes")
         # TODO: sub-ranges
         self.band_idx = BandIndex(self, cfg.get("bands"))
+        self.cfg_native_resolution = cfg.get("native_resolution")
+        self.cfg_native_crs = cfg.get("native_crs")
+        self.declare_unready("resolution_x")
+        self.declare_unready("resolution_y")
         self.resource_limits = OWSResourceManagementRules(cfg.get("resource_limits", {}), f"Layer {self.name}")
         try:
             self.parse_flags(cfg.get("flags", {}))
@@ -451,6 +455,7 @@ class OWSNamedLayer(OWSExtensibleConfigEntry, OWSLayer):
                 raise ConfigException(f"Duplicate flag band name: {fb.pq_band}")
             self.all_flag_band_names.add(fb.pq_band)
         self.ready_image_processing(dc)
+        self.ready_native_specs()
         if self.global_cfg.wcs:
             self.ready_wcs(dc)
         for style in self.styles:
@@ -538,22 +543,40 @@ class OWSNamedLayer(OWSExtensibleConfigEntry, OWSLayer):
 
     # pylint: disable=attribute-defined-outside-init
     def parse_wcs(self, cfg):
-        if cfg is None:
+        if cfg is None or not self.global_cfg.wcs:
             self.wcs = False
             return
         else:
             self.wcs = True
+
+        if "native_resolution" in cfg:
+            if not self.cfg_native_resolution:
+                _LOG.warning(
+                    "Specifying native_resolution in wcs section of layer %s is now deprecated, please move to " +
+                    "main layer section if required.", self.name)
+                self.cfg_native_resolution = cfg.get("native_resolution")
+            else:
+                _LOG.warning(
+                    "Native_resolution in wcs section of layer %s ignored in favour of value in " +
+                    "main layer section.", self.name)
+
         # Native CRS
-        self.cfg_native_crs = cfg.get("native_crs")
+        if "native_crs" in cfg:
+            if not self.cfg_native_crs:
+                _LOG.warning("Specifying native_crs in wcs section of layer %s is now deprecated, pleas move to " +
+                             "main layer section if required", self.name)
+                self.cfg_native_crs = cfg["native_crs"]
+            else:
+                _LOG.warning(
+                    "native_crs in wcs section of layer %s ignored in favour of value in " +
+                    "main layer section.", self.name)
+
         self.declare_unready("native_CRS")
         self.declare_unready("native_CRS_def")
 
         # Rectified Grids
         self.declare_unready("origin_x")
         self.declare_unready("origin_y")
-        self.cfg_native_resolution = cfg.get("native_resolution")
-        self.declare_unready("resolution_x")
-        self.declare_unready("resolution_y")
         self.declare_unready("grid_high_x")
         self.declare_unready("grid_high_y")
         self.declare_unready("grids")
@@ -570,26 +593,67 @@ class OWSNamedLayer(OWSExtensibleConfigEntry, OWSLayer):
             self.native_format = self.global_cfg.native_wcs_format
 
     # pylint: disable=attribute-defined-outside-init
+    def ready_native_specs(self):
+        # Native CRS
+        try:
+            self.native_CRS = self.product.definition["storage"]["crs"]
+            if self.cfg_native_crs == self.native_CRS:
+                _LOG.debug(
+                    "Native crs for layer %s is specified in ODC metadata and does not need to be specified in configuration",
+                    self.name)
+            else:
+                _LOG.warning("Native crs for layer %s is specified in config as %s - overridden to %s by ODC metadata",
+                             self.name, self.cfg_native_crs, self.native_CRS)
+        except KeyError:
+            self.native_CRS = self.cfg_native_crs
+
+        if not self.native_CRS:
+            raise ConfigException(f"No native CRS could be found for layer {self.name}")
+        if self.native_CRS not in self.global_cfg.published_CRSs:
+            raise ConfigException(
+                f"Native CRS for product {self.product_name} in layer {self.name} ({self.native_CRS}) not in published CRSs")
+        self.native_CRS_def = self.global_cfg.published_CRSs[self.native_CRS]
+
+        try:
+            # Native CRS
+            self.resolution_x = self.product.definition["storage"]["resolution"][
+                self.native_CRS_def["horizontal_coord"]]
+            self.resolution_y = self.product.definition["storage"]["resolution"][self.native_CRS_def["vertical_coord"]]
+        except KeyError:
+            self.resolution_x = None
+            self.resolution_y = None
+
+        if self.resolution_x is None:
+            try:
+                if self.cfg_native_resolution is None:
+                    raise KeyError
+                self.resolution_x, self.resolution_y = self.cfg_native_resolution
+            except KeyError:
+                raise ConfigException(
+                    f"No native resolution supplied for layer {self.name} with no product-native resolution defined in ODC."
+                )
+            except ValueError:
+                raise ConfigException(f"Invalid native resolution supplied for layer {self.name}")
+            except TypeError:
+                raise ConfigException(f"Invalid native resolution supplied for layer {self.name}")
+        elif self.cfg_native_resolution:
+            config_x, config_y = (float(r) for r in self.cfg_native_resolution)
+            if (
+                    math.isclose(config_x, float(self.resolution_x), rel_tol=1e-8)
+                    and math.isclose(config_y, float(self.resolution_y), rel_tol=1e-8)
+            ):
+                _LOG.debug(
+                    "Native resolution for layer %s is specified in ODC metadata and does not need to be specified in configuration",
+                    self.name)
+            else:
+                _LOG.warning(
+                    "Native resolution for layer %s is specified in config as %s - overridden to (%.15f, %.15f) by ODC metadata",
+                    self.name, repr(self.cfg_native_resolution), self.resolution_x, self.resolution_y)
+
+    # pylint: disable=attribute-defined-outside-init
     def ready_wcs(self, dc):
         if self.global_cfg.wcs and self.wcs:
-            # Native CRS
-            try:
-                self.native_CRS = self.product.definition["storage"]["crs"]
-                if self.cfg_native_crs == self.native_CRS:
-                    _LOG.debug(
-                        "Native crs for layer %s is specified in ODC metadata and does not need to be specified in configuration",
-                        self.name)
-                else:
-                    _LOG.warning("Native crs for layer %s is specified in config as %s - overridden to %s by ODC metadata",
-                                 self.name, self.cfg_native_crs, self.native_CRS)
-            except KeyError:
-                self.native_CRS = self.cfg_native_crs
 
-            if not self.native_CRS:
-                raise ConfigException(f"No native CRS could be found for layer {self.name}")
-            if self.native_CRS not in self.global_cfg.published_CRSs:
-                raise ConfigException(f"Native CRS for product {self.product_name} in layer {self.name} ({self.native_CRS}) not in published CRSs")
-            self.native_CRS_def = self.global_cfg.published_CRSs[self.native_CRS]
             # Prepare Rectified Grids
             try:
                 native_bounding_box = self.bboxes[self.native_CRS]
@@ -603,38 +667,6 @@ class OWSNamedLayer(OWSExtensibleConfigEntry, OWSLayer):
             self.origin_x = native_bounding_box["left"]
             self.origin_y = native_bounding_box["bottom"]
 
-            try:
-                self.resolution_x = self.product.definition["storage"]["resolution"][
-                    self.native_CRS_def["horizontal_coord"]]
-                self.resolution_y = self.product.definition["storage"]["resolution"][self.native_CRS_def["vertical_coord"]]
-            except KeyError:
-                self.resolution_x = None
-                self.resolution_y = None
-
-            if self.resolution_x is None:
-                try:
-                    if self.cfg_native_resolution is None:
-                        raise KeyError
-                    self.resolution_x, self.resolution_y = self.cfg_native_resolution
-                except KeyError:
-                    raise ConfigException(f"No native resolution supplied for WCS enabled layer {self.name}")
-                except ValueError:
-                    raise ConfigException(f"Invalid native resolution supplied for WCS enabled layer {self.name}")
-                except TypeError:
-                    raise ConfigException(f"Invalid native resolution supplied for WCS enabled layer {self.name}")
-            elif self.cfg_native_resolution:
-                config_x, config_y = (float(r) for r in self.cfg_native_resolution)
-                if (
-                        math.isclose(config_x, float(self.resolution_x), rel_tol=1e-8)
-                        and math.isclose(config_y, float(self.resolution_y), rel_tol=1e-8)
-                ):
-                    _LOG.debug(
-                        "Native resolution for layer %s is specified in ODC metadata and does not need to be specified in configuration",
-                        self.name)
-                else:
-                    _LOG.warning(
-                        "Native resolution for layer %s is specified in config as %s - overridden to (%.15f, %.15f) by ODC metadata",
-                        self.name, repr(self.cfg_native_resolution), self.resolution_x, self.resolution_y)
 
             if (native_bounding_box["right"] - native_bounding_box["left"]) < self.resolution_x:
                 ConfigException(

--- a/datacube_ows/ows_configuration.py
+++ b/datacube_ows/ows_configuration.py
@@ -552,23 +552,23 @@ class OWSNamedLayer(OWSExtensibleConfigEntry, OWSLayer):
         if "native_resolution" in cfg:
             if not self.cfg_native_resolution:
                 _LOG.warning(
-                    "Specifying native_resolution in wcs section of layer %s is now deprecated, please move to " +
+                    "Specifying native_resolution in wcs section of layer %s is now deprecated, please move to " \
                     "main layer section if required.", self.name)
                 self.cfg_native_resolution = cfg.get("native_resolution")
             else:
                 _LOG.warning(
-                    "Native_resolution in wcs section of layer %s ignored in favour of value in " +
+                    "Native_resolution in wcs section of layer %s ignored in favour of value in " \
                     "main layer section.", self.name)
 
         # Native CRS
         if "native_crs" in cfg:
             if not self.cfg_native_crs:
-                _LOG.warning("Specifying native_crs in wcs section of layer %s is now deprecated, pleas move to " +
+                _LOG.warning("Specifying native_crs in wcs section of layer %s is now deprecated, pleas move to " \
                              "main layer section if required", self.name)
                 self.cfg_native_crs = cfg["native_crs"]
             else:
                 _LOG.warning(
-                    "native_crs in wcs section of layer %s ignored in favour of value in " +
+                    "native_crs in wcs section of layer %s ignored in favour of value in " \
                     "main layer section.", self.name)
 
         self.declare_unready("native_CRS")

--- a/datacube_ows/resource_limits.py
+++ b/datacube_ows/resource_limits.py
@@ -1,7 +1,50 @@
-from typing import List, Mapping, Optional, cast
+import numpy as np
 
+from typing import Any, Iterable, List, Mapping, Optional, Tuple, Union, cast
+
+from datacube.utils.geometry import CRS, polygon
 from datacube_ows.config_utils import CFG_DICT, RAW_CFG, OWSConfigEntry
 from datacube_ows.ogc_utils import ConfigException
+
+
+class RequestScale:
+    def __init__(self,
+                 native_crs: CRS,
+                 native_resolution: Tuple[Union[float, int], Union[float, int]],
+                 pixel_size: Tuple[int, int],
+                 n_dates: int,
+                 request_bands: Optional[Iterable[Mapping[str, Any]]] = None,
+                 total_band_size: Optional[int] = None) -> None:
+        self.resolution = self._metre_resolution(native_crs, native_resolution)
+        self.crs = native_crs
+        self.pixel_size = pixel_size
+        self.n_dates = n_dates
+        self.bands = request_bands
+        assert (request_bands is not None) ^ (total_band_size is not None)
+        if total_band_size is not None:
+            self.total_band_size = total_band_size
+        else:
+            self.total_band_size = sum(np.dtype(band['dtype']).itemsize for band in request_bands)
+        self.scale_factor: float = (float(self.n_dates) * self.pixel_size[0] * self.pixel_size[1] *
+                                    self.total_band_size / self.resolution[0] / self.resolution[1])
+
+    def _metre_resolution(self, crs, resolution):
+        # Convert native resolution to metres for ready comparison.
+        if crs.units == ('metre', 'metre'):
+            return [abs(r) for r in resolution]
+        resolution_rectangle = polygon(
+                            ((0, 0), (0, resolution[1]), resolution, (0, resolution[0]), (0, 0)),
+                            crs=crs)
+        proj_bbox = resolution_rectangle.to_crs("EPSG:3857").boundingbox
+        return (
+            abs(proj_bbox.right - proj_bbox.left),
+            abs(proj_bbox.top - proj_bbox.bottom),
+        )
+
+
+RequestScale.standard_scale = RequestScale(CRS("EPSG:3857"), (25.0, 25.0),
+                                           (256, 256), 1,
+                                           total_band_size=(3 * 2))
 
 
 class CacheControlRules(OWSConfigEntry):

--- a/docs/cfg_layers.rst
+++ b/docs/cfg_layers.rst
@@ -399,6 +399,51 @@ Band aliases are useful:
 * when you wish to share configuration chunks that reference
   bands between layers but the native band names do not match.
 
+------------------------------------------------------------------------------------
+Native Coordinate Reference System and resolution (native_crs and native_resolution)
+------------------------------------------------------------------------------------
+
+In many cases, OWS can determine the native coordinate system
+ans resolution directly from the ODC metadata. In such cases
+they need not be explicitly provided (and indeed, will be ignored
+if they are.)
+
+However some ODC products do not have a product wide CRS,
+but rather define a native CRS from for each dataset from a family
+of related CRSs. (e.g. Sentinel-2 data is usually packaged like this.)
+In this case you must manually declare a "native" CRS. Similarly,
+if the native resolution is included in product-level metadata in
+the ODC, it must be declared explicitly.
+
+The "native" CRS and resolution
+allows OWS to treat the entire layer as a single coverage, and
+are used for calculating request resource limits.
+
+The native_crs can be any CRS
+declared in the `global published_CRSs section
+<https://datacube-ows.readthedocs.io/en/latest/cfg_global.html#co-ordinate-reference-systems-published-crss>`_
+and need not be related to the CRSs that the data is actually
+stored in.
+
+The native_resolution is
+the number of native CRS units (e.g. degrees, metres) per pixel in
+the horizontal and vertical directions.
+
+E.g. for EPSG:3577 (measured in metres) you would use (25.0, 25.0)
+for Landsat and (10.0, 10.0) for Sentinel-2.
+
+Depending on the native CRS and the way the data has been processed,
+Landsat resolution may be closer to 30m. If the native CRS is measured
+in degrees, then the native resolution must also be measured in
+degrees, not metres.
+
+E.g.
+
+::
+
+        "native_crs": "EPSG:3577",
+        "native_resolution": [25.0, 25.0],
+
 ---------------------------------
 Resource Limits (resource_limits)
 ---------------------------------
@@ -879,50 +924,8 @@ E.g.
 ::
 
     "wcs": {
-        "native_crs": "EPSG:3577",
-        "native_resolution": [25.0, 25.0],
         "default_bands": ["red", "green", "blue"]
     }
-
-Native Coordinate Reference System (native_crs)
-+++++++++++++++++++++++++++++++++++++++++++++++
-
-In many cases, OWS can determine the native coordinate system
-directly from the ODC metadata. In such cases the native_crs
-need not be explicitly provided (and indeed, will be ignored
-if it is.)
-
-However some ODC products do not have a product wide CRS, but
-rather define a native CRS from for each dataset from a family
-of related CRSs. (e.g.
-Sentinel-2 data is usually packaged like this.)  In this case
-you must manually declare a "native" CRS (if WCS is active).
-This can be any CRS
-declared in the `global published_CRSs section
-<https://datacube-ows.readthedocs.io/en/latest/cfg_global.html#co-ordinate-reference-systems-published-crss>`_
-and need not be related to the CRSs that the data is actually
-stored in.
-
-Native Resolution (native_resolution)
-+++++++++++++++++++++++++++++++++++++
-
-In many cases, OWS can determine the native resolution
-directly from the ODC metadata. In such cases the native_resolution
-need not be explicitly provided (and indeed, will be ignored
-if it is.)
-
-A native_resolution is required for WCS-enabled layers where
-is cannot be determined from ODC metadata.  It is
-the number of native CRS units (e.g. degrees, metres) per pixel in
-the horizontal and vertical directions.
-
-E.g. for EPSG:3577 (measured in metres) you would use (25.0, 25.0)
-for Landsat and (10.0, 10.0) for Sentinel-2.
-
-Depending on the native CRS and the way the data has been processed,
-Landsat resolution may be closer to 30m. If the native CRS is measured
-in degrees, then the native resolution must also be measured in
-degrees, not metres.
 
 Default WCS Bands (default_bands)
 +++++++++++++++++++++++++++++++++

--- a/integration_tests/cfg/ows_test_cfg.py
+++ b/integration_tests/cfg/ows_test_cfg.py
@@ -678,6 +678,8 @@ ows_cfg = {
                     "user_band_math": True,
                     "bands": ls8_usgs_level1_bands,
                     "resource_limits": standard_resource_limits,
+                    "native_crs": "EPSG:4326",
+                    "native_resolution": [0.000225, 0.000225],
                     "flags": [
                         {
                             "band": "quality",
@@ -706,8 +708,6 @@ ows_cfg = {
                         "apply_solar_corrections": True,
                     },
                     "wcs": {
-                        "native_crs": "EPSG:4326",
-                        "native_resolution": [0.000225, 0.000225],
                         "default_bands": ["red", "green", "blue"],
                     },
                     "styling": {
@@ -760,6 +760,8 @@ For service status information, see https://status.dea.ga.gov.au
                     "product_name": "ls5_fc_albers",
                     "bands": bands_fc,
                     "resource_limits": reslim_aster,
+                    "native_crs": "EPSG:3577",
+                    "native_resolution": [25, -25],
                     "image_processing": {
                         "extent_mask_func": "datacube_ows.ogc_utils.mask_by_val",
                         "always_fetch_bands": [],
@@ -775,9 +777,7 @@ For service status information, see https://status.dea.ga.gov.au
                         },
                     ],
                     "wcs": {
-                        "native_crs": "EPSG:3577",
                         "default_bands": ["BS", "PV", "NPV"],
-                        "native_resolution": [25, -25],
                     },
                     "styling": {
                         "default_style": "simple_fc",
@@ -799,6 +799,8 @@ For service status information, see https://status.dea.ga.gov.au
                     "bands": bands_wofs_obs,
                     "resource_limits": reslim_wofs_obs,
                     "dynamic": True,
+                    "native_crs": "EPSG:3577",
+                    "native_resolution": [25, -25],
                     "image_processing": {
                         "extent_mask_func": "datacube_ows.ogc_utils.mask_by_bitflag",
                         "always_fetch_bands": [],
@@ -806,8 +808,6 @@ For service status information, see https://status.dea.ga.gov.au
                         "fuse_func": "datacube_ows.wms_utils.wofls_fuser",
                     },
                     "wcs": {
-                        "native_crs": "EPSG:3577",
-                        "native_resolution": [25, -25],
                         "default_bands": ["water"],
                     },
                     "styling": {
@@ -829,6 +829,8 @@ For service status information, see https://status.dea.ga.gov.au
                     "bands": bands_fc,
                     "resource_limits": reslim_aster,
                     "dynamic": True,
+                    "native_crs": "EPSG:3577",
+                    "native_resolution": [25, -25],
                     "image_processing": {
                         "extent_mask_func": "datacube_ows.ogc_utils.mask_by_val",
                         "always_fetch_bands": [],
@@ -844,9 +846,7 @@ For service status information, see https://status.dea.ga.gov.au
                         },
                     ],
                     "wcs": {
-                        "native_crs": "EPSG:3577",
                         "default_bands": ["BS", "PV", "NPV"],
-                        "native_resolution": [25, -25],
                     },
                     "styling": {
                         "default_style": "simple_fc",
@@ -869,6 +869,8 @@ For service status information, see https://status.dea.ga.gov.au
                     "bands": bands_fc,
                     "resource_limits": reslim_aster,
                     "dynamic": True,
+                    "native_crs": "EPSG:3577",
+                    "native_resolution": [25, -25],
                     "image_processing": {
                         "extent_mask_func": "datacube_ows.ogc_utils.mask_by_val",
                         "always_fetch_bands": [],
@@ -884,9 +886,7 @@ For service status information, see https://status.dea.ga.gov.au
                         },
                     ],
                     "wcs": {
-                        "native_crs": "EPSG:3577",
                         "default_bands": ["BS", "PV", "NPV"],
-                        "native_resolution": [25, -25],
                     },
                     "styling": {
                         "default_style": "simple_fc",
@@ -910,6 +910,8 @@ Fractional Cover version 2.2.1, 25 metre, 100km tile, Australian Albers Equal Ar
                     "bands": bands_fc,
                     "resource_limits": reslim_aster,
                     "dynamic": True,
+                    "native_crs": "EPSG:3577",
+                    "native_resolution": [25, -25],
                     "image_processing": {
                         "extent_mask_func": "datacube_ows.ogc_utils.mask_by_val",
                         "always_fetch_bands": [],
@@ -925,9 +927,7 @@ Fractional Cover version 2.2.1, 25 metre, 100km tile, Australian Albers Equal Ar
                         },
                     ],
                     "wcs": {
-                        "native_crs": "EPSG:3577",
                         "default_bands": ["BS", "PV", "NPV"],
-                        "native_resolution": [25, -25],
                     },
                     "styling": {
                         "default_style": "simple_fc",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -159,7 +159,7 @@ def minimal_dc():
         elif 'nativecrs' in s:
             mprod.definition["storage"]["crs"] = "EPSG:4326"
         else:
-            pass
+            mprod.definition["storage"]["crs"] = "EPSG:4326"
         if 'nonativeres' in s:
             pass
         elif 'nativeres' in s:
@@ -168,7 +168,10 @@ def minimal_dc():
                 "longitude": 0.001,
             }
         else:
-            pass
+            mprod.definition["storage"]["resolution"] = {
+                "latitude": 0.001,
+                "longitude": 0.001,
+            }
         return mprod
     dc.index.products.get_by_name = product_by_name
     return dc


### PR DESCRIPTION
Move native_crs and native_resolution from wcs config into main layer config.

Needed because they will be required for WMS-only deployments under the planned resource management overhaul.

Backwards incompatibility: 

> Layers with no CRS and/or resolution defined in the ODC product metadata now ALWAYS require a native CRS and resolution to be defined in configuration.  This was previously only the case if WCS was enabled for the layer.