### PR TITLE
Legend translation

### DIFF
--- a/datacube_ows/cfg_parser_impl.py
+++ b/datacube_ows/cfg_parser_impl.py
@@ -222,7 +222,7 @@ def translation(languages, msg_file, new, domain, translations_dir, cfg):
         if msg_file is None and cfg.msg_file_name is None:
             click.echo("No message file name was supplied or is configured")
             sys.exit(1)
-        else:
+        elif msg_file is None:
             click.echo(f"Using message file location '{cfg.msg_file_name}' from configuration")
             msg_file = cfg.msg_file_name
         all_langs = cfg.locales

--- a/datacube_ows/cfg_parser_impl.py
+++ b/datacube_ows/cfg_parser_impl.py
@@ -224,7 +224,7 @@ def translation(languages, msg_file, new, domain, translations_dir, cfg):
             sys.exit(1)
         else:
             click.echo(f"Using message file location '{cfg.msg_file_name}' from configuration")
-            msg_file_name = cfg.msg_file_name
+            msg_file = cfg.msg_file_name
         all_langs = cfg.locales
     else:
         all_langs = []

--- a/datacube_ows/config_utils.py
+++ b/datacube_ows/config_utils.py
@@ -287,8 +287,13 @@ class OWSMetadataConfig(OWSConfigEntry):
         return None
 
     # Holders for managing inheritance.
-    default_title: Optional[str] = None
-    default_abstract: Optional[str] = None
+    @property
+    def default_title(self) -> Optional[str]:
+        return None
+
+    @property
+    def default_abstract(self) -> Optional[str]:
+        return None
 
     _keywords: Set[str] = set()
 
@@ -304,10 +309,10 @@ class OWSMetadataConfig(OWSConfigEntry):
         inherit_from = self.can_inherit_from()
         if self.METADATA_TITLE:
             if self.default_title:
-                self.register_metadata(self.get_obj_label(), FLD_TITLE, cast(str, cfg.get("title", self.default_title)))
+                self.register_metadata(self.get_obj_label(), FLD_TITLE, cast(str, cfg.get(FLD_TITLE, self.default_title)))
             else:
                 try:
-                    self.register_metadata(self.get_obj_label(), FLD_TITLE, cast(str, cfg["title"]))
+                    self.register_metadata(self.get_obj_label(), FLD_TITLE, cast(str, cfg[FLD_TITLE]))
                 except KeyError:
                     raise ConfigException(f"Entity {self.get_obj_label()} has no title.")
         if self.METADATA_ABSTRACT:

--- a/datacube_ows/config_utils.py
+++ b/datacube_ows/config_utils.py
@@ -236,6 +236,7 @@ class OWSConfigEntry:
 # Label names for metadata separation and translation
 
 FLD_TITLE = "title"
+FLD_UNITS = "units"
 FLD_ABSTRACT = "abstract"
 FLD_KEYWORDS = "local_keywords"
 FLD_FEES = "fees"
@@ -262,6 +263,7 @@ class OWSMetadataConfig(OWSConfigEntry):
     METADATA_ATTRIBUTION: bool = False
     METADATA_DEFAULT_BANDS: bool = False
     METADATA_VALUE_RULES: bool = False
+    METADATA_LEGEND_UNITS: bool = False
 
     # Class registries, mapping metadata paths to their default value and whether the metadata value is
     # unique to that path, or has been inherited from a parent metadata path.
@@ -347,7 +349,7 @@ class OWSMetadataConfig(OWSConfigEntry):
             if attrib_title:
                 self.register_metadata(self.get_obj_label(), FLD_ATTRIBUTION, attrib_title, inheriting)
         if self.METADATA_FEES:
-            fees = cast(str, cfg.get("fees"))
+            fees = cast(str, cfg.get(FLD_FEES))
             if not fees:
                 fees = "none"
             self.register_metadata(self.get_obj_label(), FLD_FEES, fees)
@@ -372,8 +374,13 @@ class OWSMetadataConfig(OWSConfigEntry):
                 else:
                     self.register_metadata(self.get_obj_label(), k, k)
         if self.METADATA_VALUE_RULES:
+            # Note that parse_metadata must be called after everything else is parsed.
             for patch in self.patches:
                 self.register_metadata(self.get_obj_label(), f"rule_{patch.idx}", patch.label)
+        if self.METADATA_LEGEND_UNITS:
+            units = cast(str, cfg.get(FLD_UNITS))
+            if units is not None:
+                self.register_metadata(self.get_obj_label(), FLD_UNITS, units)
 
     @property
     def keywords(self) -> Set[str]:
@@ -477,7 +484,9 @@ class OWSMetadataConfig(OWSConfigEntry):
         """"
         Expose separated or internationalised metadata as attributes
         """
-        if name in (FLD_TITLE, FLD_ABSTRACT, FLD_FEES, FLD_ACCESS_CONSTRAINTS, FLD_CONTACT_POSITION, FLD_CONTACT_ORGANISATION):
+        if name in (FLD_TITLE, FLD_ABSTRACT, FLD_FEES,
+                    FLD_ACCESS_CONSTRAINTS, FLD_CONTACT_POSITION, FLD_CONTACT_ORGANISATION,
+                    FLD_UNITS):
             return self.read_local_metadata(name)
         elif name == FLD_KEYWORDS:
             kw = self.read_local_metadata(FLD_KEYWORDS)

--- a/datacube_ows/config_utils.py
+++ b/datacube_ows/config_utils.py
@@ -264,6 +264,7 @@ class OWSMetadataConfig(OWSConfigEntry):
     METADATA_DEFAULT_BANDS: bool = False
     METADATA_VALUE_RULES: bool = False
     METADATA_LEGEND_UNITS: bool = False
+    METADATA_TICK_LABELS: bool = False
 
     # Class registries, mapping metadata paths to their default value and whether the metadata value is
     # unique to that path, or has been inherited from a parent metadata path.
@@ -374,13 +375,18 @@ class OWSMetadataConfig(OWSConfigEntry):
                 else:
                     self.register_metadata(self.get_obj_label(), k, k)
         if self.METADATA_VALUE_RULES:
-            # Note that parse_metadata must be called after everything else is parsed.
+            # Note that parse_metadata must be called after the value map is parsed.
             for patch in self.patches:
                 self.register_metadata(self.get_obj_label(), f"rule_{patch.idx}", patch.label)
         if self.METADATA_LEGEND_UNITS:
             units = cast(str, cfg.get(FLD_UNITS))
             if units is not None:
                 self.register_metadata(self.get_obj_label(), FLD_UNITS, units)
+        if self.METADATA_TICK_LABELS:
+            # Note that parse_metadata must be called after legend ticks are parsed.
+            for tick, lbl in zip(self.ticks, self.tick_labels):
+                if any(c.isalpha() for c in lbl):
+                    self.register_metadata(self.get_obj_label(), f"lbl_{tick}", lbl)
 
     @property
     def keywords(self) -> Set[str]:

--- a/datacube_ows/config_utils.py
+++ b/datacube_ows/config_utils.py
@@ -312,7 +312,7 @@ class OWSMetadataConfig(OWSConfigEntry):
         # pylint: disable=assignment-from-none
         inherit_from = self.can_inherit_from()
         if self.METADATA_TITLE:
-            if self.default_title:
+            if self.default_title is not None:
                 self.register_metadata(self.get_obj_label(), FLD_TITLE, cast(str, cfg.get(FLD_TITLE, self.default_title)))
             else:
                 try:

--- a/datacube_ows/config_utils.py
+++ b/datacube_ows/config_utils.py
@@ -261,6 +261,7 @@ class OWSMetadataConfig(OWSConfigEntry):
     METADATA_ACCESS_CONSTRAINTS: bool = False
     METADATA_ATTRIBUTION: bool = False
     METADATA_DEFAULT_BANDS: bool = False
+    METADATA_VALUE_RULES: bool = False
 
     # Class registries, mapping metadata paths to their default value and whether the metadata value is
     # unique to that path, or has been inherited from a parent metadata path.
