### PR TITLE
Getcap caching

### DIFF
--- a/datacube_ows/ogc_utils.py
+++ b/datacube_ows/ogc_utils.py
@@ -371,6 +371,13 @@ class FunctionWrapper:
         return self._func(*calling_args, **calling_kwargs)
 
 
+def cache_control_headers(max_age: int) -> str:
+    if max_age <= 0:
+        return {"cache-control": "no-cache"}
+    else:
+        return {"cache-control": f"max-age={max_age}"}
+
+
 # Extent Mask Functions
 
 def mask_by_val(data: "xarray.Dataset", band: str, val: Optional[Any] = None) -> "xarray.DataArray":

--- a/datacube_ows/ows_configuration.py
+++ b/datacube_ows/ows_configuration.py
@@ -1249,10 +1249,29 @@ class OWSConfig(OWSMetadataConfig):
         self.s3_bucket = cfg.get("s3_bucket", "")
         self.s3_url = cfg.get("s3_url", "")
         self.s3_aws_zone = cfg.get("s3_aws_zone", "")
-        self.wms_max_width = cfg.get("max_width", 256)
-        self.wms_max_height = cfg.get("max_height", 256)
+        try:
+            self.wms_max_width = int(cfg.get("max_width", 256))
+            self.wms_max_height = int(cfg.get("max_height", 256))
+        except ValueError:
+            raise ConfigException(
+                f"max_width and max_height in wms section must be integers: {cfg.get('max_width', 256)},{cfg.get('max_height', 256)}"
+            )
+        if self.wms_max_width < 1 or self.wms_max_height < 1:
+            raise ConfigException(
+                f"max_width and max_height in wms section must be positive integers: {cfg.get('max_width', 256)},{cfg.get('max_height', 256)}"
+            )
         self.authorities = cfg.get("authorities", {})
         self.user_band_math_extension = cfg.get("user_band_math_extension", False)
+        try:
+            self.wms_cap_cache_age = int(cfg.get("caps_cache_maxage", 0))
+        except ValueError:
+            raise ConfigException(
+                f"caps_cache_maxage in wms section must be an integer: {cfg['caps_cache_maxage']}"
+            )
+        if self.wms_cap_cache_age < 0:
+            raise ConfigException(
+                f"caps_cache_maxage in wms section cannot be negative: {cfg['caps_cache_maxage']}"
+            )
         if "attribution" in cfg:
             _LOG.warning("Attribution entry in top level 'wms' section will be ignored. Attribution should be moved to the 'global' section")
 

--- a/datacube_ows/resource_limits.py
+++ b/datacube_ows/resource_limits.py
@@ -6,7 +6,7 @@ import numpy as np
 from datacube.utils.geometry import CRS, GeoBox, polygon
 
 from datacube_ows.config_utils import CFG_DICT, RAW_CFG, OWSConfigEntry
-from datacube_ows.ogc_utils import ConfigException, create_geobox
+from datacube_ows.ogc_utils import ConfigException, cache_control_headers, create_geobox
 
 
 # pyre-ignore[13]
@@ -163,16 +163,16 @@ class CacheControlRules(OWSConfigEntry):
             return {}
         assert n_datasets >= 0
         if n_datasets == 0 or n_datasets > self.max_datasets:
-            return {"cache-control": "no-cache"}
+            return cache_control_headers(0)
         rule = None
         for r in self.rules:
             if n_datasets < r["min_datasets"]:
                 break
             rule = r
         if rule:
-            return {"cache-control": f"max-age={rule['max_age']}"}
+            return cache_control_headers(rule['max_age'])
         else:
-            return {"cache-control": "no-cache"}
+            return cache_control_headers(0)
 
 
 class ResourceLimited(Exception):

--- a/datacube_ows/resource_limits.py
+++ b/datacube_ows/resource_limits.py
@@ -6,7 +6,8 @@ import numpy as np
 from datacube.utils.geometry import CRS, GeoBox, polygon
 
 from datacube_ows.config_utils import CFG_DICT, RAW_CFG, OWSConfigEntry
-from datacube_ows.ogc_utils import ConfigException, cache_control_headers, create_geobox
+from datacube_ows.ogc_utils import (ConfigException, cache_control_headers,
+                                    create_geobox)
 
 
 # pyre-ignore[13]

