### PR TITLE
Remove query_url from prometheus config and add protocol tracking.

### DIFF
--- a/datacube_ows/startup_utils.py
+++ b/datacube_ows/startup_utils.py
@@ -200,7 +200,7 @@ def initialise_prometheus_register(metrics):
     if os.environ.get("prometheus_multiproc_dir", False):
         metrics.register_default(
             metrics.summary(
-                'flask_ows_request_full_url', 'Request summary by request url',
+                'flask_ows_request_method_and_layer', 'Request summary by protocol, version, command and layer',
                 labels={
                     'query_request': lambda: request.args.get('request'),
                     'query_service': lambda: request.args.get('service'),


### PR DESCRIPTION
Re: #749 @omad what do you think of this?  I've dropped the query_url.  I've also extended the "layers" tracking to the other protocols.  I've also added version which is really only of interest for wcs.