### PR TITLE
Wcs multidate fixes

### DIFF
--- a/datacube_ows/wcs1.py
+++ b/datacube_ows/wcs1.py
@@ -113,10 +113,6 @@ def desc_coverages(args):
 def get_coverage(args):
     cfg = get_config()
     req = WCS1GetCoverageRequest(args)
-    if req.format.multi_time and len(req.times) > 1:
-        raise WCS1Exception("Multi-time requests are not currently supported for WCS1",
-                            WCS1Exception.INVALID_PARAMETER_VALUE,
-                            locator="Time parameter")
     qprof = QueryProfiler(req.ows_stats)
     n_datasets, data = get_coverage_data(req, qprof)
     if req.ows_stats:

--- a/datacube_ows/wcs1_utils.py
+++ b/datacube_ows/wcs1_utils.py
@@ -147,7 +147,7 @@ class WCS1GetCoverageRequest():
                     locator="TIME parameter",
                     valid_keys = [d.strftime('%Y-%m-%d') for d in self.product.ranges["time_set"]]
                 )
-            elif len(self.times) > 1 and not self.format["multi-time"]:
+            elif len(self.times) > 1 and not self.format.multi_time:
                 raise WCS1Exception(
                     "Cannot select more than one time slice with the %s format" % self.format["name"],
                     WCS1Exception.INVALID_PARAMETER_VALUE,

--- a/datacube_ows/wcs2_utils.py
+++ b/datacube_ows/wcs2_utils.py
@@ -8,7 +8,6 @@ from __future__ import absolute_import, division, print_function
 import collections
 import logging
 
-import datacube
 from datacube.utils import geometry
 from dateutil.parser import parse
 from ows.wcs.v20 import ScaleAxis, ScaleExtent, ScaleSize, Slice, Trim

--- a/datacube_ows/wcs2_utils.py
+++ b/datacube_ows/wcs2_utils.py
@@ -112,6 +112,11 @@ def get_coverage_data(request, qprof):
             dimension = subset.dimension.lower()
             if dimension == 'time':
                 if isinstance(subset, Trim):
+                    if "," in subset.high:
+                        raise WCS2Exception(
+                            "Subsets can only contain 2 elements - the lower and upper bounds. For arbitrary date lists, use WCS1",
+                            WCS2Exception.INVALID_SUBSETTING,
+                            locator="time")
                     low = parse(subset.low).date() if subset.low is not None else None
                     high = parse(subset.high).date() if subset.high is not None else None
                     if low is not None:
@@ -127,7 +132,6 @@ def get_coverage_data(request, qprof):
                 elif isinstance(subset, Slice):
                     point = parse(subset.point).date()
                     times = [point]
-
             else:
                 try:
                     if isinstance(subset, Trim):

--- a/datacube_ows/wcs2_utils.py
+++ b/datacube_ows/wcs2_utils.py
@@ -277,10 +277,6 @@ def get_coverage_data(request, qprof):
         qprof.end_event("fetch-datasets")
         if qprof.active:
             qprof["datasets"] = {str(q): ids for q, ids in stacker.datasets(dc.index, mode=MVSelectOpts.IDS).items()}
-        # if fmt.multi_time and len(times) > 1:
-            # Group by solar day
-         #    group_by = datacube.api.query.query_group_by(time=times, group_by='solar_day')
-          #   datasets = dc.group_datasets(datasets, group_by)
 
         qprof.start_event("load-data")
         output = stacker.data(datasets, skip_corrections=True)

--- a/datacube_ows/wcs2_utils.py
+++ b/datacube_ows/wcs2_utils.py
@@ -274,10 +274,10 @@ def get_coverage_data(request, qprof):
         qprof.end_event("fetch-datasets")
         if qprof.active:
             qprof["datasets"] = {str(q): ids for q, ids in stacker.datasets(dc.index, mode=MVSelectOpts.IDS).items()}
-        if fmt.multi_time and len(times) > 1:
+        # if fmt.multi_time and len(times) > 1:
             # Group by solar day
-            group_by = datacube.api.query.query_group_by(time=times, group_by='solar_day')
-            datasets = dc.group_datasets(datasets, group_by)
+         #    group_by = datacube.api.query.query_group_by(time=times, group_by='solar_day')
+          #   datasets = dc.group_datasets(datasets, group_by)
 
         qprof.start_event("load-data")
         output = stacker.data(datasets, skip_corrections=True)

--- a/integration_tests/test_wcs_server.py
+++ b/integration_tests/test_wcs_server.py
@@ -1360,7 +1360,7 @@ def test_wcs2_getcov_trim_time(ows_server):
             "scalesize": "x(400),y(400)",
             "subset": subsets,
         },
-        )
+    )
     assert r.status_code == 200
 
 def test_wcs2_getcov_badtrim_time(ows_server):
@@ -1395,7 +1395,7 @@ def test_wcs2_getcov_badtrim_time(ows_server):
         },
         expected_error_message="Subsets can only contain 2 elements - the lower and upper bounds. For arbitrary date lists, use WCS1",
         expected_status_code=400,
-        )
+    )
 
 
 def test_wcs2_getcov_slice_space(ows_server):

--- a/integration_tests/test_wcs_server.py
+++ b/integration_tests/test_wcs_server.py
@@ -282,7 +282,7 @@ def test_wcs1_multi_time_exceptions(ows_server):
             "crs": "EPSG:4326",
             "format": "GeoTIFF",
             "bbox": extents["bbox"],
-            "time": ",".join(extents["times"]),
+            "time": extents['times'],
             "resx": 0.01,
             "resy": 0.01,
         },
@@ -1138,7 +1138,6 @@ def test_wcs20_getcoverage_multidate_netcdf(ows_server):
         scalesize="x(400),y(300)",
     )
 
-
 def test_wcs21_server(ows_server):
     # N.B. At time of writing owslib does not support WCS 2.1, so we have to make requests manually.
     r = requests.get(
@@ -1342,6 +1341,12 @@ def test_wcs2_getcov_trim_time(ows_server):
     subsets = extent.raw_wcs2_subsets(
         ODCExtent.OFFSET_SUBSET_FOR_TIMES, ODCExtent.FIRST_TWO
     )
+    if len(subsets[2].split(",")) == 2:
+        subsets = [
+            subsets[0],
+            subsets[1],
+            'time("2019-01-05","2019-01-09")'
+        ]
 
     r = requests.get(
         ows_server.url + "/wcs",

--- a/integration_tests/test_wcs_server.py
+++ b/integration_tests/test_wcs_server.py
@@ -1341,7 +1341,7 @@ def test_wcs2_getcov_trim_time(ows_server):
     subsets = extent.raw_wcs2_subsets(
         ODCExtent.OFFSET_SUBSET_FOR_TIMES, ODCExtent.FIRST_TWO
     )
-    if len(subsets[2].split(",")) == 2:
+    if len(subsets[2].split(",")) == 1:
         subsets = [
             subsets[0],
             subsets[1],


### PR DESCRIPTION
Multidate requests were broken in both WCS1 and WCS2 (and have been for quite some time).

Addresses issue #798

Properly testing multi-date requests is impossible without extending the integration test database. (see issue #800)