### PR TITLE
Replace s3fs tests

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -40,7 +40,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - name: Install requirements.txt and run pylint
+      - name: Install dependencies and run pylint
         run: |
           pip install .[test,dev]
           pip install pylint

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,8 +38,6 @@ COPY --from=builder  /usr/lib/python3/dist-packages /usr/lib/python3/dist-packag
 # postgres client
 COPY --from=builder  /usr/lib/postgresql /usr/lib/postgresql
 COPY --from=builder  /usr/share/postgresql /usr/share/postgresql
-# moto_server is used for  testing
-COPY --from=builder  /usr/local/bin/moto_server /usr/local/bin/moto_server
 # perl5 is used for pg_isready
 COPY --from=builder  /usr/share/perl5 /usr/share/perl5
 COPY --from=builder  /usr/bin/pg_isready /usr/bin/pg_isready

--- a/datacube_ows/config_utils.py
+++ b/datacube_ows/config_utils.py
@@ -99,6 +99,8 @@ def get_file_loc(x: str) -> str:
             raise ConfigException("Please set environment variable 'DATACUBE_OWS_CFG_ALLOW_S3=YES' "
                               + "to enable OWS config from AWS S3")
         cwd = xp.scheme + "://" + xp.netloc +  xp.path.rsplit("/", 1)[0]
+    elif xp.scheme:
+        raise ConfigException(f"Unsupported URL scheme in config inheritance: {xp.scheme}")
     else:
         abs_path = os.path.abspath(x)
         cwd = os.path.dirname(abs_path)

