### PR TITLE
Add smart resource management data to ows_stats output.

### DIFF
--- a/datacube_ows/data.py
+++ b/datacube_ows/data.py
@@ -402,6 +402,8 @@ def get_map(args):
             n_datasets = stacker.datasets(dc.index, mode=MVSelectOpts.COUNT)
             qprof.end_event("count-datasets")
             qprof["n_datasets"] = n_datasets
+            qprof["zoom_level_base"] = params.resources.base_zoom_level
+            qprof["zoom_level_adjusted"] = params.resources.load_adjusted_zoom_level
             try:
                 params.product.resource_limits.check_wms(n_datasets, params.zf, params.resources)
             except ResourceLimited as e:

--- a/datacube_ows/startup_utils.py
+++ b/datacube_ows/startup_utils.py
@@ -71,7 +71,7 @@ def initialise_sentry(log=None):
         sentry_sdk.init(
             dsn="https://%s@sentry.io/%s" % (os.environ["SENTRY_KEY"], os.environ["SENTRY_PROJECT"]),
             environment=SENTRY_ENV_TAG,
-            integrations = [FlaskIntegration()]
+            integrations=[FlaskIntegration()]
         )
         if log:
             log.info("Sentry initialised")


### PR DESCRIPTION
Add base_zoom_level and load_adjusted_zoom_level to OWS_STATS to help resource management tuning.