--- a/datacube_ows/wms.py
+++ b/datacube_ows/wms.py
@@ -10,7 +10,7 @@ from flask import render_template
 from datacube_ows.data import feature_info, get_map
 from datacube_ows.legend_generator import legend_graphic
 from datacube_ows.ogc_exceptions import WMSException
-from datacube_ows.ogc_utils import get_service_base_url
+from datacube_ows.ogc_utils import cache_control_headers, get_service_base_url
 from datacube_ows.ows_configuration import get_config
 from datacube_ows.utils import log_call
 
@@ -44,13 +44,13 @@ def get_capabilities(args):
     cfg = get_config()
     url = args.get('Host', args['url_root'])
     base_url = get_service_base_url(cfg.allowed_urls, url)
+    headers = cache_control_headers(cfg.wms_cap_cache_age)
+    headers["Content-Type"] = "application/xml"
     return (
         render_template(
             "wms_capabilities.xml",
             cfg=cfg,
             base_url=base_url),
         200,
-        cfg.response_headers(
-            {"Content-Type": "application/xml", "Cache-Control": "no-cache,max-age=0"}
-        )
+        cfg.response_headers(headers)
     )

--- a/datacube_ows/wmts.py
+++ b/datacube_ows/wmts.py
@@ -11,7 +11,7 @@ from flask import render_template
 
 from datacube_ows.data import feature_info, get_map
 from datacube_ows.ogc_exceptions import WMSException, WMTSException
-from datacube_ows.ogc_utils import get_service_base_url
+from datacube_ows.ogc_utils import get_service_base_url, cache_control_headers
 from datacube_ows.ows_configuration import get_config
 from datacube_ows.utils import log_call
 
@@ -85,6 +85,8 @@ def get_capabilities(args):
                 raise WMTSException("Invalid section: %s" % section,
                                 WMTSException.INVALID_PARAMETER_VALUE,
                                 locator="Section parameter")
+    headers = cache_control_headers(cfg.wms_cap_cache_age)
+    headers["Content-Type"] = "application/xml"
     return (
         render_template(
             "wmts_capabilities.xml",
@@ -96,9 +98,7 @@ def get_capabilities(args):
             show_contents=show_contents,
             show_themes=show_themes),
         200,
-        cfg.response_headers(
-            {"Content-Type": "application/xml", "Cache-Control": "max-age=10"}
-        )
+        cfg.response_headers(headers)
     )
 
 

--- a/datacube_ows/wmts.py
+++ b/datacube_ows/wmts.py
@@ -11,7 +11,7 @@ from flask import render_template
 
 from datacube_ows.data import feature_info, get_map
 from datacube_ows.ogc_exceptions import WMSException, WMTSException
-from datacube_ows.ogc_utils import get_service_base_url, cache_control_headers
+from datacube_ows.ogc_utils import cache_control_headers, get_service_base_url
 from datacube_ows.ows_configuration import get_config
 from datacube_ows.utils import log_call
 

--- a/docs/cfg_wms.rst
+++ b/docs/cfg_wms.rst
@@ -84,3 +84,28 @@ E.g.
             "auth": "https://authoritative-authority.com",
             "idsrus": "https://www.identifiers-r-us.com",
         },
+
+GetCapabilities Cache Control Headers (caps_cache_maxage)
+=========================================================
+
+The ``caps_cache_maxage`` entry in the ``wms`` section controls the value of the
+``Cache-control`` HTTP header returned with WMS/WMTS GetCapabilities responses.
+
+``caps_cache_maxage`` is an optional integer value that defaults to 0, and represents
+the maximum age in seconds that the Capabilities document should be cached.
+
+Note that OWS does not manage any caching itself, this entry controls a standard HTTP
+header that instructs upstream cache layers (e.g. AWS Cloudfront) how to behave.
+
+A value of zero means that OWS will recommend that the Capabilities document not be
+cached at all, and is the default.  Note that setting this entry to a non-zero value
+will introduce additional delays between new data being added to the datacube index
+and that data being advertised as available through the service. This value should therefore
+be kept fairly short (e.g. a few hours at most).
+
+E.g.
+
+    "wms": {
+        "caps_cache_maxage": 3600,   # 3600 seconds = 1 hour
+        ...
+    }