--- a/setup.py
+++ b/setup.py
@@ -45,8 +45,7 @@ test_requirements = [
     'pytest', 'pytest_cov', 'pytest_localserver',
     'owslib==0.21.0', 'pytest_mock', 'pep8',
     'pytest-helpers-namespace', 'moto', 'flask-cors',
-    's3fs==2021.11.0', 'fsspec==2021.11.0',
-    "aiobotocore==1.4.2"
+    'fsspec==2021.11.0',
 ]
 
 dev_requirements = [
@@ -54,6 +53,7 @@ dev_requirements = [
     'pylint==2.4.4',
     'sphinx_click',
     'pre-commit==2.13.0',
+    'pipdeptree'
 ]
 
 operational_requirements = [

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,8 @@ test_requirements = [
     'pytest', 'pytest_cov', 'pytest_localserver',
     'owslib==0.21.0', 'pytest_mock', 'pep8',
     'pytest-helpers-namespace', 'moto', 'flask-cors',
-    's3fs==2021.07.0', 'fsspec==2021.07.0'
+    's3fs==2021.11.0', 'fsspec==2021.11.0',
+    "aiobotocore==1.4.2"
 ]
 
 dev_requirements = [

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ install_requirements = [
 test_requirements = [
     'pytest', 'pytest_cov', 'pytest_localserver',
     'owslib==0.21.0', 'pytest_mock', 'pep8',
-    'pytest-helpers-namespace', 'moto', 'flask-cors',
+    'pytest-helpers-namespace', 'flask-cors',
     'fsspec==2021.11.0',
 ]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,96 +11,11 @@ import numpy as np
 import pytest
 import requests
 import xarray as xr
-from s3fs.core import S3FileSystem
 
 from tests.utils import (MOTO_PORT, MOTO_S3_ENDPOINT_URI, coords, dim1_da,
                          dummy_da)
 
 
-def get_boto3_client():
-    from botocore.session import Session
-    session = Session()
-    return session.create_client("s3", endpoint_url=MOTO_S3_ENDPOINT_URI)
-
-@pytest.fixture
-def s3_base():
-    # writable local S3 system
-    # adapted from https://github.com/dask/s3fs/blob/main/s3fs/tests/test_s3fs.py
-    import subprocess
-
-    proc = subprocess.Popen(["moto_server", "s3", "-p", MOTO_PORT])
-
-    timeout = 5
-    while timeout > 0:
-        try:
-            r = requests.get(MOTO_S3_ENDPOINT_URI)
-            if r.ok:
-                break
-        except:
-            pass
-        timeout -= 0.1
-        time.sleep(0.1)
-    yield
-    proc.terminate()
-    proc.wait()
-
-@pytest.fixture()
-def s3(s3_base, monkeypatch):
-    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "foo")
-    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "bar")
-
-    client = get_boto3_client()
-    client.create_bucket(Bucket="testbucket")
-
-    S3FileSystem.clear_instance_cache()
-    s3 = S3FileSystem(anon=False, client_kwargs={"endpoint_url": MOTO_S3_ENDPOINT_URI})
-    s3.invalidate_cache()
-    yield s3
-
-@pytest.fixture
-def s3_config_simple(s3):
-    config_uri = "s3://testbucket/simple.json"
-    with s3.open(config_uri, "wb") as f_open:
-        f_open.write(b'{"test": 1234}')
-
-@pytest.fixture
-def s3_config_nested_1(s3, s3_config_simple):
-    config_uri = "s3://testbucket/nested_1.json"
-    with s3.open(config_uri, "wb") as f_open:
-        f_open.write(b'{"include": "simple.json", "type": "json"}')
-
-@pytest.fixture
-def s3_config_nested_2(s3, s3_config_simple):
-    config_uri = "s3://testbucket/nested_2.json"
-    with s3.open(config_uri, "wb") as f_open:
-        f_open.write(b'[{"test": 88888}, {"include": "simple.json", "type": "json"}]')
-
-@pytest.fixture
-def s3_config_nested_3(s3, s3_config_simple):
-    config_uri = "s3://testbucket/nested_3.json"
-    with s3.open(config_uri, "wb") as f_open:
-        f_open.write(b'{"test": 2222, "things": [{"test": 22562, "thing": null}, \
-            {"test": 22563, "thing": {"include": "simple.json", "type": "json"}}, \
-            {"test": 22564, "thing": {"include": "simple.json", "type": "json"}}]}'
-        )
-
-@pytest.fixture
-def s3_config_nested_4(s3, s3_config_simple, s3_config_nested_3):
-    config_uri = "s3://testbucket/nested_4.json"
-    with s3.open(config_uri, "wb") as f_open:
-        f_open.write(b'{"test": 3222, "things": [{"test": 2572, "thing": null}, \
-            {"test": 2573, "thing": {"include": "simple.json", "type": "json"}}, \
-            {"test": 2574, "thing": {"include": "nested_3.json", "type": "json"}}]}'
-        )
-
-@pytest.fixture
-def s3_config_mixed_nested(s3, s3_config_simple):
-    config_uri = "s3://testbucket/mixed_nested.json"
-    with s3.open(config_uri, "wb") as f_open:
-        f_open.write(b'{"test": 9364, \
-            "subtest": {"test_py": {"include": "tests.cfg.simple.simple", "type": "python"}, \
-            "test_json": {"include": "tests/cfg/simple.json", "type": "json"}}}'
-        )
 
 @pytest.fixture
 def flask_client(monkeypatch):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,17 +4,13 @@
 # Copyright (c) 2017-2021 OWS Contributors
 # SPDX-License-Identifier: Apache-2.0
 import datetime
-import time
 from unittest.mock import MagicMock
 
 import numpy as np
 import pytest
-import requests
 import xarray as xr
 
-from tests.utils import (MOTO_PORT, MOTO_S3_ENDPOINT_URI, coords, dim1_da,
-                         dummy_da)
-
+from tests.utils import coords, dim1_da, dummy_da
 
 
 @pytest.fixture

--- a/tests/test_cfg_inclusion.py
+++ b/tests/test_cfg_inclusion.py
@@ -55,13 +55,22 @@ def test_get_file_loc_s3_enable(monkeypatch):
     assert get_file_loc("s3://testbucket/foo.bar") == "s3://testbucket"
 
     monkeypatch.setenv("DATACUBE_OWS_CFG_ALLOW_S3", "TRUE")
-    assert get_file_loc("s3://testbucket/foo.bar") == "s3://testbucket"
+    assert get_file_loc("s3://testbucket/dir/foo.bar") == "s3://testbucket/dir"
 
     monkeypatch.setenv("DATACUBE_OWS_CFG_ALLOW_S3", "1")
-    assert get_file_loc("s3://testbucket/foo.bar") == "s3://testbucket"
+    assert get_file_loc("s3://testbucket/nested/dir/foo.bar") == "s3://testbucket/nested/dir"
 
     monkeypatch.setenv("DATACUBE_OWS_CFG_ALLOW_S3", "Y")
     assert get_file_loc("s3://testbucket/foo.bar") == "s3://testbucket"
+
+
+def tests_get_file_loc_other_url(monkeypatch):
+    monkeypatch.setenv("DATACUBE_OWS_CFG_ALLOW_S3", "N")
+    with pytest.raises(ConfigException) as excinfo:
+        _ = get_file_loc("http://testbucket/directory/foo.bar")
+    monkeypatch.setenv("DATACUBE_OWS_CFG_ALLOW_S3", "Y")
+    with pytest.raises(ConfigException) as excinfo:
+        _ = get_file_loc("http://testbucket/another_directory/bar.foo")
 
 
 def test_cfg_inject():
@@ -175,27 +184,6 @@ def test_cfg_json_simple(monkeypatch):
 
     assert cfg["test"] == 1234
 
-def test_cfg_json_simple_s3(monkeypatch, s3, s3_config_simple):
-    monkeypatch.chdir(src_dir)
-    monkeypatch.setenv("DATACUBE_OWS_CFG_ALLOW_S3", "YES")
-    monkeypatch.setenv("DATACUBE_OWS_CFG", "s3://testbucket/simple.json")
-    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "foo")
-    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "bar")
-    fsspec_conf.update({"s3": {"client_kwargs": {"endpoint_url": MOTO_S3_ENDPOINT_URI}}})
-    cfg = read_config()
-
-    assert cfg["test"] == 1234
-
-def test_cfg_json_nested_1_s3(monkeypatch, s3, s3_config_nested_1):
-    monkeypatch.chdir(src_dir)
-    monkeypatch.setenv("DATACUBE_OWS_CFG_ALLOW_S3", "YES")
-    monkeypatch.setenv("DATACUBE_OWS_CFG", "s3://testbucket/nested_1.json")
-    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "foo")
-    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "bar")
-    fsspec_conf.update({"s3": {"client_kwargs": {"endpoint_url": MOTO_S3_ENDPOINT_URI}}})
-    cfg = read_config()
-
-    assert cfg["test"] == 1234
 
 def test_cfg_json_nested_2(monkeypatch):
     monkeypatch.chdir(src_dir)
