### PR TITLE
Attempt to sanity-check and sanitise bounding box ranges for global datasets

### DIFF
--- a/datacube_ows/product_ranges.py
+++ b/datacube_ows/product_ranges.py
@@ -270,23 +270,63 @@ def create_range_entry(dc, product, crses, summary_product=False):
     float(r[1]),
     epsg4326)
 
+  all_bboxes = bbox_projections(box, crses)
+
   conn.execute("""
     UPDATE wms.product_ranges
     SET bboxes = %(bbox)s::jsonb
     WHERE id=%(p_id)s
     """, {
-    "bbox": Json(
-      {crsid: {"top": box.to_crs(crs).boundingbox.top,
-               "bottom": box.to_crs(crs).boundingbox.bottom,
-               "left": box.to_crs(crs).boundingbox.left,
-               "right": box.to_crs(crs).boundingbox.right}
-        for crsid, crs in crses.items()
-       }
-    ),
+    "bbox": Json(all_bboxes),
     "p_id": product.id})
 
   txn.commit()
   conn.close()
+
+
+def bbox_projections(starting_box, crses):
+   globalbox = datacube.utils.geometry.box(-180, -90, 180, 90,
+                                           crs=datacube.utils.geometry.CRS("EPSG:4326"))
+   global_data = (starting_box == globalbox)
+   result = {}
+   for crsid, crs in crses.items():
+       if crs.valid_region is not None:
+           global_crs_bbox = crs.valid_region.to_crs(crs).boundingbox
+       else:
+           global_crs_bbox is None
+       if global_data and global_crs_bbox is not None:
+           result[crsid] = {
+               "top": global_crs_bbox.top,
+               "bottom": global_crs_bbox.bottom,
+               "left": global_crs_bbox.left,
+               "right": global_crs_bbox.right
+           }
+       else:
+           projbbox = starting_box.to_crs(crs).boundingbox
+           result[crsid] = sanitise_bbox(projbbox, global_crs_bbox)
+   return result
+
+
+def sanitise_bbox(bbox, global_bbox=None):
+    def santise_coordinate(coord, global_coord=None):
+        if coord in (float("-Inf"), float("-Nan")):
+            if global_coord is not None:
+                return global_coord
+            else:
+                return float("-9.999999999e99")
+        elif coord in (float("Inf"), float("Nan")):
+            if global_coord is not None:
+                return global_coord
+            else:
+                return float("9.999999999e99")
+        else:
+            return coord
+    return {
+        "top": santise_coordinate(bbox.top, getattr(global_bbox, "top", None)),
+        "bottom": santise_coordinate(bbox.bottom, getattr(global_bbox, "bottom", None)),
+        "left": santise_coordinate(bbox.left, getattr(global_bbox, "left", None)),
+        "right": santise_coordinate(bbox.right, getattr(global_bbox, "right", None)),
+    }
 
 
 def datasets_exist(dc, product_name):

--- a/datacube_ows/product_ranges.py
+++ b/datacube_ows/product_ranges.py
@@ -7,14 +7,13 @@
 #pylint: skip-file
 
 import math
-
 from datetime import datetime, timedelta, timezone
 
 import datacube
 from psycopg2.extras import Json
 
-from datacube_ows.ows_configuration import get_config
 from datacube_ows.ogc_utils import NoTimezoneException, tz_for_coord
+from datacube_ows.ows_configuration import get_config
 from datacube_ows.utils import get_sqlconn
 
 


### PR DESCRIPTION
Hopefully fixes (or at least mitigates) #824

1. If a crs.valid_range is available, use the intersection of the initial boundingbox and the valid_range.
2. If a crs.valid_range is not available and the projected bounding boxes includes an infinity or an Nan coordinate, use a very large float (with the appropriate sign).

Otherwise the calculated projected coordinate should be fine.