### PR TITLE
Remove confusing command from README docker instructions.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,6 @@ RUN apt-get update -y \
             git \
             # For Psycopg2
             libpq-dev python3-dev \
-            python3-distutils \
             gcc \
             python3-pip \
             postgresql-client-12 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,8 +29,6 @@ RUN if [ "$PYDEV_DEBUG" = "yes" ]; then \
     pip install --no-cache-dir .[dev] \
 ;fi
 
-RUN pip install pip-tools
-
 RUN pip freeze
 
 FROM osgeo/gdal:ubuntu-small-latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN apt-get update -y \
             git \
             # For Psycopg2
             libpq-dev python3-dev \
+            python3-distutils \
             gcc \
             python3-pip \
             postgresql-client-12 \
@@ -27,6 +28,8 @@ ARG PYDEV_DEBUG="no"
 RUN if [ "$PYDEV_DEBUG" = "yes" ]; then \
     pip install --no-cache-dir .[dev] \
 ;fi
+
+RUN pip install pip-tools
 
 RUN pip freeze
 
@@ -53,6 +56,7 @@ COPY --from=builder  /usr/local/bin/datacube-ows-cfg /usr/local/bin/datacube-ows
 COPY --from=builder  /usr/local/bin/flask /usr/local/bin/flask
 # gunicorn cli
 COPY --from=builder  /usr/local/bin/gunicorn /usr/local/bin/gunicorn
+COPY --from=builder  /usr/local/bin/pip-compile /usr/local/bin/pip-compile
 
 # make folders for testing and keep code in image
 RUN mkdir -p /code

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,6 @@ COPY --from=builder  /usr/local/bin/datacube-ows-cfg /usr/local/bin/datacube-ows
 COPY --from=builder  /usr/local/bin/flask /usr/local/bin/flask
 # gunicorn cli
 COPY --from=builder  /usr/local/bin/gunicorn /usr/local/bin/gunicorn
-COPY --from=builder  /usr/local/bin/pip-compile /usr/local/bin/pip-compile
 
 # make folders for testing and keep code in image
 RUN mkdir -p /code

--- a/README.rst
+++ b/README.rst
@@ -123,11 +123,6 @@ To run the standard Docker image, create a docker volume containing your ows con
 
   docker build --tag=name_of_built_container .
 
-  docker run \
-      --rm \
-      opendatacube/ows \
-      gunicorn -b '0.0.0.0:8000' -w 5 --timeout 300 datacube_ows:ogc
-
   docker run --rm \
         -e DATACUBE_OWS_CFG=datacube_ows.config.test_cfg.ows_cfg   # Location of config object
         -e AWS_NO_SIGN_REQUEST=yes                                 # Allowing access to AWS S3 buckets


### PR DESCRIPTION
Old README included a command in the docker instructions that simply won't work as written.  Issue reported on Slack.