### PR TITLE
Legend Generation Refactor.

### DIFF
--- a/datacube_ows/styles/base.py
+++ b/datacube_ows/styles/base.py
@@ -32,7 +32,7 @@ class LegendBase(OWSConfigEntry):
     """
     Legend base class.
     """
-    def __init__(self, style_or_mdh: Union["StyleDefBase","StyleDefBase.Legend"], cfg: CFG_DICT) -> None:
+    def __init__(self, style_or_mdh: Union["StyleDefBase", "StyleDefBase.Legend"], cfg: CFG_DICT) -> None:
         super().__init__(cfg)
         raw_cfg = cast(CFG_DICT, self._raw_cfg)
         self.style_or_mdh = style_or_mdh
@@ -429,6 +429,7 @@ class StyleDefBase(OWSExtensibleConfigEntry, OWSMetadataConfig):
                     return sub
         return None
 
+    # pylint: disable=abstract-method
     class Legend(LegendBase):
         """
         Style Legend class.
@@ -505,6 +506,7 @@ class StyleDefBase(OWSExtensibleConfigEntry, OWSMetadataConfig):
             """
             return self.style.transform_single_date_data(data)
 
+        # pylint: disable=abstract-method
         class Legend(LegendBase):
             """
             MultiDateHandler Legend class.

--- a/datacube_ows/styles/colormap.py
+++ b/datacube_ows/styles/colormap.py
@@ -280,7 +280,7 @@ class ColorMapLegendBase(StyleDefBase.Legend):
         self.patches: List[PatchTemplate] = []
 
     def register_value_map(self, value_map: MutableMapping[str, List["AbstractValueMapRule"]]) -> None:
-        for band in value_map.keys()flak:
+        for band in value_map.keys():
             for idx, rule in reversed(list(enumerate(value_map[band]))):
                 # only include values that are not transparent (and that have a non-blank title or abstract)
                 if rule.alpha > 0.001 and rule.label:

--- a/datacube_ows/styles/colormap.py
+++ b/datacube_ows/styles/colormap.py
@@ -277,10 +277,10 @@ class ColorMapLegendBase(StyleDefBase.Legend):
         self.ncols = int(raw_cfg.get("ncols", 1))
         if self.ncols < 1:
             raise ConfigException("ncols must be a positive integer")
+        self.patches: List[PatchTemplate] = []
 
     def register_value_map(self, value_map: MutableMapping[str, List["AbstractValueMapRule"]]) -> None:
-        self.patches = []
-        for band in value_map.keys():
+        for band in value_map.keys()flak:
             for idx, rule in reversed(list(enumerate(value_map[band]))):
                 # only include values that are not transparent (and that have a non-blank title or abstract)
                 if rule.alpha > 0.001 and rule.label:

--- a/datacube_ows/styles/colormap.py
+++ b/datacube_ows/styles/colormap.py
@@ -263,29 +263,51 @@ def apply_value_map(value_map: MutableMapping[str, List[ValueMapRule]],
     return imgdata.astype('uint8')
 
 
-def value_map_legend(value_map: MutableMapping[str, List[ValueMapRule]],
-                     legend_cfg: CFG_DICT,
-                     bytesio: io.BytesIO) -> None:
-    patches = []
-    for band in value_map.keys():
-        for rule in reversed(value_map[band]):
-            # only include values that are not transparent (and that have a non-blank title or abstract)
-            if rule.alpha > 0.001 and rule.label:
-                try:
-                    patch = mpatches.Patch(color=rule.rgb.hex_l, label=rule.label)
-                # pylint: disable=broad-except
-                except Exception as e:
-                    print("Error creating patch?", e)
-                patches.append(patch)
-    cfg = legend_cfg
-    plt.rcdefaults()
-    if cfg.get("rcParams", None) is not None:
-        plt.rcParams.update(cfg.get("rcParams"))
-    figure = plt.figure(figsize=(cfg.get("width", 3),
-                                 cfg.get("height", 1.25)))
-    plt.axis('off')
-    legend = plt.legend(handles=patches, loc='center', frameon=False)
-    plt.savefig(bytesio, format='png')
+class PatchTemplate:
+    def __init__(self, idx: int, rule: AbstractValueMapRule) -> None:
+        self.idx = idx
+        self.colour = rule.rgb.hex_l
+        self.label = rule.label
+
+
+class ColorMapLegendBase(StyleDefBase.Legend):
+    def __init__(self, style_or_mdh: Union["StyleDefBase", "StyleDefBase.Legend"], cfg: CFG_DICT) -> None:
+        super().__init__(style_or_mdh, cfg)
+        raw_cfg = cast(CFG_DICT, self._raw_cfg)
+        self.ncols = int(raw_cfg.get("ncols", 1))
+        if self.ncols < 1:
+            raise ConfigException("ncols must be a positive integer")
+
+    def register_value_map(self, value_map: MutableMapping[str, List["AbstractValueMapRule"]]) -> None:
+        self.patches = []
+        for band in value_map.keys():
+            for idx, rule in reversed(list(enumerate(value_map[band]))):
+                # only include values that are not transparent (and that have a non-blank title or abstract)
+                if rule.alpha > 0.001 and rule.label:
+                    self.patches.append(PatchTemplate(idx, rule))
+
+    def render(self, bytesio: io.BytesIO) -> None:
+        patches = [
+            mpatches.Patch(color=pt.colour, label=pt.label)
+            for pt in self.patches
+        ]
+        plt.rcdefaults()
+        if self.mpl_rcparams:
+            plt.rcParams.update(self.mpl_rcparams)
+        plt.figure(figsize=(self.width, self.height))
+        plt.axis('off')
+        if self.title:
+            plt.legend(handles=patches,
+                       loc='center',
+                       ncol=self.ncols,
+                       frameon=False,
+                       title=self.title)
+        else:
+            plt.legend(handles=patches,
+                       loc='center',
+                       ncol=self.ncols,
+                       frameon=False)
+        plt.savefig(bytesio, format='png')
 
 
 class ColorMapStyleDef(StyleDefBase):
@@ -305,6 +327,9 @@ class ColorMapStyleDef(StyleDefBase):
         super().__init__(product, style_cfg, stand_alone=stand_alone, user_defined=user_defined)
         style_cfg = cast(CFG_DICT, self._raw_cfg)
         self.value_map = AbstractValueMapRule.value_map_from_config(self, cast(CFG_DICT, style_cfg["value_map"]))
+        self.legend_cfg.register_value_map(self.value_map)
+        for mdh in self.multi_date_handlers:
+            mdh.legend_cfg.register_value_map(mdh.value_map)
         for band in self.value_map.keys():
             self.raw_needed_bands.add(band)
 
@@ -353,13 +378,8 @@ class ColorMapStyleDef(StyleDefBase):
         #            data[band] = data[band].where(extent_mask)
         return apply_value_map(self.value_map, data, self.product.band_idx.band)
 
-    def single_date_legend(self, bytesio: io.BytesIO) -> None:
-        """
-        Write a legend into a bytes buffer as a PNG image.
-
-        :param bytesio:  io.BytesIO byte buffer.
-        """
-        value_map_legend(self.value_map, self.legend_cfg, bytesio)
+    class Legend(ColorMapLegendBase):
+        pass
 
     class MultiDateHandler(StyleDefBase.MultiDateHandler):
         auto_legend = True
@@ -400,13 +420,8 @@ class ColorMapStyleDef(StyleDefBase):
                 agg = self.aggregator(data)
                 return apply_value_map(self.value_map, agg, self.style.product.band_idx.band)
 
-        def legend(self, bytesio: io.BytesIO) -> None:
-            """
-            Write a legend into a bytes buffer as a PNG image.
-
-            :param bytesio:  io.BytesIO byte buffer.
-            """
-            value_map_legend(self.value_map, self.legend_cfg, bytesio)
+        class Legend(ColorMapLegendBase):
+            pass
 
 # Register ColorMapStyleDef as a style subclass.
 StyleDefBase.register_subclass(ColorMapStyleDef, "value_map")

--- a/datacube_ows/styles/ramp.py
+++ b/datacube_ows/styles/ramp.py
@@ -320,6 +320,8 @@ class RampLegendBase(StyleDefBase.Legend):
             if "ticks" in raw_cfg:
                 raise ConfigException("Cannot use ticks and ticks_every in the same legend")
             self.ticks_every = Decimal(cast(Union[int, float, str], raw_cfg["ticks_every"]))
+            if self.ticks_every.is_zero() or self.ticks_every.is_signed():
+                raise ConfigException("ticks_every must be greater than zero")
             ticks_handled = True
         if "ticks" in raw_cfg:
             if "tick_count" in raw_cfg:
@@ -371,6 +373,9 @@ class RampLegendBase(StyleDefBase.Legend):
                     break
             if self.end.is_nan():
                 self.end = Decimal(ramp.ramp[-1]["value"])
+        for t in self.ticks:
+            if t < self.begin or t > self.end:
+                raise ConfigException("Explicit ticks must all be within legend begin/end range")
         if self.ticks_every is not None:
             tickval = self.begin
             while tickval < self.end:

--- a/datacube_ows/styles/ramp.py
+++ b/datacube_ows/styles/ramp.py
@@ -363,14 +363,14 @@ class RampLegendBase(StyleDefBase.Legend):
                     self.begin = Decimal(col_def["value"])
                     break
             if self.begin.is_nan():
-                self.begin = Decimal(self.ramp[0]["value"])
+                self.begin = Decimal(ramp.ramp[0]["value"])
         if self.end.is_nan():
             for col_def in reversed(ramp.ramp):
                 if isclose(col_def.get("alpha", 1.0), 1.0, abs_tol=1e-9):
                     self.end = Decimal(col_def["value"])
                     break
             if self.end.is_nan():
-                self.end = Decimal(self.ramp[-1]["value"])
+                self.end = Decimal(ramp.ramp[-1]["value"])
         if self.ticks_every is not None:
             tickval = self.begin
             while tickval < self.end:

--- a/datacube_ows/styles/ramp.py
+++ b/datacube_ows/styles/ramp.py
@@ -164,90 +164,13 @@ def read_mpl_ramp(mpl_ramp: str) -> RAMP_SPEC:
     return unscaled_cmap
 
 
-def colour_ramp_legend(bytesio: io.BytesIO,
-                       legend_cfg: CFG_DICT,
-                       colour_ramp: "ColorRamp",
-                       map_name: str,
-                       default_title: str) -> None:
-    """
-    Generate a matplotlib legend for a colour ramp
-
-    :param bytesio: A BytesIO object to write the legend image into
-    :param legend_cfg: Legend configuration
-    :param colour_ramp: A ColorRamp object
-    :param map_name: a name for the transient MPL colourmap object
-    :param default_title: The default title to use (used if no title is set in legend_cfg)
-    """
-    def create_cdict_ticks(cfg: CFG_DICT, ramp: "ColorRamp") -> Tuple[
-        MutableMapping[str, List[Tuple[float, float, float]]],
-        MutableMapping[float, str],
-    ]:
-        normalize_factor = float(ramp.legend_end) - float(ramp.legend_begin)
-
-        cdict = cast(MutableMapping[str, List[Tuple[float, float, float]]], dict())
-        bands = cast(MutableMapping[str, List[Tuple[float, float, float]]], defaultdict(list))
-        started = False
-        finished = False
-        for index, ramp_point in enumerate(ramp.ramp):
-            if finished:
-                continue
-
-            value = cast(Union[float, int], ramp_point.get("value"))
-            normalized = (value - float(ramp.legend_begin)) / float(normalize_factor)
-
-            if not started:
-                if isclose(value, float(ramp.legend_begin), abs_tol=1e-9):
-                    started = True
-                else:
-                    continue
-            if not finished:
-                if isclose(value, float(ramp.legend_end), abs_tol=1e-9):
-                    finished = True
-
-            for band, intensity in ramp.components.items():
-                bands[band].append((normalized, intensity[index], intensity[index]))
-
-        for band, blist in bands.items():
-            cdict[band] = blist
-
-        ticks = cast(MutableMapping[float, str], dict())
-        for tick, tick_lbl in zip(ramp.ticks, ramp.tick_labels):
-            value = float(tick)
-            normalized = (value - float(ramp.legend_begin)) / float(normalize_factor)
-            ticks[normalized] = tick_lbl   # REVISIT: map on float???
-
-        return cdict, ticks
-
-    cdict, ticks = create_cdict_ticks(legend_cfg, colour_ramp)
-
-    plt.rcdefaults()
-    if colour_ramp.legend_mpl_rcparams:
-        plt.rcParams.update(colour_ramp.legend_mpl_rcparams)
-    fig = plt.figure(figsize=(colour_ramp.legend_width, colour_ramp.legend_height))
-    ax = fig.add_axes(colour_ramp.legend_strip_location)
-    custom_map = LinearSegmentedColormap(map_name, cdict)
-    color_bar = matplotlib.colorbar.ColorbarBase(
-        ax,
-        cmap=custom_map,
-        orientation="horizontal")
-
-    color_bar.set_ticks(list(ticks.keys()))
-    color_bar.set_ticklabels(list(ticks.values()))
-
-    title = colour_ramp.legend_title if colour_ramp.legend_title else default_title
-    if colour_ramp.legend_units:
-        title = title + "(" + colour_ramp.legend_units + ")"
-
-    color_bar.set_label(title)
-
-    plt.savefig(bytesio, format='png')
-
-
 class ColorRamp:
     """
     Represents a colour ramp for image and legend rendering purposes
     """
-    def __init__(self, style: StyleDefBase, ramp_cfg: CFG_DICT) -> None:
+    def __init__(self, style: StyleDefBase,
+                       ramp_cfg: CFG_DICT,
+                       legend: "RampLegendBase") -> None:
         """
         :param style: The style owning the ramp
         :param ramp_cfg: Style config
