### PR TITLE
add more option for logging ip

### DIFF
--- a/datacube_ows/ogc.py
+++ b/datacube_ows/ogc.py
@@ -240,6 +240,14 @@ def start_timer():
 @app.after_request
 def log_time_and_request_response(response):
     time_taken = int((monotonic() - g.ogc_start_time) * 1000)
-    _LOG.info("ip: %s request: %s returned status: %d and took: %d ms", request.environ.get('HTTP_X_REAL_IP'), request.url, response.status_code, time_taken)
+    if request.environ.get('HTTP_X_REAL_IP'):
+        ip = request.environ.get('HTTP_X_REAL_IP')
+    elif request.environ.get('HTTP_X_FORWARDED_FOR'):
+        ip = request.environ.get('HTTP_X_FORWARDED_FOR')
+    elif request.environ.get('REMOTE_ADDR'):
+        ip = request.environ.get('REMOTE_ADDR')
+    else:
+        ip = 'Not found'
+    _LOG.info("ip: %s request: %s returned status: %d and took: %d ms", ip, request.url, response.status_code, time_taken)
     return response
 

--- a/datacube_ows/ogc.py
+++ b/datacube_ows/ogc.py
@@ -240,10 +240,13 @@ def start_timer():
 @app.after_request
 def log_time_and_request_response(response):
     time_taken = int((monotonic() - g.ogc_start_time) * 1000)
+    # request.environ.get('HTTP_X_REAL_IP') captures requester ip on a local docker container via gunicorn
     if request.environ.get('HTTP_X_REAL_IP'):
         ip = request.environ.get('HTTP_X_REAL_IP')
+    # request.environ.get('HTTP_X_FORWARDED_FOR') captures request IP forwarded by ingress/loadbalancer
     elif request.environ.get('HTTP_X_FORWARDED_FOR'):
         ip = request.environ.get('HTTP_X_FORWARDED_FOR')
+    # request.environ.get('REMOTE_ADDR') is standard internal IP address
     elif request.environ.get('REMOTE_ADDR'):
         ip = request.environ.get('REMOTE_ADDR')
     else:


### PR DESCRIPTION
- `request.environ.get('HTTP_X_REAL_IP')` captures requester ip on a local docker container
- `request.environ.get('HTTP_X_FORWARDED_FOR')` captures request IP forwarded by ingress/loadbalancer
- `request.environ.get('REMOTE_ADDR')` is standard internal IP address


```
[2022-03-30 02:54:05,019] [INFO] ip: 49.2.70.36 request: http://ows-iptest.dev.dea.ga.gov.au/wms?request=GetCapabilities&service=WMS&version=1.3.0 returned status: 200 and took: 1100 ms
[2022-03-30 02:54:06,063] [INFO] ip: 10.95.72.77 request: http://10.95.85.173:8000/ping returned status: 200 and took: 17 ms
[2022-03-30 02:54:06,698] [INFO] ip: 10.95.7.197 request: http://10.95.85.173:8000/ping returned status: 200 and took: 2 ms
```
