### PR TITLE
Change default behaviour of AWS_NO_SIGN_REQUEST to match everything else

### DIFF
--- a/docs/environment_variables.rst
+++ b/docs/environment_variables.rst
@@ -53,9 +53,10 @@ AWS_NO_SIGN_REQUEST:
     S3 access will be unsigned if this environment variable is set
     to "y", "t", "yes", "true" or "1".
 
-    If requests are signed then the ``$AWS_ACCESS_KEY_ID``
-    ``$AWS_SECRET_ACCESS_KEY`` environment variables must be
-    set - refer to the boto3 documentation for more information).
+    If requests are signed then you will also need to ensure that
+    boto3 has access to appropriate AWS credentials - typically
+    the ``$AWS_ACCESS_KEY_ID`` and ``$AWS_SECRET_ACCESS_KEY`` environment
+    variables.
 
     N.B. Signed requests are the default behaviour - explicitly
     set ``$AWS_NO_SIGN_REQUEST`` to 'yes' to use unsigned request.

--- a/docs/environment_variables.rst
+++ b/docs/environment_variables.rst
@@ -51,13 +51,16 @@ AWS_DEFAULT_REGION:
 
 AWS_NO_SIGN_REQUEST:
     S3 access will be unsigned if this environment variable is set
-    to a non-empty value other than "n", "f", "no", "false" or "0".
+    to "y", "t", "yes", "true" or "1".
 
-    N.B. Unsigned requests is the default behaviour - explicitly
-    set ``$AWS_NO_SIGN_REQUEST`` to an empty string to sign requests
-    (and set the ``$AWS_ACCESS_KEY_ID`` and
-    ``$AWS_SECRET_ACCESS_KEY`` environment variables - refer to
-    the boto3 documentation for more information).
+    If requests are signed then the ``$AWS_ACCESS_KEY_ID``
+    ``$AWS_SECRET_ACCESS_KEY`` environment variables must be
+    set - refer to the boto3 documentation for more information).
+
+    N.B. Signed requests are the default behaviour - explicitly
+    set ``$AWS_NO_SIGN_REQUEST`` to 'yes' to use unsigned request.
+    The default behaviour for this variable changed in version 1.8.17.
+
 
 AWS_REQUEST_PAYER:
     Set to "requester" if accessing requester-pays S3 buckets.

--- a/tests/test_startup.py
+++ b/tests/test_startup.py
@@ -21,7 +21,7 @@ def test_fake_creds(monkeypatch):
         s3a.return_value = None
         initialise_aws_credentials()
         assert os.getenv("AWS_NO_SIGN_REQUEST") is None
-        monkeypatch.setenv("AWS_NO_SIGN_REQUEST", "indubitably")
+        monkeypatch.setenv("AWS_NO_SIGN_REQUEST", "yes")
         initialise_aws_credentials()
         assert os.getenv("AWS_ACCESS_KEY_ID") == "fake"
 


### PR DESCRIPTION
Default behaviour (AWS_NO_SIGN_REQUEST) now matches boto3 conventions.  (i.e. default behaviour = signed requests).

A warning message is logged if the `$AWS_NO_SIGN_REQUEST` variable does not exist.

Default previously was unsigned requests for some reason I've now forgotten.