### PR TITLE
Soft-limit (dataset count) check for no lowres data was broken.

### DIFF
--- a/datacube_ows/wcs1_utils.py
+++ b/datacube_ows/wcs1_utils.py
@@ -315,7 +315,7 @@ def get_coverage_data(req, qprof):
                                                   sum(req.product.band_idx.dtype_size(b) for b in req.bands),
                                                   len(req.times))
         except ResourceLimited as e:
-            if e.wcs_hard or req.product.low_res_product_names is None:
+            if e.wcs_hard or not req.product.low_res_product_names:
                 raise WCS1Exception(
                     f"This request processes too much data to be served in a reasonable amount of time. ({e}) "
                     + "Please reduce the bounds of your request and try again.")

--- a/datacube_ows/wcs2_utils.py
+++ b/datacube_ows/wcs2_utils.py
@@ -257,7 +257,7 @@ def get_coverage_data(request, qprof):
                                                   len(times)
                                            )
         except ResourceLimited as e:
-            if e.wcs_hard or layer.low_res_product_names is None:
+            if e.wcs_hard or not layer.low_res_product_names:
                 raise WCS2Exception(
                     f"This request processes too much data to be served in a reasonable amount of time. ({e}) "
                     + "Please reduce the bounds of your request and try again.")


### PR DESCRIPTION
Dataset count resource limit for WCS was not being applied because the presence of lowres mosaic data was not being checked correctly.  Hard bit of code to test with our current test infrastructure.