### PR TITLE
Improve usability of external legends.

### DIFF
--- a/datacube_ows/legend_utils.py
+++ b/datacube_ows/legend_utils.py
@@ -5,9 +5,9 @@
 # SPDX-License-Identifier: Apache-2.0
 import io
 import logging
-import requests
 from typing import Optional
 
+import requests
 from PIL import Image
 
 from datacube_ows.ogc_exceptions import WMSException

--- a/datacube_ows/legend_utils.py
+++ b/datacube_ows/legend_utils.py
@@ -4,10 +4,15 @@
 # Copyright (c) 2017-2021 OWS Contributors
 # SPDX-License-Identifier: Apache-2.0
 import io
+import logging
+import requests
 from typing import Optional
 
-import requests
 from PIL import Image
+
+from datacube_ows.ogc_exceptions import WMSException
+
+_LOG = logging.getLogger(__name__)
 
 
 def get_image_from_url(url: str) -> Optional[Image.Image]:
@@ -18,9 +23,12 @@ def get_image_from_url(url: str) -> Optional[Image.Image]:
     :return: A PIL image object (OR None if the url does not return a PNG image)
     """
     r = requests.get(url, timeout=1)
-    if r.status_code == 200 and r.headers['content-type'] == 'image/png':
-        bytesio = io.BytesIO()
-        bytesio.write(r.content)
-        bytesio.seek(0)
-        return Image.open(bytesio)
-    return None
+    if r.status_code != 200:
+        raise WMSException(f"Could not retrieve legend - external URL is failing with http code {r.status_code}")
+    if r.headers['content-type'] != 'image/png':
+        _LOG.warning("External legend has MIME type %s. OWS strongly recommends PNG format for legend images.",
+                     r.headers['content-type'])
+    bytesio = io.BytesIO()
+    bytesio.write(r.content)
+    bytesio.seek(0)
+    return Image.open(bytesio)

--- a/tests/test_legend_generator.py
+++ b/tests/test_legend_generator.py
@@ -9,6 +9,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from datacube_ows.legend_utils import get_image_from_url
+from datacube_ows.ogc_exceptions import WMSException
 from datacube_ows.styles.base import StyleDefBase
 from datacube_ows.styles.ramp import ColorRamp, ColorRampDef
 from tests.test_band_utils import dummy_layer  # noqa: F401,F811
@@ -50,8 +51,8 @@ def test_image_from_url(image_url):
 
 
 def test_image_from_bad_image_url(bad_image_url):
-    img = get_image_from_url(bad_image_url)
-    assert img is None
+    with pytest.raises(WMSException) as e:
+        img = get_image_from_url(bad_image_url)
 
 def test_parse_colorramp_defaults():
     legend = ColorRampDef.Legend(MagicMock(), {})


### PR DESCRIPTION
Two bugfixes with Remote Legend URLs:

* Raise warning instead of failing when external legend url is not PNG.
* Clearer error reporting when reading from external url fails.