@@ -262,74 +185,59 @@ class ColorRamp:
                 unscaled_ramp = read_mpl_ramp(cast(str, ramp_cfg["mpl_ramp"]))
             raw_scaled_ramp = scale_unscaled_ramp(rmin, rmax, unscaled_ramp)
         self.ramp = raw_scaled_ramp
-        legend_cfg = cast(CFG_DICT, ramp_cfg.get("legend", {}))
-
-        # Legend typing
-        self.legend_begin = Decimal("nan")
-        self.legend_end = Decimal("nan")
-        self.ticks = cast(List[Decimal], [])
-        self.tick_labels = cast(List[str], [])
-        self.legend_mpl_rcparams = cast(MutableMapping[str, str], {})
-        self.legend_width = 0.0
-        self.legend_height = 0.0
-        self.legend_strip_location = cast(List[float], [])
-        self.legend_title = ""
-        self.legend_units = ""
-        self.legend_decimal_places = Decimal("nan")
-        self.rounder = Decimal("nan")
-        if legend_cfg.get("show_legend", True) and not legend_cfg.get("url"):
-            self.parse_legend(legend_cfg)
-        else:
-            self.auto_legend = False
 
         self.values = cast(List[float], [])
         self.components = cast(MutableMapping[str, List[float]], {})
         self.crack_ramp()
 
-        if self.auto_legend:
-            fbegin = float(self.legend_begin)
-            fend = float(self.legend_end)
-            begin_in_ramp = False
-            end_in_ramp = False
-            begin_before_idx = None
-            end_before_idx = None
+        # Handle the mutual interdepencies between the ramp and the legend
+        # 1. Let legend read its defaults from this ramp if needed
+        legend.register_ramp(self)
+        # 2. Extend our colour ramp to support legend if needed
+        if self.style.auto_legend:
+            fleg_begin = float(legend.begin)
+            fleg_end = float(legend.end)
+            leg_begin_in_ramp = False
+            leg_end_in_ramp = False
+            leg_begin_before_idx = None
+            leg_end_before_idx = None
             for idx, col_point in enumerate(self.ramp):
                 col_val = col_point["value"]
