### PR TITLE
Remove wcs default_bands config entry, as per issue #725

### DIFF
--- a/datacube_ows/ows_configuration.py
+++ b/datacube_ows/ows_configuration.py
@@ -408,7 +408,7 @@ class OWSNamedLayer(OWSExtensibleConfigEntry, OWSLayer):
 
         if self.global_cfg.wcs:
             try:
-                self.parse_wcs(cfg.get("wcs"))
+                self.parse_wcs(cfg.get("wcs", {}))
             except KeyError as e:
                 raise ConfigException(f"Missing required config item {e} in wcs section for layer {self.name}")
 
@@ -584,8 +584,12 @@ class OWSNamedLayer(OWSExtensibleConfigEntry, OWSLayer):
         self.declare_unready("grid_high_y")
         self.declare_unready("grids")
         # Band management
-        self.wcs_raw_default_bands = cfg["default_bands"]
-        self.declare_unready("wcs_default_bands")
+        if cfg.get("default_bands"):
+            _LOG.warning(
+                "wcs section contains a 'default_bands' list.  WCS default_bands list is no longer supported. "
+                "Functionally, the default behaviour is now to return all available bands (as mandated by "
+                "the WCS2.x spec). "
+            )
 
         # Native format
         if "native_format" in cfg:
@@ -723,8 +727,6 @@ class OWSNamedLayer(OWSExtensibleConfigEntry, OWSLayer):
                             (bbox["top"] - bbox["bottom"]) / self.grid_high_y
                         )
                     }
-            # Band management
-            self.wcs_default_bands = [self.band_idx.band(b) for b in self.wcs_raw_default_bands]
 
     def parse_product_names(self, cfg):
         raise NotImplementedError()

--- a/datacube_ows/ows_configuration.py
+++ b/datacube_ows/ows_configuration.py
@@ -546,7 +546,7 @@ class OWSNamedLayer(OWSExtensibleConfigEntry, OWSLayer):
 
     # pylint: disable=attribute-defined-outside-init
     def parse_wcs(self, cfg):
-        if cfg is None or not self.global_cfg.wcs:
+        if not self.global_cfg.wcs:
             self.wcs = False
             return
         else:

--- a/datacube_ows/wcs1_utils.py
+++ b/datacube_ows/wcs1_utils.py
@@ -191,7 +191,7 @@ class WCS1GetCoverageRequest():
                     if b not in style.flag_bands:
                         self.bands.add(b)
             else:
-                self.bands = self.product.bands.band_labels()
+                self.bands = self.product.band_idx.band_labels()
         else:
             self.bands = self.product.band_idx.band_labels()
 

--- a/datacube_ows/wcs1_utils.py
+++ b/datacube_ows/wcs1_utils.py
@@ -193,7 +193,7 @@ class WCS1GetCoverageRequest():
             else:
                 self.bands = self.product.bands.band_labels()
         else:
-            self.bands = self.product.bands.band_labels()
+            self.bands = self.product.band_idx.band_labels()
 
         # Argument: EXCEPTIONS (optional - defaults to XML)
         if "exceptions" in args and args["exceptions"] != "application/vnd.ogc.se_xml":

--- a/datacube_ows/wcs1_utils.py
+++ b/datacube_ows/wcs1_utils.py
@@ -191,9 +191,9 @@ class WCS1GetCoverageRequest():
                     if b not in style.flag_bands:
                         self.bands.add(b)
             else:
-                self.bands = self.product.wcs_default_bands
+                self.bands = self.product.bands.band_labels()
         else:
-            self.bands = self.product.wcs_default_bands
+            self.bands = self.product.bands.band_labels()
 
         # Argument: EXCEPTIONS (optional - defaults to XML)
         if "exceptions" in args and args["exceptions"] != "application/vnd.ogc.se_xml":

--- a/datacube_ows/wcs2_utils.py
+++ b/datacube_ows/wcs2_utils.py
@@ -212,7 +212,7 @@ def get_coverage_data(request, qprof):
                     end = band_labels.index(range_subset.end)
                     bands.extend(band_labels[start:(end + 1) if end > start else (end - 1)])
         else:
-            bands = layer.bands.band_labels()
+            bands = band_labels
 
         #
         # Format handling

--- a/datacube_ows/wcs2_utils.py
+++ b/datacube_ows/wcs2_utils.py
@@ -212,7 +212,7 @@ def get_coverage_data(request, qprof):
                     end = band_labels.index(range_subset.end)
                     bands.extend(band_labels[start:(end + 1) if end > start else (end - 1)])
         else:
-            bands = layer.wcs_default_bands  # TODO: standard says differently
+            bands = layer.bands.band_labels()
 
         #
         # Format handling

--- a/docs/cfg_layers.rst
+++ b/docs/cfg_layers.rst
@@ -955,33 +955,6 @@ the flag band is read from a separate product.
 If true, OWS assumes that flag product has no time dimension
 (i.e. the same flags apply to all times).
 
------------------------
-Layer WCS Section (wcs)
------------------------
-
-This section is optional, but if the WCS service is
-active and this section is omitted, then this layer
-will not appear as a coverage in WCS (but will still
-appear as a layer in WMS/WMTS).
-
-E.g.
-
-::
-
-    "wcs": {
-        "default_bands": ["red", "green", "blue"]
-    }
-
-Default WCS Bands (default_bands)
-+++++++++++++++++++++++++++++++++
-
-List the bands included in response to a WCS request that does not
-explicitly specify a band list.
-
-Must be provided if WCS is active, and must contain at least one band.
-Bands must be declared in the layer's `bands dictionary <#bands-dictionary-bands>`_
-and may use native band names or aliases.
-
 ---------------------------------
 Identifiers Section (identifiers)
 ---------------------------------

