### PR TITLE
Remove "experimental" warning on animations.

### DIFF
--- a/datacube_ows/styles/base.py
+++ b/datacube_ows/styles/base.py
@@ -454,9 +454,6 @@ class StyleDefBase(OWSExtensibleConfigEntry, OWSMetadataConfig):
                 raise ConfigException("multi_date handler allowed_count_range: minimum must be less than equal to maximum")
 
             self.animate = cast(bool, cfg.get("animate", False))
-            if self.animate:
-                _LOG.warning("animations are experimental, use at your own risk")
-
             self.frame_duration: int = 1000
             if "aggregator_function" in cfg:
                 self.aggregator = FunctionWrapper(style.product,


### PR DESCRIPTION
With "adjusted zoom level" resource management, animations no longer need to be considered experimental.

(On the server side, still waiting for clients to catch up.)