@@ -206,18 +194,6 @@ def test_cfg_json_nested_2(monkeypatch):
     assert cfg[0]["test"] == 88888
     assert cfg[1]["test"] == 1234
 
-def test_cfg_json_nested_2_s3(monkeypatch, s3_config_nested_2):
-    monkeypatch.chdir(src_dir)
-    monkeypatch.setenv("DATACUBE_OWS_CFG_ALLOW_S3", "YES")
-    monkeypatch.setenv("DATACUBE_OWS_CFG", "s3://testbucket/nested_2.json")
-    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "foo")
-    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "bar")
-
-    cfg = read_config()
-
-    assert len(cfg) == 2
-    assert cfg[0]["test"] == 88888
-    assert cfg[1]["test"] == 1234
 
 def validated_nested_3(cfg):
     assert cfg["test"] == 2222
@@ -236,14 +212,6 @@ def test_cfg_json_nested_3(monkeypatch):
     cfg = read_config()
     validated_nested_3(cfg)
 
-def test_cfg_json_nested_3_s3(monkeypatch, s3_config_nested_3):
-    monkeypatch.chdir(src_dir)
-    monkeypatch.setenv("DATACUBE_OWS_CFG_ALLOW_S3", "YES")
-    monkeypatch.setenv("DATACUBE_OWS_CFG", "s3://testbucket/nested_3.json")
-    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "foo")
-    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "bar")
-    cfg = read_config()
-    validated_nested_3(cfg)
 
 def test_cfg_json_nested_4(monkeypatch):
     monkeypatch.chdir(src_dir)
@@ -259,22 +227,6 @@ def test_cfg_json_nested_4(monkeypatch):
     assert cfg["things"][2]["test"] == 2574
     validated_nested_3(cfg["things"][2]["thing"])
 
-def test_cfg_json_nested_4_s3(monkeypatch, s3_config_nested_4):
-    monkeypatch.chdir(src_dir)
-    monkeypatch.setenv("DATACUBE_OWS_CFG_ALLOW_S3", "YES")
-    monkeypatch.setenv("DATACUBE_OWS_CFG", "s3://testbucket/nested_4.json")
-    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "foo")
-    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "bar")
-    cfg = read_config()
-
-    assert cfg["test"] == 3222
-    assert len(cfg["things"]) == 3
-    assert cfg["things"][0]["test"] == 2572
-    assert cfg["things"][0]["thing"] is None
-    assert cfg["things"][1]["test"] == 2573
-    assert cfg["things"][1]["thing"]["test"] == 1234
-    assert cfg["things"][2]["test"] == 2574
-    validated_nested_3(cfg["things"][2]["thing"])
 
 def test_cfg_json_infinite_1(monkeypatch):
     monkeypatch.chdir(src_dir)
@@ -341,14 +293,3 @@ def test_cfg_json_mixed(monkeypatch):
     assert cfg["subtest"]["test_py"]["test"] == 123
     assert cfg["subtest"]["test_json"]["test"] == 1234
 
