### PR TITLE
WCS fixes

### DIFF
--- a/datacube_ows/protocol_versions.py
+++ b/datacube_ows/protocol_versions.py
@@ -17,7 +17,7 @@ class SupportedSvcVersion(object):
         self.service = service.lower()
         self.service_upper = service.upper()
         self.version = version
-        self.version_parts = [ int(i) for i in version.split(".")]
+        self.version_parts = [int(i) for i in version.split(".")]
         assert len(self.version_parts) == 3
         self.router = router
         self.exception_class = exception_class
@@ -42,7 +42,7 @@ class SupportedSvc(object):
     def negotiated_version(self, request_version):
         if not request_version:
             return self.versions[-1]
-        rv_parts = [ int(i) for i in request_version.split(".")]
+        rv_parts = [int(i) for i in request_version.split(".")]
         while len(rv_parts) < 3:
             rv_parts.append(0)
         for v in reversed(self.versions):

--- a/datacube_ows/protocol_versions.py
+++ b/datacube_ows/protocol_versions.py
@@ -17,7 +17,7 @@ class SupportedSvcVersion(object):
         self.service = service.lower()
         self.service_upper = service.upper()
         self.version = version
-        self.version_parts = version.split(".")
+        self.version_parts = [ int(i) for i in version.split(".")]
         assert len(self.version_parts) == 3
         self.router = router
         self.exception_class = exception_class
@@ -42,7 +42,9 @@ class SupportedSvc(object):
     def negotiated_version(self, request_version):
         if not request_version:
             return self.versions[-1]
-        rv_parts = request_version.split(".")
+        rv_parts = [ int(i) for i in request_version.split(".")]
+        while len(rv_parts) < 3:
+            rv_parts.append(0)
         for v in reversed(self.versions):
             if rv_parts >= v.version_parts:
                 return v

--- a/datacube_ows/wcs2.py
+++ b/datacube_ows/wcs2.py
@@ -29,7 +29,7 @@ WCS_REQUESTS = ("DESCRIBECOVERAGE", "GETCOVERAGE")
 
 @log_call
 def handle_wcs2(nocase_args):
-    operation = request.args.get("request", "").upper()
+    operation = nocase_args.get("request", "").upper()
     if not operation:
         raise WCS2Exception("No operation specified", locator="Request parameter")
     elif operation == "GETCAPABILITIES":
@@ -280,7 +280,6 @@ def desc_coverages(args):
             "Cache-Control": "no-cache, max-age=0"
         })
     )
-
 
 
 @log_call

--- a/tests/test_protocol_versions.py
+++ b/tests/test_protocol_versions.py
@@ -15,16 +15,20 @@ def supported_service():
     return datacube_ows.protocol_versions.SupportedSvc([
         datacube_ows.protocol_versions.SupportedSvcVersion("wxs", "1.2.7", fake_router, TestException1),
         datacube_ows.protocol_versions.SupportedSvcVersion("wxs", "1.13.0", fake_router, TestException1),
+        datacube_ows.protocol_versions.SupportedSvcVersion("wxs", "2.0.0", fake_router, TestException1),
     ], TestException2)
 
 def test_default_exception(supported_service):
     assert supported_service.default_exception_class == TestException2
 
 def test_version_negotiation(supported_service):
+    assert supported_service.negotiated_version("1.0").version == "1.2.7"
+    assert supported_service.negotiated_version("1.2").version == "1.2.7"
     assert supported_service.negotiated_version("1.0.0").version == "1.2.7"
     assert supported_service.negotiated_version("1.2.1").version == "1.2.7"
     assert supported_service.negotiated_version("1.2.7").version == "1.2.7"
     assert supported_service.negotiated_version("1.2.8").version == "1.2.7"
     assert supported_service.negotiated_version("1.13.0").version == "1.13.0"
     assert supported_service.negotiated_version("1.13.100").version == "1.13.0"
-    assert supported_service.negotiated_version("2.7.22").version == "1.13.0"
+    assert supported_service.negotiated_version("2.0").version == "2.0.0"
+    assert supported_service.negotiated_version("2.7.22").version == "2.0.0"

--- a/tests/test_protocol_versions.py
+++ b/tests/test_protocol_versions.py
@@ -1,0 +1,30 @@
+import pytest
+import datacube_ows.protocol_versions
+
+class TestException1(Exception):
+    pass
+
+class TestException2(Exception):
+    pass
+
+def fake_router(*args, **kwargs):
+    return None
+
+@pytest.fixture
+def supported_service():
+    return datacube_ows.protocol_versions.SupportedSvc([
+        datacube_ows.protocol_versions.SupportedSvcVersion("wxs", "1.2.7", fake_router, TestException1),
+        datacube_ows.protocol_versions.SupportedSvcVersion("wxs", "1.13.0", fake_router, TestException1),
+    ], TestException2)
+
+def test_default_exception(supported_service):
+    assert supported_service.default_exception_class == TestException2
+
+def test_version_negotiation(supported_service):
+    assert supported_service.negotiated_version("1.0.0").version == "1.2.7"
+    assert supported_service.negotiated_version("1.2.1").version == "1.2.7"
+    assert supported_service.negotiated_version("1.2.7").version == "1.2.7"
+    assert supported_service.negotiated_version("1.2.8").version == "1.2.7"
+    assert supported_service.negotiated_version("1.13.0").version == "1.13.0"
+    assert supported_service.negotiated_version("1.13.100").version == "1.13.0"
+    assert supported_service.negotiated_version("2.7.22").version == "1.13.0"

--- a/tests/test_protocol_versions.py
+++ b/tests/test_protocol_versions.py
@@ -1,5 +1,7 @@
 import pytest
+
 import datacube_ows.protocol_versions
+
 
 class TestException1(Exception):
     pass

--- a/tests/test_startup.py
+++ b/tests/test_startup.py
@@ -116,7 +116,7 @@ def test_supported_version():
     assert ver.service == "wts"
     assert ver.service_upper == "WTS"
     assert ver.version == "1.2.3"
-    assert ver.version_parts == ["1", "2", "3"]
+    assert ver.version_parts == [1, 2, 3]
     assert ver.router == "a"
     assert ver.exception_class == "b"
     from datacube_ows.protocol_versions import supported_versions


### PR DESCRIPTION
1. OGC version negotiation was broken. 
2. WCS "request" parameter name was not being recognised case-insensitively for WCS2.x 