### PR TITLE
Patch docker image for Ubuntu 20.04 security vulnerabilities

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,9 @@ RUN pip freeze
 
 FROM osgeo/gdal:ubuntu-small-latest
 
+# update for security packages, since osgeo/gdal doesn't
+RUN apt-get update -y && apt-get upgrade -y
+
 # all the python pip installed libraries
 COPY --from=builder  /usr/local/lib/python3.8/dist-packages /usr/local/lib/python3.8/dist-packages
 COPY --from=builder  /usr/lib/python3/dist-packages /usr/lib/python3/dist-packages


### PR DESCRIPTION
Trivy security scan [has been failing](https://github.com/opendatacube/datacube-ows/runs/5843582166?check_suite_focus=true#step:9:21) since January 2021, due to `HIGH` priority vulnerabilities with Ubuntu 20.04 packages. Since the base image osgeo/gdal does not install security packages, I've added it to our Dockerfile.

```
$ docker build -t novulns .
$ trivy image --severity=CRITICAL,HIGH novulns
2022-04-06T19:10:20.502+1000	INFO	Need to update DB
2022-04-06T19:10:20.502+1000	INFO	Downloading DB...
31.04 MiB / 31.04 MiB [---------------------------------------------------------------------------------------------------------------] 100.00% 5.59 MiB p/s 6s
2022-04-06T19:10:36.179+1000	INFO	Detected OS: ubuntu
2022-04-06T19:10:36.179+1000	INFO	Detecting Ubuntu vulnerabilities...
2022-04-06T19:10:36.185+1000	INFO	Number of language-specific files: 1
2022-04-06T19:10:36.185+1000	INFO	Detecting python-pkg vulnerabilities...

novulns (ubuntu 20.04)
=======================
Total: 0 (HIGH: 0, CRITICAL: 0)


Python (python-pkg)
===================
Total: 0 (HIGH: 0, CRITICAL: 0)
```

Downside is we get less stability from upgrading here, than depending on upstream. Ideally, upstream repo could do the security patches, or use a later Ubuntu release.