-def test_cfg_json_mixed_s3(monkeypatch, s3_config_mixed_nested):
-    monkeypatch.chdir(src_dir)
-    monkeypatch.setenv("DATACUBE_OWS_CFG_ALLOW_S3", "YES")
-    monkeypatch.setenv("DATACUBE_OWS_CFG", "s3://testbucket/mixed_nested.json")
-    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "foo")
-    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "bar")
-    cfg = read_config()
-
-    assert cfg["test"] == 9364
-    assert cfg["subtest"]["test_py"]["test"] == 123
-    assert cfg["subtest"]["test_json"]["test"] == 1234

--- a/tests/test_cfg_inclusion.py
+++ b/tests/test_cfg_inclusion.py
@@ -7,11 +7,9 @@ import os
 import sys
 
 import pytest
-from fsspec.config import conf as fsspec_conf
 
 from datacube_ows.config_utils import get_file_loc
 from datacube_ows.ows_configuration import ConfigException, read_config
-from tests.utils import MOTO_S3_ENDPOINT_URI
 
 src_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 if src_dir not in sys.path:

--- a/tests/test_cfg_inclusion.py
+++ b/tests/test_cfg_inclusion.py
@@ -175,7 +175,6 @@ def test_cfg_json_simple(monkeypatch):
 
     assert cfg["test"] == 1234
 
-@pytest.mark.skip("S3FS testing suspended pending aiobotocore dependency issue")
 def test_cfg_json_simple_s3(monkeypatch, s3, s3_config_simple):
     monkeypatch.chdir(src_dir)
     monkeypatch.setenv("DATACUBE_OWS_CFG_ALLOW_S3", "YES")
@@ -187,7 +186,6 @@ def test_cfg_json_simple_s3(monkeypatch, s3, s3_config_simple):
 
     assert cfg["test"] == 1234
 
-@pytest.mark.skip("S3FS testing suspended pending aiobotocore dependency issue")
 def test_cfg_json_nested_1_s3(monkeypatch, s3, s3_config_nested_1):
     monkeypatch.chdir(src_dir)
     monkeypatch.setenv("DATACUBE_OWS_CFG_ALLOW_S3", "YES")
@@ -208,7 +206,6 @@ def test_cfg_json_nested_2(monkeypatch):
     assert cfg[0]["test"] == 88888
     assert cfg[1]["test"] == 1234
 
-@pytest.mark.skip("S3FS testing suspended pending aiobotocore dependency issue")
 def test_cfg_json_nested_2_s3(monkeypatch, s3_config_nested_2):
     monkeypatch.chdir(src_dir)
     monkeypatch.setenv("DATACUBE_OWS_CFG_ALLOW_S3", "YES")
@@ -239,7 +236,6 @@ def test_cfg_json_nested_3(monkeypatch):
     cfg = read_config()
     validated_nested_3(cfg)
 
-@pytest.mark.skip("S3FS testing suspended pending aiobotocore dependency issue")
 def test_cfg_json_nested_3_s3(monkeypatch, s3_config_nested_3):
     monkeypatch.chdir(src_dir)
     monkeypatch.setenv("DATACUBE_OWS_CFG_ALLOW_S3", "YES")
@@ -263,7 +259,6 @@ def test_cfg_json_nested_4(monkeypatch):
     assert cfg["things"][2]["test"] == 2574
     validated_nested_3(cfg["things"][2]["thing"])
 
-@pytest.mark.skip("S3FS testing suspended pending aiobotocore dependency issue")
 def test_cfg_json_nested_4_s3(monkeypatch, s3_config_nested_4):
     monkeypatch.chdir(src_dir)
     monkeypatch.setenv("DATACUBE_OWS_CFG_ALLOW_S3", "YES")
@@ -346,7 +341,6 @@ def test_cfg_json_mixed(monkeypatch):
     assert cfg["subtest"]["test_py"]["test"] == 123
     assert cfg["subtest"]["test_json"]["test"] == 1234
 
-@pytest.mark.skip("S3FS testing suspended pending aiobotocore dependency issue")
 def test_cfg_json_mixed_s3(monkeypatch, s3_config_mixed_nested):
     monkeypatch.chdir(src_dir)
     monkeypatch.setenv("DATACUBE_OWS_CFG_ALLOW_S3", "YES")


### PR DESCRIPTION
Remove S3FS-based testing and improve unit tests of get_file_loc.

get_file_loc was not actually checking for non-S3 urls.