-                if not begin_in_ramp and begin_before_idx is None:
-                    if isclose(col_val, fbegin, abs_tol=1e-9):
-                        begin_in_ramp = True
-                    elif col_val > fbegin:
-                        begin_before_idx = idx
-                if not end_in_ramp and end_before_idx is None:
-                    if isclose(col_val, fend, abs_tol=1e-9):
+                if not leg_begin_in_ramp and leg_begin_before_idx is None:
+                    if isclose(col_val, fleg_begin, abs_tol=1e-9):
+                        leg_begin_in_ramp = True
+                    elif col_val > fleg_begin:
+                        leg_begin_before_idx = idx
+                if not leg_end_in_ramp and leg_end_before_idx is None:
+                    if isclose(col_val, fleg_end, abs_tol=1e-9):
                         end_in_ramp = True
-                    elif col_val > fend:
+                    elif col_val > fleg_end:
                         end_before_idx = idx
-            if not begin_in_ramp:
-                color, alpha = self.color_alpha_at(fbegin)
+            if not leg_begin_in_ramp:
+                color, alpha = self.color_alpha_at(fleg_begin)
                 begin_col_point = {
-                    "value": fbegin,
+                    "value": fleg_begin,
                     "color": color.get_hex(),
                     "alpha": alpha
                 }
-                if begin_before_idx is None:
+                if leg_begin_before_idx is None:
                     self.ramp.append(begin_col_point)
                 else:
-                    self.ramp.insert(begin_before_idx, begin_col_point)
-                if end_before_idx is not None:
-                    end_before_idx += 1
-            if not end_in_ramp:
-                color, alpha = self.color_alpha_at(fend)
+                    self.ramp.insert(leg_begin_before_idx, begin_col_point)
+                if leg_end_before_idx is not None:
+                    leg_end_before_idx += 1
+            if not leg_end_in_ramp:
+                color, alpha = self.color_alpha_at(fleg_end)
                 end_col_point = {
-                    "value": fend,
+                    "value": fleg_end,
                     "color": color.get_hex(),
                     "alpha": alpha
                 }
-                if end_before_idx is None:
+                if leg_end_before_idx is None:
                     self.ramp.append(end_col_point)
                 else:
-                    self.ramp.insert(end_before_idx, end_col_point)
-            if not end_in_ramp or not begin_in_ramp:
+                    self.ramp.insert(leg_end_before_idx, end_col_point)
+            if not leg_end_in_ramp or not leg_begin_in_ramp:
                 self.crack_ramp()
 
     def crack_ramp(self) -> None:
@@ -341,127 +249,6 @@ class ColorRamp:
             "blue": b,
             "alpha": a
         }
-
-    def parse_legend(self, cfg: CFG_DICT) -> None:
-        def rounder_str(prec: int) -> str:
-            rstr = "1"
-            if prec == 0:
-                return rstr
-            rstr += "."
-            for i in range(prec - 1):
-                rstr += "0"
-            rstr += "1"
-            return rstr
-
-        self.auto_legend = True
-        self.legend_title = cfg.get("title")
-        self.legend_units = cfg.get("units", "")
-        self.legend_decimal_places = cfg.get("decimal_places", 1)
-        if self.legend_decimal_places < 0:
-            raise ConfigException("decimal_places cannot be negative")
-        self.rounder = Decimal(rounder_str(self.legend_decimal_places))
-        self.parse_legend_range(cfg)
-        self.parse_legend_ticks(cfg)
-        self.parse_legend_tick_labels(cfg)
-        self.parse_legend_matplotlib_args(cfg)
-        # Check for old style config - was deprecated, now not supported
-        legend_legacy = any(
-            legent in cfg
-            for legent in ["major_ticks", "offset", "scale_by", "radix_point"]
-        )
-        if not legend_legacy and all(
-            legent not in cfg
-            for legent in ["begin", "end", "decimal_places", "ticks_every", "tick_count", "tick_labels", "ticks"]
-        ):
-            # No legacy entries, but no new entries either.
-            # Check ramp for legend tips
-            for r in self.ramp:
-                if "legend" in r:
-                    legend_legacy = True
-                    break
-        if legend_legacy:
-            raise ConfigException(
-                        "Style %s uses a no-longer supported format for legend configuration.  " +
-                        "Please refer to the documentation and update your config" % self.style.name)
-
-    def parse_legend_range(self, cfg: CFG_DICT) -> None:
-        if "begin" in cfg:
-            self.legend_begin = Decimal(cast(Union[str, float, int], cfg["begin"]))
-        else:
-            for col_def in self.ramp:
-                if isclose(col_def.get("alpha", 1.0), 1.0, abs_tol=1e-9):
-                    self.legend_begin = Decimal(col_def["value"])
-                    break
-            if self.legend_begin.is_nan():
-                self.legend_begin = Decimal(self.ramp[0]["value"])
-        if "end" in cfg:
-            self.legend_end = Decimal(cast(Union[str, float, int], cfg["end"]))
-        else:
-            for col_def in reversed(self.ramp):
-                if col_def.get("alpha", 1.0) == 1.0:
-                    self.legend_end = Decimal(col_def["value"])
-                    break
-            if self.legend_end.is_nan():
-                self.legend_end = Decimal(self.ramp[-1]["value"])
-
-    def parse_legend_ticks(self, cfg: CFG_DICT) -> None:
-        # Ticks
-        ticks_handled = False
-        if "ticks_every" in cfg:
-            if "tick_count" in cfg:
-                raise ConfigException("Cannot use tick count and ticks_every in the same legend")
-            if "ticks" in cfg:
-                raise ConfigException("Cannot use ticks and ticks_every in the same legend")
-            delta = Decimal(cast(Union[int, float, str], cfg["ticks_every"]))
-            tickval = self.legend_begin
-            while tickval < self.legend_end:
-                self.ticks.append(tickval)
-                tickval += delta
-            self.ticks.append(tickval)
-            ticks_handled = True
-        if "ticks" in cfg:
-            if "tick_count" in cfg:
-                raise ConfigException("Cannot use tick count and ticks in the same legend")
-            self.ticks = [Decimal(t) for t in cast(List[Union[str, int, float]], cfg["ticks"])]
-            ticks_handled = True
-        if not ticks_handled:
-            count = int(cast(Union[str, int], cfg.get("tick_count", 1)))
-            if count < 0:
-                raise ConfigException("tick_count cannot be negative")
-            elif count == 0:
-                self.ticks.append(self.legend_begin)
-            else:
-                delta = self.legend_end - self.legend_begin
-                dcount = Decimal(count)
-
-                for i in range(0, count + 1):
-                    tickval = self.legend_begin + (Decimal(i) / dcount) * delta
-                    self.ticks.append(tickval.quantize(self.rounder, rounding=ROUND_HALF_UP))
-
-    def parse_legend_tick_labels(self, cfg: CFG_DICT) -> None:
-        labels = cast(MutableMapping[str, MutableMapping[str, str]], cfg.get("tick_labels", {}))
-        defaults = labels.get("default", {})
-        default_prefix = defaults.get("prefix", "")
-        default_suffix = defaults.get("suffix", "")
-        # pylint: disable=attribute-defined-outside-init
-        for tick in self.ticks:
-            label_cfg = labels.get(str(tick))
-            if label_cfg:
-                prefix = label_cfg.get("prefix", default_prefix)
-                suffix = label_cfg.get("suffix", default_suffix)
-                label  = label_cfg.get("label", str(tick))
-                self.tick_labels.append(prefix + label + suffix)
-            else:
-                self.tick_labels.append(
-                    default_prefix + str(tick) + default_suffix
-                )
-
-    def parse_legend_matplotlib_args(self, cfg: CFG_DICT) -> None:
-        self.legend_mpl_rcparams = cast(MutableMapping[str, str], cfg.get("rcParams", {}))
-        self.legend_width = cast(float, cfg.get("width", 4.0))
-        self.legend_height = cast(float, cfg.get("height", 1.25))
-        self.legend_strip_location = cast(List[float],
-                                          cfg.get("strip_location", [0.05, 0.5, 0.9, 0.15]))
 
     def get_value(self, data: Union[float, "xarray.DataArray"], band: str) -> NDArray:
         return numpy.interp(data, self.values, self.components[band])
