### PR TITLE
Skip invalid CRS extents.

### DIFF
--- a/datacube_ows/product_ranges.py
+++ b/datacube_ows/product_ranges.py
@@ -286,7 +286,10 @@ def bbox_projections(starting_box, crses):
    result = {}
    for crsid, crs in crses.items():
        if crs.valid_region is not None:
-           clipped_crs_bbox = (starting_box & crs.valid_region).to_crs(crs).boundingbox
+           clipped_crs_region = (starting_box & crs.valid_region)
+           if clipped_crs_region.wkt == 'POLYGON EMPTY':
+               continue
+           clipped_crs_bbox = clipped_crs_region.to_crs(crs).boundingbox
        else:
            clipped_crs_bbox = None
        if clipped_crs_bbox is not None:


### PR DESCRIPTION
Fixes #831

In `datacube-ows-update` when caching product bounding boxes for published CRSs, CRS bounding boxes are now skipped where the extent of the layer is entirely outside the valid area of the CRS (if a valid area is available).

No other checks for CRS validity are made, e.g.

1) when determining which CRSs to list as supportedin the WMS Capabilities documents, all published CRSs are still listed as available in all top-level layers (and therefore inherited by all non-top-level layers), even if there is no bounding box available for that  CRS.
2) when processing a request. As long as the request bbox can be successfully converted to a valid EPSG:4326 polygon the request is handled smoothly, no checking for CRS validity is applied.