### PR TITLE
Extract more accurate extent polygons into the materialised views where possible

### DIFF
--- a/datacube_ows/sql/extent_views/create/011_create_new_space_view_raw.sql
+++ b/datacube_ows/sql/extent_views/create/011_create_new_space_view_raw.sql
@@ -10,18 +10,27 @@ metadata_lookup as (
   select id,name from agdc.metadata_type
 ),
 -- This is eo3 spatial (Uses CEMP INSAR as a sample product)
-ranges as
+eo3_ranges as
 (select id,
   (metadata #>> '{extent, lat, begin}') as lat_begin,
   (metadata #>> '{extent, lat, end}') as lat_end,
   (metadata #>> '{extent, lon, begin}') as lon_begin,
-  (metadata #>> '{extent, lon, end}') as lon_end
+  (metadata #>> '{extent, lon, end}') as lon_end,
+  ST_Transform(
+    ST_SetSRID(
+      ST_GeomFromGeoJSON(
+        metadata #>> '{geometry}'),
+        substr(
+          metadata #>> '{crs}',6)::integer
+        ),
+        4326
+      ) as valid_geom
    from agdc.dataset where
       metadata_type_ref in (select id from metadata_lookup where name='eo3')
       and archived is null
   ),
 -- This is eo spatial (Uses ALOS-PALSAR over Africa as a sample product)
-corners as
+eo_corners as
 (select id,
   (metadata #>> '{extent, coord, ll, lat}') as ll_lat,
   (metadata #>> '{extent, coord, ll, lon}') as ll_lon,
@@ -31,22 +40,51 @@ corners as
   (metadata #>> '{extent, coord, ul, lon}') as ul_lon,
   (metadata #>> '{extent, coord, ur, lat}') as ur_lat,
   (metadata #>> '{extent, coord, ur, lon}') as ur_lon
+   from agdc.dataset
+   where metadata_type_ref in (select id from metadata_lookup where name in ('eo','eo_s2_nrt','gqa_eo','eo_plus', 'boku'))
+        and archived is null
+   and (metadata #>> '{grid_spatial, projection, valid_data}' is null
+       or
+        substr(metadata #>> '{grid_spatial, projection, spatial_reference}', 1, 4) <> 'EPSG'
+   )
+),
+eo_geoms as
+(select id,
+  ST_Transform(
+    ST_SetSRID(
+      ST_GeomFromGeoJSON(
+        metadata #>> '{grid_spatial, projection, valid_data}'),
+        substr(
+          metadata #>> '{grid_spatial, projection, spatial_reference}',6)::integer
+        ),
+        4326
+      ) as valid_data
    from agdc.dataset where
         metadata_type_ref in (select id from metadata_lookup where name in ('eo','eo_s2_nrt','gqa_eo','eo_plus', 'boku'))
         and archived is null
-    )
+   and metadata #>> '{grid_spatial, projection, valid_data}' is not null
+   and substr(metadata #>> '{grid_spatial, projection, spatial_reference}', 1, 5) = 'EPSG:'
+)
 select id,format('POLYGON(( %s %s, %s %s, %s %s, %s %s, %s %s))',
-        lon_begin, lat_begin, lon_end, lat_begin,  lon_end, lat_end,
-        lon_begin, lat_end, lon_begin, lat_begin)::geometry
+                 lon_begin, lat_begin, lon_end, lat_begin,  lon_end, lat_end,
+                 lon_begin, lat_end, lon_begin, lat_begin)::geometry
 as spatial_extent
-from ranges
+from eo3_ranges
+where valid_geom is null
+UNION
+select id,valid_geom as spatial_extent
+from eo3_ranges
+where valid_geom is not null
 UNION
 select id,format('POLYGON(( %s %s, %s %s, %s %s, %s %s, %s %s))',
-        ll_lon, ll_lat, lr_lon, lr_lat,  ur_lon, ur_lat,
-        ul_lon, ul_lat, ll_lon, ll_lat)::geometry as spatial_extent
-from corners
+                 ll_lon, ll_lat, lr_lon, lr_lat,  ur_lon, ur_lat,
+                 ul_lon, ul_lat, ll_lon, ll_lat)::geometry as spatial_extent
+from eo_corners
 UNION
--- This is lansat_scene and landsat_l1_scene with geometries
+select id, valid_data as spatial_extent
+from eo_geoms
+UNION
+-- This is landsat_scene and landsat_l1_scene with geometries
 select id,
   ST_Transform(
     ST_SetSRID(


### PR DESCRIPTION
Should result in more accurate/less blocky extent polygons when resource limits are exceeded.

Requires re-running `datacube-ows-update --schema --role rolename`.  (Regenerating the schema is done in-place and does not entail any service downtime.)  and then `datacube-ows-update`.   There is no need to re-run with the `--views` option first, as rebuilding the schema has the same effect.

Results in more accurate extents for all EO3 products and most DEA EO products, with some flow-on efficiency gains from more accurate geospatial dataset search.