@@ -490,6 +277,202 @@ class ColorRamp:
         return color, alpha
 
 
+class RampLegendBase(StyleDefBase.Legend):
+    def __init__(self, style_or_mdh: Union["StyleDefBase", "StyleDefBase.Legend"], cfg: CFG_DICT) -> None:
+        super().__init__(style_or_mdh, cfg)
+        raw_cfg = cast(CFG_DICT, self._raw_cfg)
+        # Basic text
+        self.units = cast(Optional[str], raw_cfg.get("units"))
+        # Range - defaults deferred until we have parsed the associated ramp
+        if "begin" not in raw_cfg:
+            self.begin = Decimal("nan")
+        else:
+            self.begin = Decimal(cast(Union[str, float, int], raw_cfg["begin"]))
+        if "end" not in raw_cfg:
+            self.end = Decimal("nan")
+        else:
+            self.end = Decimal(cast(Union[str, float, int], raw_cfg["end"]))
+
+        # decimal_places, rounder
+        def rounder_str(prec: int) -> str:
+            rstr = "1"
+            if prec == 0:
+                return rstr
+            rstr += "."
+            for i in range(prec - 1):
+                rstr += "0"
+            rstr += "1"
+            return rstr
+
+        self.decimal_places = raw_cfg.get("decimal_places", 1)
+        if self.decimal_places < 0:
+            raise ConfigException("decimal_places cannot be negative")
+        self.rounder = Decimal(rounder_str(self.decimal_places))
+
+        # Ticks - Non-explicit tick values deferred until we have parsed the associated ramp
+        ticks_handled = False
+        self.ticks_every: Optional[Decimal] = None
+        self.tick_count: Optional[int] = None
+        self.ticks: List[Decimal] = []
+        if "ticks_every" in raw_cfg:
+            if "tick_count" in raw_cfg:
+                raise ConfigException("Cannot use tick count and ticks_every in the same legend")
+            if "ticks" in raw_cfg:
+                raise ConfigException("Cannot use ticks and ticks_every in the same legend")
+            self.ticks_every = Decimal(cast(Union[int, float, str], raw_cfg["ticks_every"]))
+            ticks_handled = True
+        if "ticks" in raw_cfg:
+            if "tick_count" in raw_cfg:
+                raise ConfigException("Cannot use tick count and ticks in the same legend")
+            self.ticks = [Decimal(t) for t in cast(List[Union[str, int, float]], raw_cfg["ticks"])]
+            ticks_handled = True
+        if not ticks_handled:
+            self.tick_count = int(cast(Union[str, int], raw_cfg.get("tick_count", 1)))
+            if self.tick_count < 0:
+                raise ConfigException("tick_count cannot be negative")
+        # prepare for tick labels
+        self.cfg_labels = cast(MutableMapping[str, MutableMapping[str, str]], raw_cfg.get("tick_labels", {}))
+        defaults = self.cfg_labels.get("default", {})
+        self.lbl_default_prefix = defaults.get("prefix", "")
+        self.lbl_default_suffix = defaults.get("suffix", "")
+        self.tick_labels: List[str] = []
+        # handle matplotlib args
+        self.strip_location = cast(List[float],
+                                   raw_cfg.get("strip_location", [0.05, 0.5, 0.9, 0.15]))
+        # throw error on legacy syntax
+        self.fail_legacy()
+
+    def parse_common_auto_elements(self, cfg: CFG_DICT):
+        super().parse_common_auto_elements(cfg)
+        if self.title is None:
+            self.title = self.style.title
+
+    def fail_legacy(self) -> None:
+        if any(
+                legent in self._raw_cfg
+                for legent in ["major_ticks", "offset", "scale_by", "radix_point"]
+        ):
+            raise ConfigException(
+                f"Style {self.style.name} uses a no-longer supported format for legend configuration.  " +
+                "Please refer to the documentation and update your config")
+
+    def register_ramp(self, ramp: ColorRamp) -> None:
+        if self.begin.is_nan():
+            for col_def in ramp.ramp:
+                if isclose(col_def.get("alpha", 1.0), 1.0, abs_tol=1e-9):
+                    self.begin = Decimal(col_def["value"])
+                    break
+            if self.begin.is_nan():
+                self.begin = Decimal(self.ramp[0]["value"])
+        if self.end.is_nan():
+            for col_def in reversed(ramp.ramp):
+                if isclose(col_def.get("alpha", 1.0), 1.0, abs_tol=1e-9):
+                    self.end = Decimal(col_def["value"])
+                    break
+            if self.end.is_nan():
+                self.end = Decimal(self.ramp[-1]["value"])
+        if self.ticks_every is not None:
+            tickval = self.begin
+            while tickval < self.end:
+                self.ticks.append(tickval)
+                tickval += self.ticks_every
+            self.ticks.append(self.end)
+        elif self.tick_count is not None:
+            if self.tick_count == 0:
+                self.ticks.append(self.begin)
+            else:
+                delta = self.end - self.begin
+                dcount = Decimal(self.tick_count)
+                for i in range(0, self.tick_count + 1):
+                    tickval = self.begin + (Decimal(i) / dcount) * delta
+                    self.ticks.append(tickval.quantize(self.rounder, rounding=ROUND_HALF_UP))
+
+        # handle tick labels
+        for tick in self.ticks:
+            label_cfg = self.cfg_labels.get(str(tick))
+            if label_cfg:
+                prefix = label_cfg.get("prefix", self.lbl_default_prefix)
+                suffix = label_cfg.get("suffix", self.lbl_default_suffix)
+                label = label_cfg.get("label", str(tick))
+                self.tick_labels.append(prefix + label + suffix)
+            else:
+                self.tick_labels.append(
+                    self.lbl_default_prefix + str(tick) + self.lbl_default_suffix
+                )
+
+        # Check for legacy legend tips in ramp:
+        for r in ramp.ramp:
+            if "legend" in r:
+                raise ConfigException(
+                    f"Style {self.style.name} uses a no-longer supported format for legend configuration.  " +
+                    "Please refer to the documentation and update your config")
+
+    def create_cdict_ticks(self) -> Tuple[
+        MutableMapping[str, List[Tuple[float, float, float]]],
+        MutableMapping[float, str],
+    ]:
+        normalize_factor = float(self.end) - float(self.begin)
+        cdict = cast(MutableMapping[str, List[Tuple[float, float, float]]], dict())
+        bands = cast(MutableMapping[str, List[Tuple[float, float, float]]], defaultdict(list))
+        started = False
+        finished = False
+        for index, ramp_point in enumerate(self.style_or_mdh.color_ramp.ramp):
+            if finished:
+                break
+
+            value = cast(Union[float, int], ramp_point.get("value"))
+            normalized = (value - float(self.begin)) / float(normalize_factor)
+
+            if not started:
+                if isclose(value, float(self.begin), abs_tol=1e-9):
+                    started = True
+                else:
+                    continue
+            if not finished:
+                if isclose(value, float(self.end), abs_tol=1e-9):
+                    finished = True
+
+            for band, intensity in self.style_or_mdh.color_ramp.components.items():
+                bands[band].append((normalized, intensity[index], intensity[index]))
+
+        for band, blist in bands.items():
+            cdict[band] = blist
+
+        ticks = cast(MutableMapping[float, str], dict())
+        for tick, tick_lbl in zip(self.ticks, self.tick_labels):
+            value = float(tick)
+            normalized = (value - float(self.begin)) / float(normalize_factor)
+            ticks[normalized] = tick_lbl  # REVISIT: map on float???
+
+        return cdict, ticks
+
+    def display_title(self):
+        if self.units:
+            return f"{self.title}({self.units})"
+        else:
+            return self.title
+
+    def plot_name(self):
+        return f"{self.style.product.name}_{self.style.name}"
+
+    def render(self, bytesio: io.BytesIO) -> None:
+        cdict, ticks = self.create_cdict_ticks()
+        plt.rcdefaults()
+        if self.mpl_rcparams:
+            plt.rcParams.update(self.mpl_rcparams)
+        fig = plt.figure(figsize=(self.width, self.height))
+        ax = fig.add_axes(self.strip_location)
+        custom_map = LinearSegmentedColormap(self.plot_name(), cdict)
+        color_bar = matplotlib.colorbar.ColorbarBase(
+            ax,
+            cmap=custom_map,
+            orientation="horizontal")
+        color_bar.set_ticks(list(ticks.keys()))
+        color_bar.set_ticklabels(list(ticks.values()))
+        color_bar.set_label(self.display_title())
+        plt.savefig(bytesio, format='png')
+
+
 class ColorRampDef(StyleDefBase):
     """
     Colour ramp Style subclass
@@ -508,7 +491,7 @@ class ColorRampDef(StyleDefBase):
         super(ColorRampDef, self).__init__(product, style_cfg,
                            stand_alone=stand_alone, defer_multi_date=True, user_defined=user_defined)
         style_cfg = cast(CFG_DICT, self._raw_cfg)
-        self.color_ramp = ColorRamp(self, style_cfg)
+        self.color_ramp = ColorRamp(self, style_cfg, self.legend_cfg)
         self.include_in_feature_info = bool(style_cfg.get("include_in_feature_info", True))
 
         if "index_function" in style_cfg:
@@ -554,18 +537,8 @@ class ColorRampDef(StyleDefBase):
         d = self.apply_index(data)
         return self.color_ramp.apply(d)
 
-    def single_date_legend(self, bytesio: io.BytesIO) -> None:
-        """
-        Write a legend into a bytes buffer as a PNG image.
-
-        :param bytesio:  io.BytesIO byte buffer.
-        """
-        colour_ramp_legend(bytesio,
-                           self.legend_cfg,
-                           self.color_ramp,
-                           self.product.name,
-                           self.title      # pyre-ignore[16]
-                           )
+    class Legend(RampLegendBase):
+        pass
 
     class MultiDateHandler(StyleDefBase.MultiDateHandler):
         auto_legend = True
@@ -583,7 +556,7 @@ class ColorRampDef(StyleDefBase):
                 self.color_ramp = style.color_ramp
             else:
                 self.feature_info_label = cast(Optional[str], cfg.get("feature_info_label", None))
-                self.color_ramp = ColorRamp(style, cfg)
+                self.color_ramp = ColorRamp(style, cfg, self.legend_cfg)
 
         def transform_data(self, data: "xarray.Dataset") -> "xarray.Dataset":
             """
