### PR TITLE
Fix WCS for queries against layers with flag band in the main product.

### DIFF
--- a/datacube_ows/data.py
+++ b/datacube_ows/data.py
@@ -180,7 +180,7 @@ class DataStacker:
             queries = ProductBandQuery.full_layer_queries(self._product, self.needed_bands())
         else:
             # Just take needed bands.
-            queries = ProductBandQuery.full_layer_queries(self._product, self.needed_bands())
+            queries = [ProductBandQuery.simple_layer_query(self._product, self.needed_bands())]
 
         if point:
             geom = point


### PR DESCRIPTION
This should fix the immediate bug affecting Terria Export via WCS1.

I think there will still be issues with WCS queries returning flag-band data from the main product, but I need to think about that a bit more, and I want to get this fix out.