### PR TITLE
schemas.opengis.net is back up - restoring deactivated tests.

### DIFF
--- a/integration_tests/test_wcs_server.py
+++ b/integration_tests/test_wcs_server.py
@@ -86,9 +86,8 @@ def test_wcs1_getcap(ows_server):
 
     # Validate XML Schema
     resp_xml = etree.parse(resp.fp)
-    # schemas.opengis.net is down
-    # gc_xds = get_xsd("1.0.0/wcsCapabilities.xsd")
-    # assert gc_xds.validate(resp_xml)
+    gc_xds = get_xsd("1.0.0/wcsCapabilities.xsd")
+    assert gc_xds.validate(resp_xml)
 
 
 def test_wcs1_getcap_sections(ows_server):
@@ -958,9 +957,8 @@ def test_wcs1_describecoverage(ows_server):
 
     resp = wcs.getDescribeCoverage(test_layer_name)
 
-    # schemas.opengis.net is down
-    # gc_xds = get_xsd("1.0.0/describeCoverage.xsd")
-    # assert gc_xds.validate(resp)
+    gc_xds = get_xsd("1.0.0/describeCoverage.xsd")
+    assert gc_xds.validate(resp)
 
 
 def test_wcs1_describecov_badcov(ows_server):


### PR DESCRIPTION
I had to temporarily deactivate the WCS XSD validation tests because `schemas.opengis.net` was down for several hours today.

It's back now, so reverting.