@@ -596,23 +569,9 @@ class ColorRampDef(StyleDefBase):
             agg = self.aggregator(xformed_data)
             return self.color_ramp.apply(agg)
 
-        def legend(self, bytesio: io.BytesIO) -> None:
-            """
-            Write a legend as a png to a bytesio buffer.
-
-            :param bytesio:
-            """
-            if self.animate and not self.legend_cfg:
-                self.style.single_date_legend(bytesio)
-            else:
-                title = self.legend_cfg.get("title", self.range_str() + " Dates")
-                name = self.style.product.name + f"_{self.min_count}"
-                colour_ramp_legend(bytesio,
-                                   self.legend_cfg,
-                                   self.color_ramp,
-                                   name,
-                                   title
-                                   )
+        class Legend(RampLegendBase):
+            def plot_name(self):
+                return f"{self.style.product.name}_{self.style.name}_{self.style_or_mdh.min_count}"
 
 # Register ColorRampDef as Style subclass.
 StyleDefBase.register_subclass(ColorRampDef, ("range", "color_ramp"))

--- a/datacube_ows/templates/wms_capabilities.xml
+++ b/datacube_ows/templates/wms_capabilities.xml
@@ -151,7 +151,7 @@
                 <Name>{{ style.name }}</Name>
                 <Title>{{ style.title }}</Title>
                 <Abstract>{{ style.abstract }}</Abstract>
-                {% if style.show_legend %}
+                {% if style.legend_cfg.show_legend %}
                     <LegendURL>
                         <Format>image/png</Format>
                         <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink"

--- a/datacube_ows/templates/wmts_capabilities.xml
+++ b/datacube_ows/templates/wmts_capabilities.xml
@@ -143,8 +143,10 @@
                 <ows:Identifier>{{ style.name }}</ows:Identifier>
                 <ows:Title>{{ style.title }}</ows:Title>
                 <ows:Abstract>{{ style.abstract }}</ows:Abstract>
+                {% if style.legend_cfg.show_legend %}
                 <LegendURL format="image/png"
                         xlink:href="{{ base_url }}/legend/{{ layer.name }}/{{ style.name }}/legend.png"/>
+                {% endif %}
             </Style>
             {% endfor %}
             <Format>image/png</Format>

--- a/docs/cfg_colourmap_styles.rst
+++ b/docs/cfg_colourmap_styles.rst
@@ -177,7 +177,7 @@ The ``width`` and ``height`` values are passed to matplotlib to specify the size
 of the generated image.
 
 The image size defaults to 4 inches wide by 1.25 inches tall.  The default
-dpi for MatPlotLib is 100, so this corresponds to 300x125 pixels unless you
+dpi for MatPlotLib is 100, so this corresponds to 400x125 pixels unless you
 have over-ridden the default dpi.
 
 E.g.::

--- a/docs/cfg_colourmap_styles.rst
+++ b/docs/cfg_colourmap_styles.rst
@@ -135,6 +135,33 @@ A patch and label is added to the legend for each value rule in the
 configuration.  See `title and abstract <#title-and-abstract>`_ for
 customising the label of each rule.
 
+Legend Title
+============
+
+A title can be added to the top of the legend.  The default is no title.
+
+E.g.::
+
+        "legend": {
+            # Legend title will be display as "This is a nice legend"
+            "title": "This is a nice legend"
+        }
+
+Number of columns (ncols)
+=========================
+
+By default, the patches and labels are laid out in the legend in a single column.  You can specify
+as multi-column format with the ``ncols`` legend entry to the number of desired columns.
+
+Note: You may need to adjust the width of your legend to fit the number of columns (see below).
+
+E.g.::
+
+    "legend": {
+        # Use a two column legend layout.
+        "ncols": 2,
+    }
+
 Values passed to MatPlotLib
 ===========================
 
@@ -149,7 +176,7 @@ Image Size
 The ``width`` and ``height`` values are passed to matplotlib to specify the size
 of the generated image.
 
-The image size defaults to 3 inches wide by 1.25 inches tall.  The default
+The image size defaults to 4 inches wide by 1.25 inches tall.  The default
 dpi for MatPlotLib is 100, so this corresponds to 300x125 pixels unless you
 have over-ridden the default dpi.
 

--- a/tests/test_legend_generator.py
+++ b/tests/test_legend_generator.py
@@ -4,6 +4,7 @@
 # Copyright (c) 2017-2021 OWS Contributors
 # SPDX-License-Identifier: Apache-2.0
 from decimal import Decimal
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -52,175 +53,41 @@ def test_image_from_bad_image_url(bad_image_url):
     img = get_image_from_url(bad_image_url)
     assert img is None
 
-@pytest.mark.skip(reason="Needs to be rewritten post-refactor")
 def test_parse_colorramp_defaults():