@@ -370,6 +371,9 @@ class OWSMetadataConfig(OWSConfigEntry):
                     self.register_metadata(self.get_obj_label(), k, v[0])
                 else:
                     self.register_metadata(self.get_obj_label(), k, k)
+        if self.METADATA_VALUE_RULES:
+            for patch in self.patches:
+                self.register_metadata(self.get_obj_label(), f"rule_{patch.idx}", patch.label)
 
     @property
     def keywords(self) -> Set[str]:

--- a/datacube_ows/ows_configuration.py
+++ b/datacube_ows/ows_configuration.py
@@ -18,6 +18,7 @@ import math
 import os
 from collections.abc import Mapping
 from importlib import import_module
+from typing import Optional
 
 import numpy
 from babel.messages.catalog import Catalog
@@ -1071,7 +1072,9 @@ class OWSConfig(OWSMetadataConfig):
     METADATA_ACCESS_CONSTRAINTS = True
     METADATA_CONTACT_INFO = True
 
-    default_abstract = ""
+    @property
+    def default_abstract(self) -> Optional[str]:
+        return ""
 
     def __init__(self, refresh=False, cfg=None, ignore_msgfile=False, called_from_update_ranges=False):
         self.called_from_update_ranges = called_from_update_ranges

--- a/datacube_ows/styles/base.py
+++ b/datacube_ows/styles/base.py
@@ -15,9 +15,9 @@ from flask_babel import get_locale
 from PIL import Image
 
 import datacube_ows.band_utils