--- a/integration_tests/cfg/ows_test_cfg.py
+++ b/integration_tests/cfg/ows_test_cfg.py
@@ -637,6 +637,7 @@ ows_cfg = {
         "max_width": 512,
         "max_height": 512,
 
+        "caps_cache_maxage": 5,
         # These define the AuthorityURLs.
         # They represent the authorities that define the "Identifiers" defined layer by layer below.
         # The spec allows AuthorityURLs to be defined anywhere on the Layer heirarchy, but datacube_ows treats them

--- a/integration_tests/test_wms_server.py
+++ b/integration_tests/test_wms_server.py
@@ -85,7 +85,7 @@ def test_getcap_xsd(ows_server):
     assert result
 
 
-def test_getcap_coord_order(ows_server):
+def test_getcap_response(ows_server):
     resp = request.urlopen(
         ows_server.url + "/wms?request=GetCapabilities&service=WMS&version=1.3.0",
         timeout=10,
@@ -93,6 +93,9 @@ def test_getcap_coord_order(ows_server):
 
     # Confirm success
     assert resp.code == 200
+
+    # Check cache header
+    assert resp.headers["cache-control"] == "max-age=5"
 
     # Validate XML Schema
     resp_xml = etree.parse(resp.fp)

--- a/integration_tests/test_wmts_server.py
+++ b/integration_tests/test_wmts_server.py
@@ -68,6 +68,7 @@ def test_wmts_getcap(ows_server):
 
     # Confirm success
     assert resp.code == 200
+    assert resp.headers["cache-control"] == "max-age=5"
 
     # Validate XML Schema
     resp_xml = etree.parse(resp.fp)

--- a/tests/test_cfg_global.py
+++ b/tests/test_cfg_global.py
@@ -224,6 +224,7 @@ def test_two_langs(minimal_global_raw_cfg, minimal_dc):
     assert len(cfg.global_config().locales) == 2
     assert not cfg.global_config().internationalised
 
+
 def test_internationalised(minimal_global_raw_cfg, minimal_dc):
     OWSConfig._instance = None
 
@@ -231,3 +232,33 @@ def test_internationalised(minimal_global_raw_cfg, minimal_dc):
     minimal_global_raw_cfg["global"]["translations_directory"] = "/integration_tests/cfg/translations" # no need to be valid
     cfg = OWSConfig(cfg=minimal_global_raw_cfg)
     assert cfg.global_config().internationalised
+
+
+def test_bad_integers_in_wms_section(minimal_global_raw_cfg, minimal_dc):
+    minimal_global_raw_cfg["wms"] = {}
+    minimal_global_raw_cfg["wms"]["max_width"] = "very big"
+    with pytest.raises(ConfigException) as e:
+        OWSConfig._instance = None
+        cfg = OWSConfig(cfg=minimal_global_raw_cfg)
+    assert "max_width and max_height in wms section must be integers" in str(e.value)
+    assert "very big" in str(e.value)
+    minimal_global_raw_cfg["wms"]["max_width"] = 0
+    with pytest.raises(ConfigException) as e:
+        OWSConfig._instance = None
+        cfg = OWSConfig(cfg=minimal_global_raw_cfg)
+    assert "max_width and max_height in wms section must be positive integers" in str(e.value)
+    assert "0" in str(e.value)
+    minimal_global_raw_cfg["wms"]["max_width"] = 256
+    minimal_global_raw_cfg["wms"]["caps_cache_maxage"] = "forever"
+    with pytest.raises(ConfigException) as e:
+        OWSConfig._instance = None
+        cfg = OWSConfig(cfg=minimal_global_raw_cfg)
+    assert "caps_cache_maxage in wms section must be an integer" in str(e.value)
+    assert "forever" in str(e.value)
+    minimal_global_raw_cfg["wms"]["caps_cache_maxage"] = -100
+    with pytest.raises(ConfigException) as e:
+        OWSConfig._instance = None
+        cfg = OWSConfig(cfg=minimal_global_raw_cfg)
+    assert "caps_cache_maxage in wms section cannot be negative" in str(e.value)
+    assert "-100" in str(e.value)
+


### PR DESCRIPTION
Add configurable cache hints for WMS GetCapabilities response, as requested by @valpesendorfer .

Edit top-level `wms` config section to add:

```
   "wms": {
        ....
        "cap_cache_maxage": 300,    # 300 seconds = 5 minutes
   }
```

Default is 0, which explicitly returns "nocache".

This applies to WMS and WMTS only. Similar support may be implemented in future for the WCS XML requests.