### PR TITLE
Value map multi-date handlers

### DIFF
--- a/datacube_ows/styles/base.py
+++ b/datacube_ows/styles/base.py
@@ -435,6 +435,8 @@ class StyleDefBase(OWSExtensibleConfigEntry, OWSMetadataConfig):
         """
         auto_legend: bool = False
 
+        non_animate_requires_aggregator = True
+
         def __init__(self, style: "StyleDefBase", cfg: CFG_DICT) -> None:
             """
             First stage initialisation
@@ -456,13 +458,15 @@ class StyleDefBase(OWSExtensibleConfigEntry, OWSMetadataConfig):
             self.animate = cast(bool, cfg.get("animate", False))
             self.frame_duration: int = 1000
             if "aggregator_function" in cfg:
-                self.aggregator = FunctionWrapper(style.product,
+                self.aggregator: Optional[FunctionWrapper] = FunctionWrapper(style.product,
                                                   cast(CFG_DICT, cfg["aggregator_function"]))
             elif self.animate:
                 self.aggregator = FunctionWrapper(style.product, lambda x: x, stand_alone=True)
                 self.frame_duration = cast(int, cfg.get("frame_duration", 1000))
             else:
-                raise ConfigException("Aggregator function is required for non-animated multi-date handlers.")
+                self.aggregator = None
+                if self.non_animate_requires_aggregator:
+                    raise ConfigException("Aggregator function is required for non-animated multi-date handlers.")
             self.parse_legend_cfg(cast(CFG_DICT, cfg.get("legend", {})))
             self.preserve_user_date_order = cast(bool, cfg.get("preserve_user_date_order", False))
 

--- a/datacube_ows/styles/base.py
+++ b/datacube_ows/styles/base.py
@@ -459,7 +459,8 @@ class StyleDefBase(OWSExtensibleConfigEntry, OWSMetadataConfig):
             self.frame_duration: int = 1000
             if "aggregator_function" in cfg:
                 self.aggregator: Optional[FunctionWrapper] = FunctionWrapper(style.product,
-                                                  cast(CFG_DICT, cfg["aggregator_function"]))
+                                                  cast(CFG_DICT, cfg["aggregator_function"]),
+                                                                             stand_alone=self.style.stand_alone)
             elif self.animate:
                 self.aggregator = FunctionWrapper(style.product, lambda x: x, stand_alone=True)
                 self.frame_duration = cast(int, cfg.get("frame_duration", 1000))

--- a/datacube_ows/styles/colormap.py
+++ b/datacube_ows/styles/colormap.py
@@ -163,8 +163,8 @@ class MultiDateValueMapRule(OWSConfigEntry):
         self.values: Optional[List[List[int]]] = []
         if "flags" in cfg:
             date_flags = cast(CFG_DICT, cfg["flags"])
-            if len(date_flags) != len(self.mdh.max_count):
-                pass
+            if len(date_flags) != self.mdh.max_count:
+                raise ConfigException(f"Flags entry has wrong number of rule sets for date count")
             for flags in date_flags:
                 or_flag: bool = False
                 if "or" in flags and "and" in flags:
@@ -216,14 +216,14 @@ class MultiDateValueMapRule(OWSConfigEntry):
                 if not flags:
                     d_mask = d_slice == d_slice
                 elif or_flags:
-                    for f in cast(CFG_DICT, self.flags).items():
+                    for f in cast(CFG_DICT, flags).items():
                         f = {f[0]: f[1]}
                         if d_mask is None:
                             d_mask = make_mask(d_slice, **f)
                         else:
                             d_mask |= make_mask(d_slice, **f)
                 else:
-                    d_mask = make_mask(d_slice, **cast(CFG_DICT, self.flags))
+                    d_mask = make_mask(d_slice, **cast(CFG_DICT, flags))
                 if mask is None:
                     mask = d_mask
                 else:
@@ -265,10 +265,10 @@ def apply_multidate_value_map(value_map: MutableMapping[str, List[MultiDateValue
             bdata = ColorMapStyleDef.reint(bdata)
         for rule in rules:
             mask = rule.create_mask(bdata)
-            masked = ColorMapStyleDef.create_colordata(bdata, rule.rgb, rule.alpha, mask)
+            masked = ColorMapStyleDef.create_colordata(mask, rule.rgb, rule.alpha, mask)
             band_data = masked if len(band_data.data_vars) == 0 else band_data.combine_first(masked)
         imgdata = band_data if len(imgdata.data_vars) == 0 else merge([imgdata, band_data])
-    imgdata *= 255
+    imgdata = imgdata * 255 + 0.5
     return imgdata.astype('uint8')
 
 

--- a/datacube_ows/styles/colormap.py
+++ b/datacube_ows/styles/colormap.py
@@ -197,12 +197,15 @@ class MultiDateValueMapRule(OWSConfigEntry):
         if self.values:
             for d_slice, vals in zip(date_slices, self.values):
                 d_mask: Optional[DataArray] = None
-                for v in cast(List[int], vals):
-                    vmask = d_slice == v
-                    if d_mask is None:
-                        d_mask = vmask
-                    else:
-                        d_mask |= vmask
+                if len(vals) == 0:
+                    d_mask = d_slice == d_slice
+                else:
+                    for v in cast(List[int], vals):
+                        vmask = d_slice == v
+                        if d_mask is None:
+                            d_mask = vmask
+                        else:
+                            d_mask |= vmask
                 if mask is None:
                     mask = d_mask
                 else:

--- a/datacube_ows/styles/colormap.py
+++ b/datacube_ows/styles/colormap.py
@@ -82,9 +82,7 @@ class AbstractValueMapRule(OWSConfigEntry):
             typ = ValueMapRule
         else:
             mdh = cast(ColorMapStyleDef.MultiDateHandler, style_or_mdh)
-            if mdh.animate:
-                raise ConfigException("Multidate value maps not supported for animation handlers")
-            elif mdh.aggregator:
+            if mdh.aggregator:
                 style_or_mdh = mdh.style
                 typ = ValueMapRule
             else:
@@ -417,7 +415,10 @@ class ColorMapStyleDef(StyleDefBase):
             """
             super().__init__(style, cfg)
             self._value_map: Optional[MutableMapping[str, AbstractValueMapRule]] = None
-            if not self.animate:
+            if self.animate:
+                if "value_map" in self._raw_cfg:
+                    raise ConfigException("Multidate value maps not supported for animation handlers")
+            else:
                 self._value_map = AbstractValueMapRule.value_map_from_config(self,
                                                         cast(CFG_DICT, self._raw_cfg["value_map"]))
 

--- a/datacube_ows/styles/colormap.py
+++ b/datacube_ows/styles/colormap.py
@@ -213,7 +213,9 @@ class MultiDateValueMapRule(OWSConfigEntry):
         else:
             for d_slice, flags, or_flags in zip(date_slices, self.flags, self.or_flags):
                 d_mask: Optional[DataArray] = None
-                if or_flags:
+                if not flags:
+                    d_mask = d_slice == d_slice
+                elif or_flags:
                     for f in cast(CFG_DICT, self.flags).items():
                         f = {f[0]: f[1]}
                         if d_mask is None:
@@ -402,7 +404,6 @@ class ColorMapStyleDef(StyleDefBase):
             :param cfg: The multidate handler configuration
             """
             super().__init__(style, cfg)
-            style_cfg = cast(CFG_DICT, self._raw_cfg)
             if self.animate:
                 self._value_map: Optional[MutableMapping[str, Union[ValueMapRule, MultiDateValueMapRule]]] = None
             elif self.aggregator:

--- a/datacube_ows/styles/colormap.py
+++ b/datacube_ows/styles/colormap.py
@@ -119,7 +119,7 @@ class ValueMapRule(AbstractValueMapRule):
         self.values: Optional[List[int]] = None
         super().__init__(style_def=style_cfg, band=band, cfg=cfg)
 
-    def parse_rule_spec(self, cfg:CFG_DICT):
+    def parse_rule_spec(self, cfg: CFG_DICT):
         if "flags" in cfg:
             flags = cast(CFG_DICT, cfg["flags"])
             self.or_flags: bool = False

--- a/datacube_ows/styles/colormap.py
+++ b/datacube_ows/styles/colormap.py
@@ -52,11 +52,7 @@ class ValueMapRule(OWSConfigEntry):
             self.label = None
         self.color_str = cast(str, cfg["color"])
         self.rgb = Color(self.color_str)
-        if cfg.get("mask", False):
-            self.alpha: float = 0.0
-        else:
-            self.alpha = float(cast(Union[float, int, str], cfg.get("alpha", 1.0)))
-
+        self.alpha = float(cast(Union[float, int, str], cfg.get("alpha", 1.0)))
         if "flags" in cfg:
             flags = cast(CFG_DICT, cfg["flags"])
             self.or_flags: bool = False
@@ -126,6 +122,151 @@ class ValueMapRule(OWSConfigEntry):
         return vmap
 
 
+class MultiDateValueMapRule(OWSConfigEntry):
+    # TODO: inherit from ValueMapRule? or merge into it?
+    """
+    A  Mulit-Date Value Map Rule.
+
+    Construct a Multi-Date ValueMap rule-set with MultiDateValueMapRule.value_map_from_config
+    """
+    def __init__(self, mdh: "ColorMapStyleDef.MultiDateHandler", band: str,
+                 rule_id: int, cfg: CFG_DICT) -> None:
+        """
+        Construct a Multi-date Value Map Rule
+
+        :param style_def: The owning ColorMapStyleDef object
+        :param band: The name of the flag-band the rules apply to
+        :param cfg: The rule specification
+        """
+        super().__init__(cfg)
+        cfg = cast(CFG_DICT, self._raw_cfg)
+        self.mdh = mdh
+        self.id = rule_id
+        self.band = mdh.style.local_band(band)
+
+        self.title = cast(str, cfg["title"])
+        self.abstract = cast(str, cfg.get("abstract"))
+        if self.title and self.abstract:
+            self.label: Optional[str] = f"{self.title} - {self.abstract}"
+        elif self.title:
+            self.label = self.title
+        elif self.abstract:
+            self.label = self.abstract
+        else:
+            self.label = None
+        self.color_str = cast(str, cfg["color"])
+        self.rgb = Color(self.color_str)
+        self.alpha = float(cast(Union[float, int, str], cfg.get("alpha", 1.0)))
+
+        self.flags: Optional[List[CFG_DICT]] = []
+        self.or_flags: Optional[List[bool]] = []
+        self.values: Optional[List[List[int]]] = []
+        if "flags" in cfg:
+            date_flags = cast(CFG_DICT, cfg["flags"])
+            if len(date_flags) != len(self.mdh.max_count):
+                pass
+            for flags in date_flags:
+                or_flag: bool = False
+                if "or" in flags and "and" in flags:
+                    raise ConfigException(f"MultiDateValueMap rule in style {self.mdh.style.name} of layer {self.mdh.style.product.name} combines 'and' and 'or' rules")
+                elif "or" in flags:
+                    or_flag = True
+                    flags = cast(CFG_DICT, flags["or"])
+                elif "and" in flags:
+                    flags = cast(CFG_DICT, flags["and"])
+                self.flags.append(flags)
+                self.or_flags.append(or_flag)
+        if "values" in cfg:
+            self.values = cast(List[List[int]], list(cfg["values"]))
+        else:
+            self.values = None
+        if not self.flags and not self.values:
+            raise ConfigException(f"Multi-Date Value map rule in style {mdh.style.name} of layer {mdh.style.product.name} must have a non-empty 'flags' or 'values' section.")
+        if self.flags and self.values:
+            raise ConfigException(f"Multi-Date Value map rule in style {mdh.style.name} of layer {mdh.style.product.name} has both a 'flags' and a 'values' section - choose one.")
+
+    def create_mask(self, data: DataArray) -> DataArray:
+        """
+        Create a mask from raw flag band data.
+
+        :param data: Multi-date Raw flag data, assumed to be for this rule's flag band.
+        :return: A boolean dateless DataArray, True where the data matches this rule
+        """
+        date_slices = (data.sel(time=dt) for dt in data.coords["time"].values)
+        mask: Optional[DataArray] = None
+        if self.values:
+            for d_slice, vals in zip(date_slices, self.values):
+                d_mask: Optional[DataArray] = None
+                for v in cast(List[int], vals):
+                    vmask = d_slice == v
+                    if d_mask is None:
+                        d_mask = vmask
+                    else:
+                        d_mask |= vmask
+                if mask is None:
+                    mask = d_mask
+                else:
+                    mask &= d_mask
+        else:
+            for d_slice, flags, or_flags in zip(date_slices, self.flags, self.or_flags):
+                d_mask: Optional[DataArray] = None
+                if or_flags:
+                    for f in cast(CFG_DICT, self.flags).items():
+                        f = {f[0]: f[1]}
+                        if d_mask is None:
+                            d_mask = make_mask(d_slice, **f)
+                        else:
+                            d_mask |= make_mask(d_slice, **f)
+                else:
+                    d_mask = make_mask(d_slice, **cast(CFG_DICT, self.flags))
+                if mask is None:
+                    mask = d_mask
+                else:
+                    mask &= d_mask
+        return mask
+
+    @classmethod
+    def value_map_from_config(cls,
+                              mdh: "ColorMapStyleDef.MultiDateHandler",
+                              cfg: CFG_DICT) -> MutableMapping[str, List["MultiDateValueMapRule"]]:
+        """
+        Create a multi-date value map rule set from a config specification
+
+        :param style: The parent style definition object
+        :param cfg: The specification for the multi-date value map.
+
+        :return: A value map ruleset dictionary.
+        """
+        vmap: MutableMapping[str, List["ValueMapRule"]] = {}
+        if mdh.min_count != mdh.max_count:
+            raise ConfigException("MultiDate value map only supported on multi-date handlers with min_count and max_count equal.")
+        for i, (band_name, rules) in enumerate(cfg.items()):
+            band_rules = [cls(mdh, band_name, i, rule) for rule in cast(List[CFG_DICT], rules)]
+            vmap[band_name] = band_rules
+        return vmap
+
+
+def apply_multidate_value_map(value_map: MutableMapping[str, List[MultiDateValueMapRule]],
+                    data: Dataset,
+                    band_mapper: Callable[[str], str]) -> Dataset:
+    imgdata = Dataset(coords={k: v for k, v in data.coords.items() if k != "time"})
+    for cfg_band, rules in value_map.items():
+        # Run through each item
+        band = band_mapper(cfg_band)
+        bdata = cast(DataArray, data[band])
+        band_data = Dataset()
+        if bdata.dtype.kind == 'f':
+            # Convert back to int for bitmasking
+            bdata = ColorMapStyleDef.reint(bdata)
+        for rule in rules:
+            mask = rule.create_mask(bdata)
+            masked = ColorMapStyleDef.create_colordata(bdata, rule.rgb, rule.alpha, mask)
+            band_data = masked if len(band_data.data_vars) == 0 else band_data.combine_first(masked)
+        imgdata = band_data if len(imgdata.data_vars) == 0 else merge([imgdata, band_data])
+    imgdata *= 255
+    return imgdata.astype('uint8')
+
+
 def apply_value_map(value_map: MutableMapping[str, List[ValueMapRule]],
                     data: Dataset,
                     band_mapper: Callable[[str], str]) -> Dataset:
@@ -140,7 +281,6 @@ def apply_value_map(value_map: MutableMapping[str, List[ValueMapRule]],
             bdata = ColorMapStyleDef.reint(bdata)
         for rule in rules:
             mask = rule.create_mask(bdata)
-
             masked = ColorMapStyleDef.create_colordata(bdata, rule.rgb, rule.alpha, mask)
             band_data = masked if len(band_data.data_vars) == 0 else band_data.combine_first(masked)
 
@@ -249,6 +389,7 @@ class ColorMapStyleDef(StyleDefBase):
 
     class MultiDateHandler(StyleDefBase.MultiDateHandler):
         auto_legend = True
+        non_animate_requires_aggregator = False
 
         def __init__(self, style: "ColorMapStyleDef", cfg: CFG_DICT) -> None:
             """
@@ -259,13 +400,18 @@ class ColorMapStyleDef(StyleDefBase):
             """
             super().__init__(style, cfg)
             style_cfg = cast(CFG_DICT, self._raw_cfg)
+            if self.animate:
+                self._value_map: Optional[MutableMapping[str, Union[ValueMapRule, MultiDateValueMapRule]]] = None
+            elif self.aggregator:
+                self._value_map = ValueMapRule.value_map_from_config(self.style, cast(CFG_DICT, self._raw_cfg["value_map"]))
+            else:
+                self._value_map = MultiDateValueMapRule.value_map_from_config(self, cast(CFG_DICT, self._raw_cfg["value_map"]))
 
         @property
         def value_map(self):
-            if self.animate:
-                return self.style.value_map
-            else:
-                return ValueMapRule.value_map_from_config(self.style, cast(CFG_DICT, self._raw_cfg["value_map"]))
+            if self._value_map is None:
+                self._value_map = self.style.value_map
+            return self._value_map
 
         def transform_data(self, data: "xarray.Dataset") -> "xarray.Dataset":
             """
@@ -274,8 +420,19 @@ class ColorMapStyleDef(StyleDefBase):
             :param data: Raw data
             :return: RGBA image xarray.  May have a time dimension
             """
-            agg = self.aggregator(data)
-            return apply_value_map(self.value_map, agg, self.style.product.band_idx.band)
+            if self.aggregator is None:
+                return apply_multidate_value_map(self.value_map, data, self.style.product.band_idx.band)
+            else:
+                agg = self.aggregator(data)
+                return apply_value_map(self.value_map, agg, self.style.product.band_idx.band)
+
+        def legend(self, bytesio: io.BytesIO) -> None:
+            """
+            Write a legend into a bytes buffer as a PNG image.
+
+            :param bytesio:  io.BytesIO byte buffer.
+            """
+            value_map_legend(self.value_map, self.legend_cfg, bytesio)
 
 # Register ColorMapStyleDef as a style subclass.
 StyleDefBase.register_subclass(ColorMapStyleDef, "value_map")

--- a/datacube_ows/styles/ramp.py
+++ b/datacube_ows/styles/ramp.py
@@ -568,11 +568,6 @@ class ColorRampDef(StyleDefBase):
                            )
 
     class MultiDateHandler(StyleDefBase.MultiDateHandler):
-        """
-        MultiDateHandler base class.
-
-        Handles "aggregator"-based index-value multi-date requests (e.g. delta)
-        """
         auto_legend = True
 
         def __init__(self, style: "ColorRampDef", cfg: CFG_DICT) -> None:

--- a/docs/cfg_colourmap_styles.rst
+++ b/docs/cfg_colourmap_styles.rst
@@ -463,11 +463,11 @@ You can access this with:
             "value_map": {
                 "level4": [
                     {'title': "Unchanged", 'abstract': "Equal", 'values': [255], 'color': '#000000'},
-                    # Other rules, as per single-value colour map
+                    # ... Other rules, as per the single-value colour map, not shown.
                 ]
             }
         }
     ],
 
-Note that the multi-date value_map is expected to act as single-date value map on the time-flattened
+The multi-date value_map is expected to act as single-date value map on the time-flattened
 data as returned by the aggregator function.

--- a/docs/cfg_colourramp_styles.rst
+++ b/docs/cfg_colourramp_styles.rst
@@ -532,9 +532,10 @@ Multi-Date Requests
 -------------------
 
 Colour Ramp Styles support customised non-animated handlers for
-`multi-date requests <https://datacube-ows.readthedocs.io/en/latest/cfg_styling.html#multi-date>`_.
-
-An aggregator function is defined that takes
+`multi-date requests <https://datacube-ows.readthedocs.io/en/latest/cfg_styling.html#multi-date>`_
+by providing for an aggregator function that converts the multi-date index data
+into a dateless index, and apply either the style's colour ramp (i.e. the same
+as the single-date case), or a separate colour ramp.
 
 aggregator_function
 ===================

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -427,7 +427,7 @@ flags_def = {
 def dummy_col_map_data():
     dim_coords = [-2.0, -1.0, 0.0, -1.0, -2.0, -3.0]
     output = xr.Dataset({
-        "pq": dim1_da("pq", [0b01000, 0b11001, 0b01010, 0b10011, 0b00100, 0b10111], dim_coords,
+        "pq": dim1_da("pq", [0b01000, 0b11001, 0b00010, 0b10011, 0b00100, 0b10001], dim_coords,
                       attrs={
                           "flags_definition": flags_def
                       })

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,7 @@ import numpy as np
 import pytest
 import xarray as xr
 
-from tests.utils import coords, dim1_da, dummy_da
+from tests.utils import coords, dim1_da, dim1_da_time, dummy_da
 
 
 @pytest.fixture
@@ -372,6 +372,56 @@ def raw_calc_null_mask():
     dim_coords = [-2.0, -1.0, 0.0, -1.0, -2.0, -3.0]
     return dim1_da("mask", [True] * len(dim_coords), dim_coords)
 
+@pytest.fixture
+def timed_raw_calc_null_mask():
+    dim_coords = [-2.0, -1.0, 0.0, -1.0, -2.0, -3.0]
+    dates = [datetime.datetime(2000, 1, 1), datetime.datetime(2020, 1, 1)]
+    return dim1_da_time("mask", [[True] * len(dates)] * len(dim_coords), dates, dim_coords)
+
+
+flags_def = {
+    "joviality": {
+        "bits": 4,
+        "values": {
+            '0': "Melancholic",
+            '1': "Joyous",
+        },
+        "description": "All splodgy looking"
+    },
+    "flavour": {
+        "bits": 3,
+        "values": {
+            '0': "Bland",
+            '1': "Tasty",
+        },
+        "description": "All splodgy looking"
+    },
+    "splodgy": {
+        "bits": 2,
+        "values": {
+            '0': "Splodgeless",
+            '1': "Splodgy",
+        },
+        "description": "All splodgy looking"
+    },
+    "ugly": {
+        "bits": 1,
+        "values": {
+            '0': False,
+            '1': True
+        },
+        "description": "Real, real ugly",
+    },
+    "impossible": {
+        "bits": 0,
+        "values": {
+            '0': False,
+            '1': "Woah!"
+        },
+        "description": "Won't happen. Can't happen. Might happen.",
+    },
+}
+
 
 @pytest.fixture
 def dummy_col_map_data():
@@ -379,49 +429,28 @@ def dummy_col_map_data():
     output = xr.Dataset({
         "pq": dim1_da("pq", [0b01000, 0b11001, 0b01010, 0b10011, 0b00100, 0b10111], dim_coords,
                       attrs={
-                          "flags_definition": {
-                              "joviality": {
-                                  "bits": 3,
-                                  "values": {
-                                      '0': "Melancholic",
-                                      '1': "Joyous",
-                                  },
-                                  "description": "All splodgy looking"
-                              },
-                              "flavour": {
-                                  "bits": 3,
-                                  "values": {
-                                      '0': "Bland",
-                                      '1': "Tasty",
-                                  },
-                                  "description": "All splodgy looking"
-                              },
-                              "splodgy": {
-                                  "bits": 2,
-                                  "values": {
-                                      '0': "Splodgeless",
-                                      '1': "Splodgy",
-                                  },
-                                  "description": "All splodgy looking"
-                              },
-                              "ugly": {
-                                  "bits": 1,
-                                  "values": {
-                                      '0': False,
-                                      '1': True
-                                  },
-                                  "description": "Real, real ugly",
-                              },
-                              "impossible": {
-                                  "bits": 0,
-                                  "values": {
-                                      '0': False,
-                                      '1': "Woah!"
-                                  },
-                                  "description": "Won't happen. Can't happen. Might happen.",
-                              },
-                          }
+                          "flags_definition": flags_def
                       })
+    })
+    return output
+
+@pytest.fixture
+def dummy_col_map_time_data():
+    dim_coords = [-2.0, -1.0, 0.0, -1.0, -2.0, -3.0]
+    dates = [datetime.datetime(2000, 1, 1), datetime.datetime(2020, 1, 1)]
+    output = xr.Dataset({
+        "pq": dim1_da_time("pq", [
+                [0b01000, 0b11110],
+                [0b11001, 0b10001],
+                [0b01010, 0b01101],
+                [0b10011, 0b01110],
+                [0b00100, 0b11011],
+                [0b10111, 0b11000],
+                            ],
+                            dates, dim_coords,
+                            attrs={
+                      "flags_definition": flags_def
+                  })
     })
     return output
 

--- a/tests/test_multidate_handler.py
+++ b/tests/test_multidate_handler.py
@@ -32,6 +32,7 @@ def test_multidate_handler():
             self.product = "test"
             self.needed_bands = ["test"]
             self.index_function = lambda x: FakeData()
+            self.stand_alone = True
             self.transform_single_date_data = lambda x: x
 
     data = np.random.randint(0, 255, size=(4, 3), dtype=np.uint8)

--- a/tests/test_style_api.py
+++ b/tests/test_style_api.py
@@ -483,9 +483,9 @@ def test_enum_colormap_style(dummy_col_map_data, raw_calc_null_mask, enum_colorm
         assert channel in result.data_vars.keys()
     # point 0 (8) Blah - red
     assert result["alpha"].values[0] == 255
-    assert result["red"].values[1] == 255
-    assert result["green"].values[1] == 0
-    assert result["blue"].values[1] == 0
+    assert result["red"].values[0] == 255
+    assert result["green"].values[0] == 0
+    assert result["blue"].values[0] == 0
     # point 1 (25) Blah - red
     assert result["alpha"].values[1] == 255
     assert result["red"].values[1] == 255
@@ -517,9 +517,9 @@ def test_enum_colormap_multidate(dummy_col_map_time_data, timed_raw_calc_null_ma
         assert channel in result.data_vars.keys()
     # point 0 (8->30) Blah Blah - red
     assert result["alpha"].values[0] == 255
-    assert result["red"].values[1] == 255
-    assert result["green"].values[1] == 0
-    assert result["blue"].values[1] == 0
+    assert result["red"].values[0] == 255
+    assert result["green"].values[0] == 0
+    assert result["blue"].values[0] == 0
     # point 1 (25->17) Blah - red
     assert result["alpha"].values[1] == 255
     assert result["red"].values[1] == 255
@@ -539,6 +539,58 @@ def test_enum_colormap_multidate(dummy_col_map_time_data, timed_raw_calc_null_ma
     assert result["blue"].values[4] == 0
     # point 5 (23->24): fall through - transparent
     assert result["alpha"].values[5] == 0
+
+
+@pytest.fixture
+def enum_animated_value_map():
+    return {
+        "name": "test_style",
+        "title": "Test Style",
+        "abstract": "This is a Test Style for Datacube WMS",
+        "value_map": {
+            "pq": [
+                {
+                    "title": "Blah",
+                    "values": [8, 25],
+                    "color": "#FF0000"
+                },
+                {
+                    "title": "Rock and Roll",
+                    "values": [4, 19, 25, 30],
+                    "color": "#00FF00"
+                },
+                {
+                    "title": "",
+                    "values": [17],
+                    "color": "#0000FF"
+                },
+            ]
+        },
+        "multi_date": [
+            {
+                "animate": True,
+                "preserve_user_date_order": True,
+                "allowed_count_range": [2, 2],
+            }
+        ]
+    }
+
+def test_animated_colour_map(enum_animated_value_map, dummy_col_map_time_data, timed_raw_calc_null_mask):
+    result = apply_ows_style_cfg(enum_animated_value_map,
+                                 dummy_col_map_time_data,
+                                 valid_data_mask=timed_raw_calc_null_mask)
+    for channel in ("red", "green", "blue", "alpha"):
+        assert channel in result.data_vars.keys()
+    # point 0 (8) Blah - red, green
+    assert result["alpha"].values[0][0] == 255
+    assert result["red"].values[0][0]== 255
+    assert result["green"].values[0][0]== 0
+    assert result["blue"].values[0][0]== 0
+
+    assert result["alpha"].values[0][1] == 255
+    assert result["red"].values[0][1] == 0
+    assert result["green"].values[0][1] == 255
+    assert result["blue"].values[0][1] == 0
 
 
 @pytest.fixture

--- a/tests/test_style_api.py
+++ b/tests/test_style_api.py
@@ -436,7 +436,7 @@ def enum_colormap_style_cfg():
                         },
                         {
                             "title": "Blah Blah",
-                            "values": [[8,25], [17,30,31]],
+                            "values": [[8, 25], [17, 30, 31]],
                             "color": "#FF0000"
                         },
                         {

--- a/tests/test_style_api.py
+++ b/tests/test_style_api.py
@@ -332,8 +332,11 @@ def test_colormap_style(dummy_col_map_data, raw_calc_null_mask, simple_colormap_
     result = apply_ows_style_cfg(simple_colormap_style_cfg, dummy_col_map_data, valid_data_mask=raw_calc_null_mask)
     for channel in ("red", "green", "blue", "alpha"):
         assert channel in result.data_vars.keys()
-    # point 0 fall through - transparent
-    assert result["alpha"].values[0] == 0
+    # point 0 tasy and possible: green
+    assert result["alpha"].values[0] == 255
+    assert result["red"].values[0] == 0
+    assert result["green"].values[0] == 255
+    assert result["blue"].values[0] == 0
     # point 1 tasty & impossible: red
     assert result["alpha"].values[1] == 255
     assert result["red"].values[1] == 255
@@ -344,21 +347,18 @@ def test_colormap_style(dummy_col_map_data, raw_calc_null_mask, simple_colormap_
     assert result["red"].values[2] == 0
     assert result["green"].values[2] == 0
     assert result["blue"].values[2] == 255
-    # point 3 bland & impossible: green
+    # point 3 splodgy or ugly: blue
     assert result["alpha"].values[3] == 255
     assert result["red"].values[3] == 0
-    assert result["green"].values[3] == 255
-    assert result["blue"].values[3] == 0
+    assert result["green"].values[3] == 0
+    assert result["blue"].values[3] == 255
     # point 4 splodgy or ugly: blue
     assert result["alpha"].values[4] == 255
     assert result["red"].values[4] == 0
     assert result["green"].values[4] == 0
     assert result["blue"].values[4] == 255
-    # point 5 bland & impossible: green
-    assert result["alpha"].values[5] == 255
-    assert result["red"].values[5] == 0
-    assert result["green"].values[5] == 255
-    assert result["blue"].values[5] == 0
+    # point 5 fall through -transparent
+    assert result["alpha"].values[5] == 0
 
 def test_colormap_multidate(dummy_col_map_time_data, timed_raw_calc_null_mask, simple_colormap_style_cfg):
     result = apply_ows_style_cfg(
@@ -416,7 +416,7 @@ def enum_colormap_style_cfg():
                 },
                 {
                     "title": "",
-                    "values": [23],
+                    "values": [17],
                     "color": "#0000FF"
                 },
             ]
@@ -450,7 +450,7 @@ def test_enum_colormap_style(dummy_col_map_data, raw_calc_null_mask, enum_colorm
     assert result["red"].values[4] == 0
     assert result["green"].values[4] == 255
     assert result["blue"].values[4] == 0
-    # point 5 (23): blue
+    # point 5 (17): blue
     assert result["alpha"].values[5] == 255
     assert result["red"].values[5] == 0
     assert result["green"].values[5] == 0

--- a/tests/test_style_api.py
+++ b/tests/test_style_api.py
@@ -605,7 +605,38 @@ def test_invalid_multidate_rules(enum_colormap_style_cfg, simple_colormap_style_
     with pytest.raises(ConfigException) as e:
         style = StandaloneStyle(simple_colormap_style_cfg)
     assert "min_count and max_count equal" in str(e.value)
-
+    simple_colormap_style_cfg["multi_date"][0]["allowed_count_range"] = [2, 2]
+    simple_colormap_style_cfg["multi_date"][0]["animate"] = True
+    with pytest.raises(ConfigException) as e:
+        style = StandaloneStyle(simple_colormap_style_cfg)
+    assert "value maps not supported for animation handlers" in str(e.value)
+    simple_colormap_style_cfg["multi_date"][0]["animate"] = False
+    simple_colormap_style_cfg["multi_date"][0]["value_map"]["pq"][0]["flags"] = [
+        {
+            "flavour": "Bland"
+        },
+        {
+            "flavour": "Bland"
+        },
+        {
+            "flavour": "Tasty"
+        },
+    ],
+    with pytest.raises(ConfigException) as e:
+        style = StandaloneStyle(simple_colormap_style_cfg)
+    assert "Flags entry has wrong number of rule sets for date count" in str(e.value)
+    simple_colormap_style_cfg["multi_date"][0]["value_map"]["pq"][0]["flags"] = [
+        {
+            "or": {"flavour": "Bland"},
+            "and": {"flavour": "Tasty"},
+        },
+        {
+            "flavour": "Tasty"
+        },
+    ]
+    with pytest.raises(ConfigException) as e:
+        style = StandaloneStyle(simple_colormap_style_cfg)
+    assert "combines 'and' and 'or' rules" in str(e.value)
 
 def test_ramp_legend(simple_colormap_style_cfg):
     img = generate_ows_legend_style_cfg(simple_colormap_style_cfg, 1)

--- a/tests/test_style_api.py
+++ b/tests/test_style_api.py
@@ -253,7 +253,8 @@ def simple_colormap_style_cfg():
                     "title": "Possibly Tasty",
                     "abstract": "Tasty and Possible",
                     "flags": {
-                        "impossible": "Woah!"
+                        "flavour": "Tasty",
+                        "impossible": False
                     },
                     "color": "#00FF00"
                 },
@@ -269,7 +270,61 @@ def simple_colormap_style_cfg():
                     "color": "#0000FF"
                 },
             ]
-        }
+        },
+        "multi_date": [
+            {
+                "animate": False,
+                "preserve_user_date_order": True,
+                "allowed_count_range": [2, 2],
+                "value_map": {
+                    "pq": [
+                        {
+                            "title": "Bland to Tasty",
+                            "abstract": "All yummification.",
+                            "flags": [
+                                {
+                                    "flavour": "Bland"
+                                },
+                                {
+                                    "flavour": "Tasty"
+                                },
+                            ],
+                            "color": "#8080FF"
+                        },
+                        {
+                            "title": "Was ugly, is splodgy",
+                            "abstract": "unless they have also been yummified",
+                            "flags": [
+                                {
+                                    "ugly": True,
+                                },
+                                {
+                                    "splodgy": "Splodgy"
+                                }
+                            ],
+                            "color": "#FF00FF"
+                        },
+                        {
+                            "title": "Woah!",
+                            "abstract": "Ended up impossible (may have just always been impossible) - doesn't include impossible yummifications",
+                            "flags": [
+                                {}, # Empty date rule = matches all remaining pixels for that date
+                                {
+                                    "impossible": "Woah!"
+                                }
+                            ],
+                            "color": "#FF0080"
+                        },
+                        {
+                            "title": "Everything else",
+                            "abstract": "The rest of what's left",
+                            "flags": [{}, {}],
+                            "color": "#808080"
+                        }
+                    ]
+                }
+            }
+        ]
     }
 
 
@@ -305,6 +360,41 @@ def test_colormap_style(dummy_col_map_data, raw_calc_null_mask, simple_colormap_
     assert result["green"].values[5] == 255
     assert result["blue"].values[5] == 0
 
+def test_colormap_multidate(dummy_col_map_time_data, timed_raw_calc_null_mask, simple_colormap_style_cfg):
+    result = apply_ows_style_cfg(
+                        simple_colormap_style_cfg,
+                        dummy_col_map_time_data,
+                        valid_data_mask=timed_raw_calc_null_mask)
+    # Point 0: fallback
+    assert result["alpha"].values[0] == 255
+    assert result["red"].values[0] == 128
+    assert result["green"].values[0] == 128
+    assert result["blue"].values[0] == 128
+    # Point 1: Woah!
+    assert result["alpha"].values[1] == 255
+    assert result["red"].values[1] == 255
+    assert result["green"].values[1] == 0
+    assert result["blue"].values[1] == 128
+    # Point 2: ugly to splody
+    assert result["alpha"].values[2] == 255
+    assert result["red"].values[2] == 255
+    assert result["green"].values[2] == 0
+    assert result["blue"].values[2] == 255
+    # Point 3: yummification
+    assert result["alpha"].values[3] == 255
+    assert result["red"].values[3] == 128
+    assert result["green"].values[3] == 128
+    assert result["blue"].values[3] == 255
+    # Point 4: yummification
+    assert result["alpha"].values[4] == 255
+    assert result["red"].values[4] == 128
+    assert result["green"].values[4] == 128
+    assert result["blue"].values[4] == 255
+    # Point 5: yummification
+    assert result["alpha"].values[5] == 255
+    assert result["red"].values[5] == 128
+    assert result["green"].values[5] == 128
+    assert result["blue"].values[5] == 255
 
 @pytest.fixture
 def enum_colormap_style_cfg():

--- a/tests/test_style_api.py
+++ b/tests/test_style_api.py
@@ -318,6 +318,30 @@ def simple_colormap_style_cfg():
                             "color": "#FF0080"
                         },
                         {
+                            "title": "Flawless to Perfect",
+                            "flags": [
+                                {
+                                    "and": {
+                                        "impossible": "Woah!",
+                                        "joviality": "Joyous",
+                                        "flavour": "Tasty",
+                                        "splodgy": "Splodgeless",
+                                        "ugly": False,
+                                    },
+                                },
+                                {
+                                    "or": {
+                                        "impossible": False,
+                                        "joviality": "Melancholic",
+                                        "flavour": "Bland",
+                                        "splodgy": "Splodgy",
+                                        "ugly": True,
+                                    }
+                                }
+                            ],
+                            "color": "#FFFFFF"
+                        },
+                        {
                             "title": "Everything else",
                             "abstract": "The rest of what's left",
                             "flags": [{}, {}],
@@ -611,6 +635,7 @@ def test_invalid_multidate_rules(enum_colormap_style_cfg, simple_colormap_style_
         style = StandaloneStyle(simple_colormap_style_cfg)
     assert "value maps not supported for animation handlers" in str(e.value)
     simple_colormap_style_cfg["multi_date"][0]["animate"] = False
+    orig_flags = simple_colormap_style_cfg["multi_date"][0]["value_map"]["pq"][0]["flags"]
     simple_colormap_style_cfg["multi_date"][0]["value_map"]["pq"][0]["flags"] = [
         {
             "flavour": "Bland"
@@ -625,7 +650,7 @@ def test_invalid_multidate_rules(enum_colormap_style_cfg, simple_colormap_style_
     with pytest.raises(ConfigException) as e:
         style = StandaloneStyle(simple_colormap_style_cfg)
     assert "Flags entry has wrong number of rule sets for date count" in str(e.value)
-    simple_colormap_style_cfg["multi_date"][0]["value_map"]["pq"][0]["flags"] = [
+    enum_colormap_style_cfg["multi_date"][0]["value_map"]["pq"][0]["flags"] = [
         {
             "or": {"flavour": "Bland"},
             "and": {"flavour": "Tasty"},
@@ -635,8 +660,17 @@ def test_invalid_multidate_rules(enum_colormap_style_cfg, simple_colormap_style_
         },
     ]
     with pytest.raises(ConfigException) as e:
-        style = StandaloneStyle(simple_colormap_style_cfg)
+        style = StandaloneStyle(enum_colormap_style_cfg)
     assert "combines 'and' and 'or' rules" in str(e.value)
+    del simple_colormap_style_cfg["multi_date"][0]["value_map"]["pq"][0]["flags"]
+    with pytest.raises(ConfigException) as e:
+        style = StandaloneStyle(simple_colormap_style_cfg)
+    assert "must have a non-empty 'flags' or 'values' section" in str(e.value)
+    enum_colormap_style_cfg["multi_date"][0]["value_map"]["pq"][0]["flags"] = orig_flags
+    with pytest.raises(ConfigException) as e:
+        style = StandaloneStyle(enum_colormap_style_cfg)
+    assert "has both a 'flags' and a 'values' section - choose one" in str(e.value)
+
 
 def test_ramp_legend(simple_colormap_style_cfg):
     img = generate_ows_legend_style_cfg(simple_colormap_style_cfg, 1)

--- a/tests/test_style_api.py
+++ b/tests/test_style_api.py
@@ -6,6 +6,7 @@
 import pytest
 
 from datacube_ows.ogc_utils import ConfigException
+
 from datacube_ows.styles.api import ( # noqa: F401 isort:skip
                                      StandaloneStyle, apply_ows_style,
                                      apply_ows_style_cfg, create_geobox,

--- a/tests/test_style_api.py
+++ b/tests/test_style_api.py
@@ -583,9 +583,9 @@ def test_animated_colour_map(enum_animated_value_map, dummy_col_map_time_data, t
         assert channel in result.data_vars.keys()
     # point 0 (8) Blah - red, green
     assert result["alpha"].values[0][0] == 255
-    assert result["red"].values[0][0]== 255
-    assert result["green"].values[0][0]== 0
-    assert result["blue"].values[0][0]== 0
+    assert result["red"].values[0][0] == 255
+    assert result["green"].values[0][0] == 0
+    assert result["blue"].values[0][0] == 0
 
     assert result["alpha"].values[0][1] == 255
     assert result["red"].values[0][1] == 0

--- a/tests/test_styles.py
+++ b/tests/test_styles.py
@@ -789,3 +789,9 @@ def test_bad_mpl_ramp():
     with pytest.raises(ConfigException) as e:
         ramp = read_mpl_ramp("definitely_not_a_real_matplotlib_ramp_name")
     assert "Invalid Matplotlib name: " in str(e.value)
+
+def test_rule_spec_not_impl(product_layer_mask_map, style_cfg_map_mask, minimal_dc):
+    from datacube_ows.styles.colormap import AbstractValueMapRule
+    with pytest.raises(NotImplementedError):
+        style_def = datacube_ows.styles.StyleDef(product_layer_mask_map, style_cfg_map_mask, stand_alone=True)
+        AbstractValueMapRule(style_def, "band", {"title": "Abstract Test", "color": "magenta", "value_map": {}})

--- a/tests/test_styles.py
+++ b/tests/test_styles.py
@@ -516,7 +516,7 @@ def test_alpha_style_map(
 
         result = style_def.transform_data(ds, None)
         alpha_channel = result["alpha"].values
-        assert (alpha_channel == 127).all()
+        assert (alpha_channel == 128).all()
 
         style_def = datacube_ows.styles.StyleDef(product_layer_alpha_map, style_cfg_map_alpha_3)
 
@@ -626,8 +626,8 @@ def style_cfg_map_mask():
         "value_map": {
             "foo": [
                 {
-                    "title": "Non-Transparent",
-                    "abstract": "A Non-Transparent Value",
+                    "title": "Transparent",
+                    "abstract": "A Transparent Value",
                     "flags": {
                         "bar": 1,
                     },

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -67,3 +67,26 @@ def dim1_da(name, vals, coords, with_time=True, attrs=None):
     )
     return output
 
+def dim1_da_time(name, vals, dates, coords, attrs=None):
+    if len(coords) != len(vals):
+        raise Exception("vals and coords must match lengths")
+    for v in vals:
+        if len(v) != len(dates):
+            raise Exception("dates and coords must match lengths")
+    dims = ["dim", "time"]
+    shape = [len(coords), len(dates)]
+    coords = {
+        "dim": coords,
+        "time": [np.datetime64(d) for d in dates],
+    }
+    buff_arr = np.array(vals)
+    data = np.ndarray(shape, buffer=buff_arr, dtype=buff_arr.dtype)
+    output = xr.DataArray(
+        data,
+        coords=coords,
+        dims=dims,
+        attrs=attrs,
+        name=name,
+    )
+    return output
+


### PR DESCRIPTION
Non-animated multidate support for colour-map styles.

## Description of new features

In addition to the standard animated handlers previously supported by all style types, this PR introduces two additional approaches to produce an non-animated image from a multi-date request:

1. Using a variant of the `value_map`_ entry used for the single-date case. This is a much simpler way of achieving most use cases.
2. Using an aggregator function, which allows for fully customisable behaviour but requires writing Python code.

### Multi-date value_map

A value_map in a multi-date handler has the same general structure as the
single date value_map.  The handler must serve a single
number of date values.  The discussion here will assume an `allowed_count_range``
of `[2, 2]`, but higher values should work.

The ``flags`` or ``values`` entry for each rule is replaced by a list of
single-date entries.  A rule is matched for a pixel in the output image
if the pixel matches the provided rules at all date values.  Additionally
an empty rule set of either type for a particular date means
"matches everything for that date that hasn't matched already".

See this simple example:

E.g.:

```
    style_example = {
        "name": "multi_date_example",
        "title": "Multidate enumeration example",
        "abstract": "This uses enumeration type rules, but bitflag rules can be used in a similar manner",
        # This is the single date value map.
        "value_map": {
            "band_name": [
                {'title': "A", 'values': [0], 'color': '#000000', 'alpha': 0},
                {'title': "B", 'values': [1], 'color': '#FF0000', 'alpha': 1},
                {'title': "C", 'values': [2], 'color': '#00FF00', 'alpha': 1},
                {'title': "D", 'values': [3], 'color': '#0000FF', 'alpha': 1},
            ]
        },
        "multi_date": [
            {
                "animate": False,
                "preserve_user_date_order": True,
                "allowed_count_range": [2, 2],
                #
                # This is multi-date value-map for a handler with allowed count of 2,
                # so instead of being a list of integers, the values section of each
                # rule is a list of two lists of integers.
                #
                "value_map": {
                    "band_name": [
                        # Simple example rules
                        {'title': "A (unchanged)", 'values': [[0], [0]], 'color': '#000000', 'alpha': 1},
                        {'title': "B -> A", 'values': [[1], [0]], 'color': '#300000', 'alpha': 1},

                        # This matches all remaining cases that end in type A, so C->A and D->A
                        {'title': "Other -> A", 'values': [[], [0]], 'color': '#003030', 'alpha': 1},

                        # This covers C->C, D->D, C->D and D->C
                        {'title': "C/D -> C/D", 'values': [[2, 3], [2, 3]], 'color': '#00A0A0', 'alpha': 1},

                        # B to anything - except A, as that has already been matched by a previous rule.
                        {'title': "B -> Other", 'values': [[1], []], 'color': '#A00000', 'alpha': 1},

                        # Matches all remaining combinations
                        {'title': "Everything else", 'values': [[], []], 'color': '#FFFFFF', 'alpha': 1},
                    ]
                },
            }
        ]
    }
```

This fanciful example from the test suite illustrates the syntax for
bitflag type rules:

```
    "multi_date": [
        {
            "animate": False,
            "preserve_user_date_order": True,
            "allowed_count_range": [2, 2],
            "value_map": {
                "pq": [
                    {
                        "title": "Bland to Tasty",
                        "flags": [
                            {"flavour": "Bland"}, # Rules for first date
                            {"flavour": "Tasty"}, # Rules for second date
                        ],
                        "color": "#8080FF"
                    },
                    {
                        "title": "Was ugly, is splodgy",
                        "flags": [
                            {"ugly": True,},
                            {"splodgy": "Splodgy"}
                        ],
                        "color": "#FF00FF"
                    },
                    {
                        "title": "Woah!",
                        "flags": [
                            {}, # Empty date rule = matches all remaining pixels for that date
                            {"impossible": "Woah!"}
                        ],
                        "color": "#FF0080"
                    },
                    {
                        "title": "Everything else",
                        "abstract": "The rest of what's left",
                        "flags": [{}, {}],
                        "color": "#808080"
                    }
                ]
            }
        }
    ]
```


### Aggregator function

Alternately, you can define an aggregator function using OWS's function configuration format.

The function is passed a multi-date Xarray Dataset and is expected to return a timeless Dataset,
which can then be rendered using either the single-date value-map, or a separate single-date value-map
defined for the handler.

This approach is infinitely flexible, and may be more efficient for some use cases than
using the multidate value map approach.


As a simple example, given the following callback function:

```
    def detect_equals(data: xr.Dataset) -> xr.Dataset:
        # Split data in two date slices
        data1, data2 = (data.sel(time=dt) for dt in data.coords["time"].values)

        equality_mask = data1["level4"] != data2["level4"]

        # Set pixels that are equal in both date slices to 255, set all
        # other pixels at the second date-slice value.
        data1["level4"] = data2["level4"].where(equality_mask, other=255)
        return data1
```
You can access this with:

```
    "multi_date": [
        {
            "animate": False,
            "preserve_user_date_order": True,
            "allowed_count_range": [2, 2],
            "aggregator_function": {
                "function": "my_module.my_package.detect_equals",
            },
            "value_map": {
                "level4": [
                    {'title': "Unchanged", 'abstract': "Equal", 'values': [255], 'color': '#000000'},
                    # ... Other rules, as per the single-value colour map, not shown.
                ]
            }
        }
    ],
```

The multi-date value_map is expected to act as single-date value map on the time-flattened
data as returned by the aggregator function.