-    ramp = ColorRamp(None, {
-        "range": [0.0, 1.0],
-    })
-    assert ramp.legend_begin == Decimal(0.0)
-    assert ramp.legend_end == Decimal(1.0)
-    assert ramp.ticks == [Decimal(0.0), Decimal(1.0)]
-    assert ramp.legend_units == ""
-    assert ramp.tick_labels == ["0.0", "1.0"]
-    assert ramp.legend_width == 4.0
-    assert ramp.legend_height == 1.25
-    assert ramp.legend_strip_location == [0.05, 0.5, 0.9, 0.15]
+    legend = ColorRampDef.Legend(MagicMock(), {})
+    ramp = ColorRamp(MagicMock(),
+                     {
+                        "range": [0.0, 1.0],
+                     },
+                     legend)
+    assert legend.begin == Decimal(0.0)
+    assert legend.end == Decimal(1.0)
+    assert legend.ticks == [Decimal(0.0), Decimal(1.0)]
+    assert legend.units is None
+    assert legend.tick_labels == ["0.0", "1.0"]
+    assert legend.width == 4.0
+    assert legend.height == 1.25
+    assert legend.strip_location == [0.05, 0.5, 0.9, 0.15]
 
 
-@pytest.mark.skip(reason="Needs to be rewritten post-refactor")
 def test_parse_colorramp_legend_beginend():
-    ramp = ColorRamp(None, {
-        "range": [-1.0, 2.5],
-        "legend": {
-            "begin": "0.0",
-            "end": "2.0"
-        }
+    legend = ColorRampDef.Legend(MagicMock(), {
+        "begin": "0.0",
+        "end": "2.0"
     })
-    assert ramp.legend_begin == Decimal("0.0")
-    assert ramp.legend_end == Decimal("2.0")
-    assert ramp.ticks == [Decimal("0.0"), Decimal("2.0")]
-    assert ramp.legend_units == ""
-    assert ramp.tick_labels == ["0.0", "2.0"]
+    assert legend.begin == Decimal("0.0")
+    assert legend.end == Decimal("2.0")
 
 
-@pytest.mark.skip(reason="Needs to be rewritten post-refactor")
 def test_parse_colorramp_legend_ticksevery():
-    ramp = ColorRamp(None, {
-        "range": [-1.0, 2.5],
+    ramp = ColorRampDef.Legend(MagicMock(), {
         "legend": {
             "begin": "0.0",
             "end": "2.0",
             "ticks_every": "0.4"
         }
     })
+    ramp.register_ramp(MagicMock())
     assert ramp.ticks == [Decimal("0.0"), Decimal("0.4"), Decimal("0.8"),
                           Decimal("1.2"), Decimal("1.6"), Decimal("2.0")]
     assert ramp.tick_labels == ["0.0", "0.4", "0.8", "1.2", "1.6", "2.0"]
-
-
-@pytest.mark.skip(reason="Needs to be rewritten post-refactor")
-def test_parse_colorramp_legend_tickcount():
-    ramp = ColorRamp(None, {
-        "range": [-1.0, 2.5],
-        "legend": {
-            "begin": "0.0",
-            "end": "2.0",
-            "tick_count": 2
-        }
-    })
-    assert ramp.ticks == [Decimal("0.0"), Decimal("1.0"), Decimal("2.0")]
-    assert ramp.tick_labels == ["0.0", "1.0", "2.0"]
-
-
-@pytest.mark.skip(reason="Needs to be rewritten post-refactor")
-def test_parse_colorramp_legend_ticks():
-    ramp = ColorRamp(None, {
-        "range": [-1.0, 2.5],
-        "legend": {
-            "begin": "0.0",
-            "end": "2.0",
-            "ticks": ["0.3", "0.9", "1.1", "1.9", "2.0"]
-        }
-    })
-    assert ramp.ticks == [Decimal("0.3"), Decimal("0.9"),
-                          Decimal("1.1"), Decimal("1.9"), Decimal("2.0")]
-    assert ramp.tick_labels == ["0.3", "0.9", "1.1", "1.9", "2.0"]
-
-
-# TODO: Rewrite to Legend class.
-@pytest.mark.skip(reason="Needs to be rewritten post-refactor")
-def test_parse_colorramp_legend_find_end():
-    ramp = ColorRamp(None, {
-         'color_ramp': [
-            {
-                'value': 999,
-                'color': '#000000',
-                'alpha': 0.0
-            },
-            {
-                'value': 1000,
-                'color': '#000000'
-            },
-            {
-                'value': 2500,
-                'color': '#BA7500'
-            },
-            {
-                'value': 6500,
-                'color': '#BF4000'
-            },
-            {
-                'value': 51500,
-                'color': '#EF1000'
-            }
-        ],
-        'legend': {
-            'show_legend': True,
-            'begin': '1000',
-            'end': '6000',
-            'ticks': ['1000', '2000', '3000', '6000'],
-            'tick_labels': {
-                '1000': {
-                    'label': '-1.0'
-                },
-                '2000': {
-                    'label': '0.0'
-                },
-                '3000': {
-                    'label': '1.0'
-                },
-                '6000': {
-                    'label': '4.0'
-                }
-            }
-        }
-    })
-    assert ramp.values == [999.0, 1000.0, 2500.0, 6000.0, 6500.0, 51500.0]
-
-
-# TODO: Rewrite to Legend class.
-@pytest.mark.skip(reason="Needs to be rewritten post-refactor")
-def test_parse_colorramp_legend_tick_labels():
-    ramp = ColorRamp(None, {
-        "range": [-1.0, 2.5],
-        "legend": {
-            "begin": "0.0",
-            "end": "2.0",
-            "ticks": ["0.3", "0.5", "0.8", "0.9", "1.0",
-                      "1.1", "1.7", "1.9", "2.0"],
-            "tick_labels": {
-                "default": {
-                    "prefix": "p",
-                    "suffix": "s"
-                },
-                "0.3": {},
-                "0.8": {
-                    "prefix": "",
-                    "suffix": "Zz"
-                },
-                "0.9": {
-                    "suffix": "Zz"
-                },
-                "1.1": {
-                    "prefix": "#",
-                },
-                "1.7": {
-                    "prefix": "pre",
-                    "label": "fixe"
-                },
-                "1.9": {
-                    "label": "o",
-                },
-                "2.0": {
-                    "prefix": ":",
-                    "label": "-",
-                    "suffix": ")",
-                }
-            }
-        }
-    })
-    assert ramp.ticks == [Decimal("0.3"), Decimal("0.5"), Decimal("0.8"),
-              Decimal("0.9"), Decimal("1.0"),
-              Decimal("1.1"), Decimal("1.7"), Decimal("1.9"), Decimal("2.0")]
-    assert ramp.tick_labels == ["p0.3s", "p0.5s", "0.8Zz", "p0.9Zz", "p1.0s",
-                                "#1.1s", "prefixes", "pos", ":-)"]

--- a/tests/test_legend_generator.py
+++ b/tests/test_legend_generator.py
@@ -76,18 +76,4 @@ def test_parse_colorramp_legend_beginend():
         "end": "2.0"
     })
     assert legend.begin == Decimal("0.0")
-    assert legend.end == Decimal("2.0")
-
-
-def test_parse_colorramp_legend_ticksevery():
-    ramp = ColorRampDef.Legend(MagicMock(), {
-        "legend": {
-            "begin": "0.0",
-            "end": "2.0",
-            "ticks_every": "0.4"
-        }
-    })
-    ramp.register_ramp(MagicMock())
-    assert ramp.ticks == [Decimal("0.0"), Decimal("0.4"), Decimal("0.8"),
-                          Decimal("1.2"), Decimal("1.6"), Decimal("2.0")]
-    assert ramp.tick_labels == ["0.0", "0.4", "0.8", "1.2", "1.6", "2.0"]
+    assert legend.end == Decimal("2.0")...

--- a/tests/test_legend_generator.py
+++ b/tests/test_legend_generator.py
@@ -76,4 +76,4 @@ def test_parse_colorramp_legend_beginend():
         "end": "2.0"
     })
     assert legend.begin == Decimal("0.0")
