### PR TITLE
Prometheus refactor.

### DIFF
--- a/datacube_ows/ogc.py
+++ b/datacube_ows/ogc.py
@@ -53,11 +53,11 @@ prometheus_ows_ogc_metric = metrics.summary(
     labels={
         'query_request': lambda: request.args.get('request', "NONE").upper(),
         'query_service': lambda: request.args.get('service', "NONE").upper(),
-        'query_version': lambda: request.args.get('version', "NONE"),
-        'query_layer': lambda: (request.args.get('layers', "NONE")  # WMS
-                                or request.args.get('layer', "NONE")  # WMTS
-                                or request.args.get('coverage', "NONE")  # WCS 1.x
-                                or request.args.get('coverageid', "NONE")  # WCS 2.x
+        'query_version': lambda: request.args.get('version'),
+        'query_layer': lambda: (request.args.get('layers')  # WMS
+                                or request.args.get('layer')  # WMTS
+                                or request.args.get('coverage')  # WCS 1.x
+                                or request.args.get('coverageid')  # WCS 2.x
                                 ),
         'status': lambda r: r.status_code,
     }

--- a/datacube_ows/ogc.py
+++ b/datacube_ows/ogc.py
@@ -51,13 +51,13 @@ prometheus_ows_ogc_metric = metrics.summary(
     "ows_ogc",
     "Summary by OGC request protocol, version, operation, layer, and HTTP Status",
     labels={
-        'query_request': lambda: request.args.get('request').upper(),
-        'query_service': lambda: request.args.get('service').upper(),
-        'query_version': lambda: request.args.get('version'),
-        'query_layer': lambda: (request.args.get('layers')  # WMS
-                                or request.args.get('layer')  # WMTS
-                                or request.args.get('coverage')  # WCS 1.x
-                                or request.args.get('coverageid')  # WCS 2.x
+        'query_request': lambda: request.args.get('request', "NONE").upper(),
+        'query_service': lambda: request.args.get('service', "NONE").upper(),
+        'query_version': lambda: request.args.get('version', "NONE"),
+        'query_layer': lambda: (request.args.get('layers', "NONE")  # WMS
+                                or request.args.get('layer', "NONE")  # WMTS
+                                or request.args.get('coverage', "NONE")  # WCS 1.x
+                                or request.args.get('coverageid', "NONE")  # WCS 2.x
                                 ),
         'status': lambda r: r.status_code,
     }

--- a/datacube_ows/ogc.py
+++ b/datacube_ows/ogc.py
@@ -47,7 +47,7 @@ metrics = initialise_prometheus(app, _LOG)
 OWS_SUPPORTED = supported_versions()
 
 # Prometheus Metrics
-prometheus_ows_ogc_metric=metrics.summary(
+prometheus_ows_ogc_metric = metrics.summary(
     "ows_ogc",
     "Summary by OGC request protocol, version, operation, layer, and HTTP Status",
     labels={

--- a/datacube_ows/startup_utils.py
+++ b/datacube_ows/startup_utils.py
@@ -32,7 +32,6 @@ __all__ = [
     'parse_config_file',
     'initialise_flask',
     'initialise_prometheus',
-    'initialise_prometheus_register',
     'generate_locale_selector',
     'CredentialManager',
 ]

--- a/datacube_ows/startup_utils.py
+++ b/datacube_ows/startup_utils.py
@@ -211,27 +211,9 @@ def initialise_prometheus(app, log=None):
         return metrics
     return FakeMetrics()
 
-
-def initialise_prometheus_register(metrics):
-    # Register routes with Prometheus - call after all routes set up.
-    if os.environ.get("prometheus_multiproc_dir", False):
-        metrics.register_default(
-            metrics.summary(
-                'flask_ows_request_method_and_layer', 'Request summary by protocol, version, command and layer',
-                labels={
-                    'query_request': lambda: request.args.get('request'),
-                    'query_service': lambda: request.args.get('service'),
-                    'query_version': lambda: request.args.get('version'),
-                    'query_layer': lambda: (request.args.get('layers')          # WMS
-                                            or request.args.get('layer')        # WMTS
-                                            or request.args.get('coverage')     # WCS 1.x
-                                            or request.args.get('coverageid')   # WCS 2.x
-                                            ),
-                    'status': lambda r: r.status,
-                }
-            )
-        )
-
+def request_extractor():
+    qreq = request.args.get('request')
+    return qreq
 
 def generate_locale_selector(locales):
     def selector_template():

--- a/tests/test_startup.py
+++ b/tests/test_startup.py
@@ -107,6 +107,7 @@ def test_initialise_sentry(monkeypatch):
 def test_prometheus_inactive(monkeypatch):
     monkeypatch.setenv("prometheus_multiproc_dir", "")
     from datacube_ows.startup_utils import initialise_prometheus
+    initialise_prometheus(None)
 
 
 def test_supported_version():

--- a/tests/test_startup.py
+++ b/tests/test_startup.py
@@ -106,8 +106,7 @@ def test_initialise_sentry(monkeypatch):
 
 def test_prometheus_inactive(monkeypatch):
     monkeypatch.setenv("prometheus_multiproc_dir", "")
-    from datacube_ows.startup_utils import (  # noqa: F401
-        initialise_prometheus, initialise_prometheus_register)
+    from datacube_ows.startup_utils import initialise_prometheus
 
 
 def test_supported_version():


### PR DESCRIPTION
Simplify metric names and add a common prefix `ows_`.
Convert case insensitive parameters serving as labels to all upper case to simplify queries.