-from datacube_ows.config_utils import (CFG_DICT, RAW_CFG, AbstractMaskRule, FlagBand,
-                                       FlagProductBands, OWSConfigEntry,
-                                       OWSEntryNotFound,
+from datacube_ows.config_utils import (CFG_DICT, RAW_CFG, AbstractMaskRule,
+                                       FlagBand, FlagProductBands,
+                                       OWSConfigEntry, OWSEntryNotFound,
                                        OWSExtensibleConfigEntry,
                                        OWSFlagBandStandalone,
                                        OWSIndexedConfigEntry,

--- a/datacube_ows/styles/base.py
+++ b/datacube_ows/styles/base.py
@@ -628,6 +628,8 @@ class BandIdxProxy:
 
 class GlobalCfgProxy:
     internationalised = False
+    default_locale = "en"
+    locales = ["en"]
 
 
 class StandaloneProductProxy:

--- a/datacube_ows/styles/base.py
+++ b/datacube_ows/styles/base.py
@@ -11,17 +11,17 @@ from typing import (Any, Iterable, List, Mapping, MutableMapping, Optional,
 import datacube.model
 import numpy as np
 import xarray as xr
-from PIL import Image
 from flask_babel import get_locale
+from PIL import Image
 
 import datacube_ows.band_utils
-from datacube_ows.config_utils import (CFG_DICT, AbstractMaskRule, FlagBand,
+from datacube_ows.config_utils import (CFG_DICT, RAW_CFG, AbstractMaskRule, FlagBand,
                                        FlagProductBands, OWSConfigEntry,
                                        OWSEntryNotFound,
                                        OWSExtensibleConfigEntry,
                                        OWSFlagBandStandalone,
                                        OWSIndexedConfigEntry,
-                                       OWSMetadataConfig, RAW_CFG)
+                                       OWSMetadataConfig)
 from datacube_ows.legend_utils import get_image_from_url
 from datacube_ows.ogc_exceptions import WMSException
 from datacube_ows.ogc_utils import ConfigException, FunctionWrapper

--- a/datacube_ows/styles/colormap.py
+++ b/datacube_ows/styles/colormap.py
@@ -16,7 +16,7 @@ from matplotlib import pyplot as plt
 from xarray import DataArray, Dataset, merge
 
 from datacube_ows.config_utils import (CFG_DICT, AbstractMaskRule,
-                                       ConfigException)
+                                       ConfigException, OWSMetadataConfig)
 from datacube_ows.styles.base import StyleDefBase
 
 _LOG = logging.getLogger(__name__)
@@ -270,10 +270,13 @@ class PatchTemplate:
         self.label = rule.label
 
 
-class ColorMapLegendBase(StyleDefBase.Legend):
+class ColorMapLegendBase(StyleDefBase.Legend, OWSMetadataConfig):
+    METADATA_ABSTRACT: bool = False
+
     def __init__(self, style_or_mdh: Union["StyleDefBase", "StyleDefBase.Legend"], cfg: CFG_DICT) -> None:
         super().__init__(style_or_mdh, cfg)
         raw_cfg = cast(CFG_DICT, self._raw_cfg)
+        self.parse_metadata(raw_cfg)
         self.ncols = int(raw_cfg.get("ncols", 1))
         if self.ncols < 1:
             raise ConfigException("ncols must be a positive integer")
@@ -308,6 +311,12 @@ class ColorMapLegendBase(StyleDefBase.Legend):
                        ncol=self.ncols,
                        frameon=False)
         plt.savefig(bytesio, format='png')
+
+    # For MetadataConfig
+    @property
+    def default_title(self) -> Optional[str]:
+        return ""
+
 
 
 class ColorMapStyleDef(StyleDefBase):

--- a/datacube_ows/styles/ramp.py
+++ b/datacube_ows/styles/ramp.py
@@ -279,13 +279,12 @@ class ColorRamp:
 
 class RampLegendBase(StyleDefBase.Legend, OWSMetadataConfig):
     METADATA_ABSTRACT: bool = False
+    METADATA_LEGEND_UNITS: bool = True
 
     def __init__(self, style_or_mdh: Union["StyleDefBase", "StyleDefBase.Legend"], cfg: CFG_DICT) -> None:
         super().__init__(style_or_mdh, cfg)
         raw_cfg = cast(CFG_DICT, self._raw_cfg)
         self.parse_metadata(raw_cfg)
-        # Basic text
-        self.units = cast(Optional[str], raw_cfg.get("units"))
         # Range - defaults deferred until we have parsed the associated ramp
         if "begin" not in raw_cfg:
             self.begin = Decimal("nan")

--- a/docs/cfg_styling.rst
+++ b/docs/cfg_styling.rst
@@ -255,6 +255,8 @@ An external url pointing to an image file containing the legend. This
 url will not be exposed directly to users, the image file will be
 proxied behind an internal url.
 
+The external image file MUST be in png format.
+
 A url is required if `show_legend` is True and the style type does NOT
 support auto-legend generation.
 
@@ -267,6 +269,40 @@ E.g.::
          "show_legend": True,
          "url": "https://somedomain.com/path/to/legend_image.png",
      }
+
+If your instance of OWS
+`supports multiple languages<https://datacube-ows.readthedocs.io/en/latest/configuration.html#metadata-separation-and-internationalisation>`_
+then you may supply separate urls pointing to different versions of the legend image for each of the configured
+``supported_languages``.  In this case you MUST supply a legend image url for the default language
+(the first language listed in the global ``supported_languages`` entry), and this url will be used for
+any other supported languages for which you did not supply a specific url.
+
+E.g. given supported languages (in the global section)::
+
+    "supported_languages": [
+        "en",      # The first language listed will be the default language.
+        "fr",
+        "de",
+        "ar"
+    ]
+
+You can specify language specific legend urls with::
+
+    "url": {
+        "en": "http://myimages.com/this_product/this_style/default_english_legend.png",   # default legend image
+        "fr": "http://myimages.com/this_product/this_style/french_legend.png",
+        "ar": "http://myimages.com/this_product/this_style/arabic_legend.png",
+        "it": "http://myimages.com/this_product/this_style/italian_legend.png",
+    }
+
+In the above example:
+
+* the default english legend is used for English and German requests, as well as any language not in the
+  supported_language list.
+* French and Arabic requests will get their specific language legends.
+* Italian is not a supported language, so the Italian url will be ignored.  Italian requests will get the default
+  (English) legend.
+* Removing the English url from the `urls` dictionary will result in an error as English is the default language.
 
 multi_date
 ++++++++++

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -409,6 +409,8 @@ Fields that can be included in the message file are:
 
 *    Titles (global, folder, layer, style, colour-ramp legends, colour-map legends)
 *    Abstracts (global, folder, layer, style)