-    assert legend.end == Decimal("2.0")...
+    assert legend.end == Decimal("2.0")

--- a/tests/test_legend_generator.py
+++ b/tests/test_legend_generator.py
@@ -27,28 +27,6 @@ def prelegend_colorramp_style():
     return style
 
 
-def test_legend_parser_nolegend(prelegend_style):
-    prelegend_style.parse_legend_cfg(
-        {
-            "show_legend": False,
-        }
-    )
-    assert not prelegend_style.show_legend
-    assert prelegend_style.legend_url_override is None
-
-
-def test_legend_parser_urllegend(prelegend_style):
-    url = "http://whatevs"
-    prelegend_style.parse_legend_cfg(
-        {
-            "show_legend": True,
-            "url": url
-        }
-    )
-    assert prelegend_style.show_legend
-    assert prelegend_style.legend_url_override == url
-
-
 def test_create_legend_for_style(dummy_layer): # noqa: F811
     from datacube_ows.legend_generator import create_legend_for_style
     assert create_legend_for_style(dummy_layer, "stylish_steve") is None
@@ -74,7 +52,7 @@ def test_image_from_bad_image_url(bad_image_url):
     img = get_image_from_url(bad_image_url)
     assert img is None
 
-
+@pytest.mark.skip(reason="Needs to be rewritten post-refactor")
 def test_parse_colorramp_defaults():
     ramp = ColorRamp(None, {
         "range": [0.0, 1.0],
@@ -89,6 +67,7 @@ def test_parse_colorramp_defaults():
     assert ramp.legend_strip_location == [0.05, 0.5, 0.9, 0.15]
 
 
+@pytest.mark.skip(reason="Needs to be rewritten post-refactor")
 def test_parse_colorramp_legend_beginend():
     ramp = ColorRamp(None, {
         "range": [-1.0, 2.5],
@@ -104,6 +83,7 @@ def test_parse_colorramp_legend_beginend():
     assert ramp.tick_labels == ["0.0", "2.0"]
 
 
+@pytest.mark.skip(reason="Needs to be rewritten post-refactor")
 def test_parse_colorramp_legend_ticksevery():
     ramp = ColorRamp(None, {
         "range": [-1.0, 2.5],
@@ -118,6 +98,7 @@ def test_parse_colorramp_legend_ticksevery():
     assert ramp.tick_labels == ["0.0", "0.4", "0.8", "1.2", "1.6", "2.0"]
 
 
+@pytest.mark.skip(reason="Needs to be rewritten post-refactor")
 def test_parse_colorramp_legend_tickcount():
     ramp = ColorRamp(None, {
         "range": [-1.0, 2.5],
@@ -131,6 +112,7 @@ def test_parse_colorramp_legend_tickcount():
     assert ramp.tick_labels == ["0.0", "1.0", "2.0"]
 
 
+@pytest.mark.skip(reason="Needs to be rewritten post-refactor")
 def test_parse_colorramp_legend_ticks():
     ramp = ColorRamp(None, {
         "range": [-1.0, 2.5],
@@ -145,6 +127,8 @@ def test_parse_colorramp_legend_ticks():
     assert ramp.tick_labels == ["0.3", "0.9", "1.1", "1.9", "2.0"]
 
 
+# TODO: Rewrite to Legend class.
+@pytest.mark.skip(reason="Needs to be rewritten post-refactor")
 def test_parse_colorramp_legend_find_end():
     ramp = ColorRamp(None, {
          'color_ramp': [
@@ -194,6 +178,8 @@ def test_parse_colorramp_legend_find_end():
     assert ramp.values == [999.0, 1000.0, 2500.0, 6000.0, 6500.0, 51500.0]
 
 
+# TODO: Rewrite to Legend class.
+@pytest.mark.skip(reason="Needs to be rewritten post-refactor")
 def test_parse_colorramp_legend_tick_labels():
     ramp = ColorRamp(None, {
         "range": [-1.0, 2.5],

--- a/tests/test_multidate_handler.py
+++ b/tests/test_multidate_handler.py
@@ -58,7 +58,8 @@ def test_multidate_handler():
 
     mdh = StyleDefBase.MultiDateHandler(FakeMdhStyle(), fake_cfg)
     assert mdh is not None
-    assert not mdh.legend(None)
+    with pytest.raises(NotImplementedError):
+        mdh.legend_cfg.render(None)
     assert isinstance(mdh.range_str(), str)
     assert mdh.applies_to(2)
     assert not mdh.applies_to(11)

--- a/tests/test_style_api.py
+++ b/tests/test_style_api.py
@@ -3,8 +3,9 @@
 #
 # Copyright (c) 2017-2021 OWS Contributors
 # SPDX-License-Identifier: Apache-2.0
-import pytest
 from decimal import Decimal
+
+import pytest
 
 from datacube_ows.ogc_utils import ConfigException
 

--- a/tests/test_style_api.py
+++ b/tests/test_style_api.py
@@ -4,6 +4,7 @@
 # Copyright (c) 2017-2021 OWS Contributors
 # SPDX-License-Identifier: Apache-2.0
 import pytest
+from decimal import Decimal
 
 from datacube_ows.ogc_utils import ConfigException
 
@@ -185,6 +186,42 @@ def test_ramp_legend_standalone(simple_ramp_style_cfg):
     img = generate_ows_legend_style(style, 1)
     assert img.mode == "RGBA"
     assert img.size == (400, 125)
+
+
+def test_ramp_legend_ranges(simple_ramp_style_cfg):
+    simple_ramp_style_cfg["legend"] = {
+        "begin": "0.2",
+        "end": "0.8"
+    }
+    style = StandaloneStyle(simple_ramp_style_cfg)
+    assert style.legend_cfg.begin == Decimal("0.2")
+    assert style.legend_cfg.end == Decimal("0.8")
+    simple_ramp_style_cfg["legend"] = {
+        "begin": "0.3",
+        "end": "0.7"
+    }
+    style = StandaloneStyle(simple_ramp_style_cfg)
+    assert style.legend_cfg.begin == Decimal("0.3")
+    assert style.legend_cfg.end == Decimal("0.7")
+
+    simple_ramp_style_cfg["legend"] = {
+        "begin": "-0.3",
+        "end": "1.7"
+    }
+    style = StandaloneStyle(simple_ramp_style_cfg)
+    assert style.legend_cfg.begin == Decimal("-0.3")
+    assert style.legend_cfg.end == Decimal("1.7")
+
+
+def test_ramp_legend_parse_errs(simple_ramp_style_cfg):
+    simple_ramp_style_cfg["legend"] = {
+        "begin": "0.15",
+        "begin": "0.95",
+        "decimal_places": -1
+    }
+    with pytest.raises(ConfigException) as e:
+        style = StandaloneStyle(simple_ramp_style_cfg)
+    assert "decimal_places cannot be negative" in str(e.value)
 
 
 @pytest.fixture

--- a/tests/test_style_api.py
+++ b/tests/test_style_api.py
@@ -225,6 +225,188 @@ def test_ramp_legend_parse_errs(simple_ramp_style_cfg):
     assert "decimal_places cannot be negative" in str(e.value)
 
 
+def test_ramp_ticks_multimethod(simple_ramp_style_cfg):
+    simple_ramp_style_cfg["legend"] = {
+        "begin": "0.0",
+        "end": "1.0",
+        "ticks_every": "0.2",
+        "tick_count": 5
+    }
+    with pytest.raises(ConfigException) as e:
+        style = StandaloneStyle(simple_ramp_style_cfg)
+    assert "Cannot use tick count and ticks_every in the same legend" in str(e.value)
+    simple_ramp_style_cfg["legend"] = {
+        "begin": "0.0",
+        "end": "1.0",
+        "ticks_every": "0.2",
+        "ticks": ["0.0", "0.2", "0.4", "0.6", "0.8", "1.0"]
+    }
+    with pytest.raises(ConfigException) as e:
+        style = StandaloneStyle(simple_ramp_style_cfg)
+    assert "Cannot use ticks and ticks_every in the same legend" in str(e.value)
+    simple_ramp_style_cfg["legend"] = {
+        "begin": "0.0",
+        "end": "1.0",
+        "ticks": ["0.0", "0.2", "0.4", "0.6", "0.8", "1.0"],
+        "tick_count": 5
+    }
+    with pytest.raises(ConfigException) as e:
+        style = StandaloneStyle(simple_ramp_style_cfg)
+    assert "Cannot use tick count and ticks in the same legend" in str(e.value)
+
+
+def test_ramp_ticks_every(simple_ramp_style_cfg):
+    # ticks_every
+    simple_ramp_style_cfg["legend"] = {
+        "begin": "0.0",
+        "end": "1.0",
+        "ticks_every": "1.0",
+    }
+    style = StandaloneStyle(simple_ramp_style_cfg)
+    assert style.legend_cfg.ticks == [
+        Decimal("0.0"),
+        Decimal("1.0"),
+    ]
+    simple_ramp_style_cfg["legend"] = {
+        "begin": "0.0",
+        "end": "1.0",
+        "ticks_every": "0.5",
+    }
+    style = StandaloneStyle(simple_ramp_style_cfg)
+    assert style.legend_cfg.ticks == [
+        Decimal("0.0"),
+        Decimal("0.5"),
+        Decimal("1.0"),
+    ]
+    simple_ramp_style_cfg["legend"] = {
+        "begin": "0.0",
+        "end": "1.0",
+        "ticks_every": "0.7",
+    }
+    style = StandaloneStyle(simple_ramp_style_cfg)
+    assert style.legend_cfg.ticks == [
+        Decimal("0.0"),
+        Decimal("0.7"),
+        Decimal("1.0"),
+    ]
+    simple_ramp_style_cfg["legend"] = {
+        "begin": "0.0",
+        "end": "1.0",
+        "ticks_every": "0.2",
+    }
+    style = StandaloneStyle(simple_ramp_style_cfg)
+    assert style.legend_cfg.ticks == [
+        Decimal("0.0"),
+        Decimal("0.2"),
+        Decimal("0.4"),
+        Decimal("0.6"),
+        Decimal("0.8"),
+        Decimal("1.0"),
+    ]
+    simple_ramp_style_cfg["legend"] = {
+        "begin": "0.0",
+        "end": "1.0",
+        "ticks_every": "-0.2",
+    }
+    with pytest.raises(ConfigException) as e:
+        style = StandaloneStyle(simple_ramp_style_cfg)
+    assert "ticks_every must be greater than zero" in str(e.value)
+
+
+
+def test_ramp_tick_count(simple_ramp_style_cfg):
+    # default
+    simple_ramp_style_cfg["legend"] = {
+        "begin": "0.0",
+        "end": "1.0",
+    }
+    style = StandaloneStyle(simple_ramp_style_cfg)
+    assert style.legend_cfg.ticks == [
+        Decimal("0.0"),
+        Decimal("1.0"),
+    ]
+    simple_ramp_style_cfg["legend"] = {
+        "begin": "0.0",
+        "end": "1.0",
+        "tick_count": 1
+    }
+    style = StandaloneStyle(simple_ramp_style_cfg)
+    assert style.legend_cfg.ticks == [
+        Decimal("0.0"),
+        Decimal("1.0"),
+    ]
+    simple_ramp_style_cfg["legend"] = {
+        "begin": "0.0",
+        "end": "1.0",
+        "tick_count": 0
+    }
+    style = StandaloneStyle(simple_ramp_style_cfg)
+    assert style.legend_cfg.ticks == [
+        Decimal("0.0"),
+    ]
+    simple_ramp_style_cfg["legend"] = {
+        "begin": "0.0",
+        "end": "1.0",
+        "tick_count": 5
+    }
+    style = StandaloneStyle(simple_ramp_style_cfg)
+    assert style.legend_cfg.ticks == [
+        Decimal("0.0"),
+        Decimal("0.2"),
+        Decimal("0.4"),
+        Decimal("0.6"),
+        Decimal("0.8"),
+        Decimal("1.0"),
+    ]
+    simple_ramp_style_cfg["legend"] = {
+        "begin": "0.0",
+        "end": "1.0",
+        "tick_count": -4
+    }
+    with pytest.raises(ConfigException) as e:
+        style = StandaloneStyle(simple_ramp_style_cfg)
+    assert "tick_count cannot be negative" in str(e.value)
+
+
+def test_explicit_ticks(simple_ramp_style_cfg):
+    simple_ramp_style_cfg["legend"] = {
+        "begin": "0.0",
+        "end": "1.0",
+        "ticks": []
+    }
+    style = StandaloneStyle(simple_ramp_style_cfg)
+    assert style.legend_cfg.ticks == []
+    simple_ramp_style_cfg["legend"] = {
+        "begin": "0.0",
+        "end": "1.0",
+        "ticks": ["0.0", "0.7", "1.0"]
+    }
+    style = StandaloneStyle(simple_ramp_style_cfg)
+    assert style.legend_cfg.ticks == [
+        Decimal("0.0"),
+        Decimal("0.7"),
+        Decimal("1.0"),
+    ]
+    simple_ramp_style_cfg["legend"] = {
+        "begin": "0.0",
+        "end": "1.0",
+        "ticks": ["0.2", "0.9"]
+    }
+    style = StandaloneStyle(simple_ramp_style_cfg)
+    assert style.legend_cfg.ticks == [
+        Decimal("0.2"),
+        Decimal("0.9"),
+    ]
+    simple_ramp_style_cfg["legend"] = {
+        "begin": "0.0",
+        "end": "1.0",
+        "ticks": ["0.2", "1.9"]
+    }
+    with pytest.raises(ConfigException) as e:
+        style = StandaloneStyle(simple_ramp_style_cfg)
+    assert "Explicit ticks must all be within legend begin/end range" in str(e.value)
+
+
 @pytest.fixture
 def rgb_style_with_masking_cfg():
     return {

--- a/tests/test_style_api.py
+++ b/tests/test_style_api.py
@@ -731,11 +731,11 @@ def test_invalid_multidate_rules(enum_colormap_style_cfg, simple_colormap_style_
     assert "has both a 'flags' and a 'values' section - choose one" in str(e.value)
 
 
-def test_ramp_legend(simple_colormap_style_cfg):
+def test_map_legend(simple_colormap_style_cfg):
     img = generate_ows_legend_style_cfg(simple_colormap_style_cfg, 1)
 
     assert img.mode == "RGBA"
-    assert img.size == (300, 125)
+    assert img.size == (400, 125)
 
 
 def test_api_none_mask(dummy_col_map_data, raw_calc_null_mask, simple_colormap_style_cfg):


### PR DESCRIPTION
Fairly major refactor of legend generation factor.  Underlying motivation is to allow all text elements in auto-generated legends to be translatable, however this PR is just the preparatory refactor - the actual translation work will be done in a subsequent PR.

The refactored implementation should be mostly compatible with the previous implementation, except as noted below.

Functional changes:

1) Long-deprecated "legacy" style legend configurations now always trigger an config exception.  This was only partly the case previously.
2) The default width of colour-map legends is now 4 inches (at 100dpi) to match the default for colour-ramp legends (previously 3 inches).
3) Colour-map legends now support a legend title (previously legend titles were only supported for colour-ramp legends).  The default for colour-map legends is no title - this is different to the default title behaviour for colour-ramp legends.
4) Colour-map legends now support an "ncols" element that allows legend patches and labels to be laid out in a multi-column format.  Previously such legends were always single-columned.
5) WMTS GetCaps previously displayed a legend URL for all styles, whether or not a legend was available.  This is now fixed.
6) Some invalid legend configurations were not being detected, resulting in infinite loops, crashes, or less pathological unexpected behaviour.  (e.g. `ticks_every` being less than or equal to zero, explicit ticks outside of the legend range.) These are now detected and reported at startup.