--- a/integration_tests/cfg/ows_test_cfg.py
+++ b/integration_tests/cfg/ows_test_cfg.py
@@ -708,7 +708,6 @@ ows_cfg = {
                         "apply_solar_corrections": True,
                     },
                     "wcs": {
-                        "default_bands": ["red", "green", "blue"],
                     },
                     "styling": {
                         "default_style": "simple_rgb",
@@ -777,7 +776,6 @@ For service status information, see https://status.dea.ga.gov.au
                         },
                     ],
                     "wcs": {
-                        "default_bands": ["BS", "PV", "NPV"],
                     },
                     "styling": {
                         "default_style": "simple_fc",
@@ -808,7 +806,6 @@ For service status information, see https://status.dea.ga.gov.au
                         "fuse_func": "datacube_ows.wms_utils.wofls_fuser",
                     },
                     "wcs": {
-                        "default_bands": ["water"],
                     },
                     "styling": {
                         "default_style": "observations",
@@ -846,7 +843,6 @@ For service status information, see https://status.dea.ga.gov.au
                         },
                     ],
                     "wcs": {
-                        "default_bands": ["BS", "PV", "NPV"],
                     },
                     "styling": {
                         "default_style": "simple_fc",
@@ -886,7 +882,6 @@ For service status information, see https://status.dea.ga.gov.au
                         },
                     ],
                     "wcs": {
-                        "default_bands": ["BS", "PV", "NPV"],
                     },
                     "styling": {
                         "default_style": "simple_fc",
@@ -927,7 +922,6 @@ Fractional Cover version 2.2.1, 25 metre, 100km tile, Australian Albers Equal Ar
                         },
                     ],
                     "wcs": {
-                        "default_bands": ["BS", "PV", "NPV"],
                     },
                     "styling": {
                         "default_style": "simple_fc",

--- a/tests/test_cfg_layer.py
+++ b/tests/test_cfg_layer.py
@@ -560,22 +560,9 @@ def test_no_default_style(minimal_layer_cfg, minimal_global_cfg):
     assert lyr.default_style.name == 'band1'
 
 
-def test_no_wcs_default_bands(minimal_layer_cfg, minimal_global_cfg):
-    minimal_global_cfg.wcs = True
-    minimal_layer_cfg["wcs"] = {}
-    with pytest.raises(ConfigException) as excinfo:
-        lyr = parse_ows_layer(minimal_layer_cfg,
-                              global_cfg=minimal_global_cfg)
-    assert "Missing required" in str(excinfo.value)
-    assert "wcs" in str(excinfo.value)
-    assert "default_bands" in str(excinfo.value)
-    assert "a_layer" in str(excinfo.value)
-
-
 def test_invalid_native_format(minimal_layer_cfg, minimal_global_cfg):
     minimal_global_cfg.wcs = True
     minimal_layer_cfg["wcs"] = {
-        "default_bands": ["band1", "band2"],
         "native_format": "geosplunge"
     }
     with pytest.raises(ConfigException) as excinfo:
@@ -770,7 +757,6 @@ def test_invalid_default_time(minimal_layer_cfg, minimal_global_cfg, minimal_dc,
 
 def test_native_crs_mismatch(minimal_global_cfg, minimal_layer_cfg, minimal_dc):
     minimal_layer_cfg["native_crs"] = "EPSG:1234"
-    minimal_layer_cfg["default_bands"] = ["band1", "band2", "band3"]
     minimal_layer_cfg["product_name"] = "foo_nativecrs"
     lyr = parse_ows_layer(minimal_layer_cfg,
                           global_cfg=minimal_global_cfg)
@@ -789,13 +775,11 @@ def test_native_crs_mismatch(minimal_global_cfg, minimal_layer_cfg, minimal_dc):
 # NOTE: retire when native res/crs in wcs section support removed.
 def test_native_crs_res_wcs_mismatch(minimal_global_cfg, minimal_layer_cfg, minimal_dc):
     minimal_layer_cfg["native_crs"] = "EPSG:4326"
-    minimal_layer_cfg["default_bands"] = ["band1", "band2", "band3"]
     minimal_layer_cfg["product_name"] = "foo_nativecrs"
     minimal_global_cfg.wcs = True
     minimal_layer_cfg["wcs"] = {
         "native_crs": "EPSG:1234",
         "native_resolution": [0.123, 0.123],
-        "default_bands": ["band1", "band2", "band3"],
     }
 
     lyr = parse_ows_layer(minimal_layer_cfg,

--- a/tests/test_cfg_wcs.py
+++ b/tests/test_cfg_wcs.py
@@ -15,7 +15,6 @@ def test_zero_grid(minimal_global_cfg, minimal_layer_cfg, minimal_dc, mock_range
     minimal_global_cfg.wcs = True
     minimal_layer_cfg["native_crs"] = "EPSG:4326"
     minimal_layer_cfg["wcs"] = {
-        "default_bands": ["band1", "band2", "band3"],
     }
     minimal_layer_cfg["product_name"] = "foo_nativeres"
     lyr = parse_ows_layer(minimal_layer_cfg,


### PR DESCRIPTION
WCS1.x standard is silent on behaviour if user doesn't explicitly list desired bands - default_bands entry provided the answer.

WCS2.x standard is pretty clear that the default behaviour should be to return all available bands.

This PR removes the configured default band list, makes WCS2 more standards-compliant, and makes WCS1 behaviour consistent with WCS2. 