### PR TITLE
Don't try to read locale if babel is uninitialised.

### DIFF
--- a/datacube_ows/styles/base.py
+++ b/datacube_ows/styles/base.py
@@ -393,8 +393,9 @@ class StyleDefBase(OWSExtensibleConfigEntry, OWSMetadataConfig):
         if not legend.show_legend:
             return None
         if legend.legend_urls:
-            locale = get_locale().language
-            locales = self.global_config().locales
+            locale: Optional[str] = None
+            if self.global_config().internationalised:
+                locale = get_locale().language
             if locale not in self.global_config().locales:
                 locale = self.global_config().default_locale
             url = legend.legend_urls[locale]


### PR DESCRIPTION
Support for translatable manual legends broke manual legends in non-internationalised deployments.  This should fix.