+*    Units (colour-ramp legends only)
+*    Tick labels (colour-ramp legends only) [#tlt]_
 *    Default band names (layer only)
 *    Keywords (global, folder, layer)
 *    Attribution titles (global, folder, layer)
@@ -416,6 +418,11 @@ Fields that can be included in the message file are:
 *    Access Constraints (global only)
 *    Contact Info Organisation (global only)
 *    Contact Info Position (global only)
+
+.. [#tlt] Prefixes, suffixes and labels are pre-combined for translation purposes, and only combined tick_labels
+   that contain at least one alphabetic character are recognised by the translation engine.  E.g. a label of "0.0"
+   with a prefix of "<" will not be picked up by the translation engine, but if the prefix is changed to "less than ",
+   then the resulting combined value "less than 0.0" WILL be picked up the translation engine.
 
 Internationalisation/Translation of Metadata
 ++++++++++++++++++++++++++++++++++++++++++++

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -395,17 +395,21 @@ To separate your metadata from config (either as an end in itself, or as prepara
 The msgid's in the message file are symbolic. E.g.
 
 * ``global.title``: The title for the whole service.
-* ``folder.<label>.title``: The title for a folder, identified by label.
+* ``layer.<label>.title``: The title for a folder, identified by label.
 * ``layer.<name>.title``: The title for a named layer, identified by name.
+* ``layer.<name>.bands.<band_name>``: The default name for a band.
 * ``style.<layer_name>.<style_name>.title``: The title for a style, identified by layer name and style name.
+* ``style.<layer_name>.<style_name>.legend.1.title``: The title for a style legend (single date form),
+  identified by layer name, style name, and the lowest date count the legend supports.
 
 The msgstr's in the message file are the text used by OWS for global/layer/style metadata, in preference
 to the values in the config file.
 
 Fields that can be included in the message file are:
 
-*    Titles (global, folder, layer, style)
+*    Titles (global, folder, layer, style, colour-ramp legends, colour-map legends)
 *    Abstracts (global, folder, layer, style)
+*    Default band names (layer only)
 *    Keywords (global, folder, layer)
 *    Attribution titles (global, folder, layer)
 *    Fees (global only)

--- a/integration_tests/cfg/ows_test_cfg.py
+++ b/integration_tests/cfg/ows_test_cfg.py
@@ -162,8 +162,12 @@ style_ndvi = {
     "legend": {
         "units": "dimensionless",
         "tick_labels": {
-            "0.0": "low",
-            "1.0": "high"
+            "0.0": {
+                "label": "low",
+            },
+            "1.0": {
+                "label": "high",
+            }
         }
     }
 }

--- a/integration_tests/cfg/ows_test_cfg.py
+++ b/integration_tests/cfg/ows_test_cfg.py
@@ -5,6 +5,13 @@
 # Copyright (c) 2017-2021 OWS Contributors
 # SPDX-License-Identifier: Apache-2.0
 
+import os
+
+if os.environ.get("DATACUBE_OWS_CFG", "").startswith("integration_tests"):
+    trans_dir = "."
+else:
+    trans_dir = "/code"
+
 
 # THIS IS A TESTING FILE
 # Please refer to datacube_ows/ows_cfg_example.py for EXAMPLE CONFIG
@@ -152,6 +159,13 @@ style_ndvi = {
     # If true, the calculated index value for the pixel will be included in GetFeatureInfo responses.
     # Defaults to True.
     "include_in_feature_info": True,
+    "legend": {
+        "units": "dimensionless",
+        "tick_labels": {
+            "0.0": "low",
+            "1.0": "high"
+        }
+    }
 }
 
 style_ndvi_expr = {
@@ -488,7 +502,8 @@ ows_cfg = {
             "https://localhost/odc_ows",
             "https://alternateurl.domain.org/odc_ows",
         ],
-        "translations_directory": "/code/integration_tests/cfg/translations",
+        "message_file": f"{trans_dir}/integration_tests/cfg/message.po",
+        "translations_directory": f"{trans_dir}/integration_tests/cfg/translations",
         "supported_languages": ["en", "de"],
 
         # URL that humans can visit to learn more about the service(s) or organization

--- a/integration_tests/cfg/ows_test_cfg.py
+++ b/integration_tests/cfg/ows_test_cfg.py
@@ -72,7 +72,13 @@ style_rgb = {
             "band": "quality",
             "flags": {"cloud": False}
         }
-    ]
+    ],
+    "legend": {
+        "show_legend": True,
+        "url": {
+            "en": "https://static.wixstatic.com/media/8959d6_98a1d74703d946ecab030b32f53db883~mv2.png/v1/fill/w_268,h_68,al_c,q_85,usm_0.66_1.00_0.01/f9d4ea_7a2d1d0c69ad4da0a2f48b69bc481612_.webp"
+        }
+    }
 }
 
 style_rgb_clone = {

--- a/integration_tests/cfg/ows_test_cfg.py
+++ b/integration_tests/cfg/ows_test_cfg.py
@@ -76,7 +76,7 @@ style_rgb = {
     "legend": {
         "show_legend": True,
         "url": {
-            "en": "https://static.wixstatic.com/media/8959d6_98a1d74703d946ecab030b32f53db883~mv2.png/v1/fill/w_268,h_68,al_c,q_85,usm_0.66_1.00_0.01/f9d4ea_7a2d1d0c69ad4da0a2f48b69bc481612_.webp"
+            "en": "https://user-images.githubusercontent.com/4548530/112120795-b215b880-8c12-11eb-8bfa-1033961fb1ba.png"
         }
     }
 }
@@ -687,7 +687,7 @@ ows_cfg = {
                     # Image height in pixels (optional)
                     "height": 68,
                     # URL for the logo image. (required if logo specified)
-                    "url": "https://static.wixstatic.com/media/8959d6_98a1d74703d946ecab030b32f53db883~mv2.png/v1/fill/w_268,h_68,al_c,q_85,usm_0.66_1.00_0.01/f9d4ea_7a2d1d0c69ad4da0a2f48b69bc481612_.webp",
+                    "url": "https://user-images.githubusercontent.com/4548530/112120795-b215b880-8c12-11eb-8bfa-1033961fb1ba.png",
                     # Image MIME type for the logo - should match type referenced in the logo url (required if logo specified.)
                     "format": "image/png",
                 },

--- a/integration_tests/test_cfg_parser.py
+++ b/integration_tests/test_cfg_parser.py
@@ -157,6 +157,7 @@ def test_cfg_write_new_translation_directory_no_msg_file(runner):
     result = runner.invoke(main, ["translation", "-n",
                                   "-d", f"{this_dir}/cfg/test_translations",
                                   "-D", "ows_cfg",
+                                  "-c", "integration_tests.cfg.ows_test_cfg_bad.ows_cfg",
                                   "all"])
     assert result.exit_code == 1
 

--- a/integration_tests/test_cfg_parser.py
+++ b/integration_tests/test_cfg_parser.py
@@ -186,6 +186,12 @@ def test_cfg_write_new_translation_directory_no_directory(runner):
                                   "-c", "integration_tests.cfg.ows_test_cfg_no_i18n.ows_cfg",
                                   "all"])
     assert result.exit_code == 1
