### PR TITLE
Minor fix to prometheus metrics for GetFeatureInfo requests.

### DIFF
--- a/datacube_ows/ogc.py
+++ b/datacube_ows/ogc.py
@@ -54,7 +54,8 @@ prometheus_ows_ogc_metric = metrics.histogram(
         'query_request': lambda: request.args.get('request', "NONE").upper(),
         'query_service': lambda: request.args.get('service', "NONE").upper(),
         'query_version': lambda: request.args.get('version'),
-        'query_layer': lambda: (request.args.get('layers')  # WMS
+        'query_layer': lambda: (request.args.get('query_layers') # WMS GetFeatureInfo
+                                or request.args.get('layers')  # WMS
                                 or request.args.get('layer')  # WMTS
                                 or request.args.get('coverage')  # WCS 1.x
                                 or request.args.get('coverageid')  # WCS 2.x


### PR DESCRIPTION
Layer name not being captured correctly by Prometheus for GetFeatureInfo requests (for some clients - Terria sets both "layers" and "query_layers" so requests from Terria clients work fine.)