+    result = runner.invoke(main, ["translation", "-n",
+                                  "-D", "ows_cfg",
+                                  "-d", f"{this_dir}/cfg/test_translations",
+                                  "-c", "integration_tests.cfg.ows_test_cfg_no_i18n.ows_cfg",
+                                  "all"])
+    assert result.exit_code == 1
 
 
 def test_cfg_new_translation_no_language(runner):

--- a/integration_tests/test_cfg_parser.py
+++ b/integration_tests/test_cfg_parser.py
@@ -113,7 +113,6 @@ def test_cfg_write_update_translation_directory(runner):
 def test_cfg_write_new_translation_directory_cfg(runner):
     this_dir = os.path.dirname(__file__)
     result = runner.invoke(main, ["translation", "-n",
-                                  "-m", f"{this_dir}/cfg/message.po",
                                   "-d", f"{this_dir}/cfg/test_translations",
                                   "-D", "ows_cfg",
                                   "-c", "integration_tests.cfg.ows_test_cfg.ows_cfg",

--- a/integration_tests/test_layers.py
+++ b/integration_tests/test_layers.py
@@ -57,9 +57,15 @@ def test_missing_metadata_file(monkeypatch):
 
 def test_metadata_file_ignore(monkeypatch):
     cached_cfg = OWSConfig._instance
+    cached_reg = OWSConfig._metadata_registry
+    cached_inh_reg = OWSConfig._inheritance_registry
+    cached_catalog = OWSConfig._msg_src
     monkeypatch.chdir(src_dir)
     try:
         OWSConfig._instance = None
+        OWSConfig._metadata_registry = {}
+        OWSConfig._inheritance_registry = {}
+        OWSConfig._msg_src = None
         raw_cfg = read_config()
         raw_cfg["global"]["message_file"] = "integration_tests/cfg/message.po"
         cfg = OWSConfig(refresh=True, cfg=raw_cfg, ignore_msgfile=True)
@@ -70,6 +76,9 @@ def test_metadata_file_ignore(monkeypatch):
         assert "aardvark" not in cfg.title
     finally:
         OWSConfig._instance = cached_cfg
+        OWSConfig._metadata_registry = cached_reg
+        OWSConfig._inheritance_registry = cached_inh_reg
+        OWSConfig._msg_src = cached_catalog
 
 
 def test_metadata_read(monkeypatch):

--- a/integration_tests/test_layers.py
+++ b/integration_tests/test_layers.py
@@ -28,11 +28,20 @@ def test_metadata_export():
 
 def test_missing_metadata_file(monkeypatch):
     cached_cfg = OWSConfig._instance
+    cached_reg = OWSConfig._metadata_registry
+    cached_inh_reg = OWSConfig._inheritance_registry
+    cached_catalog = OWSConfig._msg_src
+
     monkeypatch.chdir(src_dir)
     try:
         OWSConfig._instance = None
+        OWSConfig._metadata_registry = {}
+        OWSConfig._inheritance_registry = {}
+        OWSConfig._msg_src = None
         raw_cfg = read_config()
         raw_cfg["global"]["message_file"] = "integration_tests/cfg/non-existent.po"
+        raw_cfg["global"]["translations_directory"] = None
+        raw_cfg["global"]["languages"] = ["en"]
         cfg = OWSConfig(refresh=True, cfg=raw_cfg)
         with cube() as dc:
             cfg.make_ready(dc)
@@ -41,6 +50,9 @@ def test_missing_metadata_file(monkeypatch):
         assert "aardvark" not in cfg.title
     finally:
         OWSConfig._instance = cached_cfg
+        OWSConfig._metadata_registry = cached_reg
+        OWSConfig._inheritance_registry = cached_inh_reg
+        OWSConfig._msg_src = cached_catalog
 
 
 def test_metadata_file_ignore(monkeypatch):

--- a/integration_tests/test_wms_server.py
+++ b/integration_tests/test_wms_server.py
@@ -337,7 +337,17 @@ def test_wms_getlegend(ows_server):
         # check if this layer has a legend
         legend_url = test_layer_styles[style].get("legend")
         if legend_url:
-            resp = requests.head(legend_url, allow_redirects=False)
+            resp = requests.head(legend_url, headers={
+                "Accept-Language": "en-US,en,q=0.7"
+            },
+                                 allow_redirects=False
+                                 )
+            assert resp.headers.get("content-type") == "image/png"
+            resp = requests.head(legend_url, headers={
+                                "Accept-Language": "sw,sw,q=0.7"
+                            },
+                        allow_redirects=False
+            )
             assert resp.headers.get("content-type") == "image/png"
 
 

--- a/integration_tests/test_wms_server.py
+++ b/integration_tests/test_wms_server.py
@@ -338,10 +338,10 @@ def test_wms_getlegend(ows_server):
         legend_url = test_layer_styles[style].get("legend")
         if legend_url:
             resp = requests.head(legend_url, headers={
-                "Accept-Language": "en-US,en,q=0.7"
-            },
-                                 allow_redirects=False
-                                 )
+                                "Accept-Language": "en-US,en,q=0.7"
+                            },
+                            allow_redirects=False
+            )
             assert resp.headers.get("content-type") == "image/png"
             resp = requests.head(legend_url, headers={
                                 "Accept-Language": "sw,sw,q=0.7"

--- a/tests/test_style_api.py
+++ b/tests/test_style_api.py
@@ -267,6 +267,7 @@ def test_ramp_ticks_every(simple_ramp_style_cfg):
         Decimal("0.0"),
         Decimal("1.0"),
     ]
+    assert style.default_abstract is None
     simple_ramp_style_cfg["legend"] = {
         "begin": "0.0",
         "end": "1.0",

--- a/tests/test_style_api.py
+++ b/tests/test_style_api.py
@@ -74,6 +74,22 @@ def test_perband_component_style(dummy_raw_data, null_mask, simple_rgb_perband_s
         assert channel in result.data_vars.keys()
 
 
+def test_external_legends(simple_rgb_style_cfg):
+    simple_rgb_style_cfg["legend"] = {
+        "url": "http://fake.com/not/a/real/image_url.png"
+    }
+    style = StandaloneStyle(simple_rgb_style_cfg)
+    for l in style.legend_cfg.legend_urls:
+        assert style.legend_cfg.legend_urls[l] == "http://fake.com/not/a/real/image_url.png"
+    simple_rgb_style_cfg["legend"] = {
+        "url": {
+           "de": "http://fake.com/not/a/real/image_url.png"
+        }
+    }
+    with pytest.raises(ConfigException) as e:
+        style = StandaloneStyle(simple_rgb_style_cfg)
+    assert "supplied for default language" in str(e.value)
+
 @pytest.fixture
 def simple_ramp_style_cfg():
     return {

--- a/tests/test_style_api.py
+++ b/tests/test_style_api.py
@@ -267,7 +267,7 @@ def test_ramp_ticks_every(simple_ramp_style_cfg):
         Decimal("0.0"),
         Decimal("1.0"),
     ]
-    assert style.default_abstract is None
+    assert style.legend_cfg.default_abstract is None
     simple_ramp_style_cfg["legend"] = {
         "begin": "0.0",
         "end": "1.0",

--- a/tests/test_style_api.py
+++ b/tests/test_style_api.py
@@ -90,6 +90,7 @@ def test_external_legends(simple_rgb_style_cfg):
         style = StandaloneStyle(simple_rgb_style_cfg)
     assert "supplied for default language" in str(e.value)
 
+
 @pytest.fixture
 def simple_ramp_style_cfg():
     return {


### PR DESCRIPTION
Leverage recent refactor to provide internationalisation of legends.  (Addresses issue #771)

Includes some unrelated legend-handling bug fixes and documentation corrections.

## Auto-generated legends.

Most text in config that can be written to legend is now recognised as translatable metadata by the translation engine:

* Legend titles (colour ramp and colour map legends)
* Legend units (colour ramp styles)
* Legend tick labels (colour ramp styles)  (See note below)
* Rule labels (colour map styles) (for non-transparent rules only)

Note: prefixes, suffixes and labels are combined into a single label string for translation purposes, and combined label strings that contain no alphabetic characters are explicitly excluded from the translation engine.

## Manual legends.

For manual legends, you can now specify a separate external image url per supported language.  If a supported language does not have a specific url, the url for the default language is used.

