### PR TITLE
Sort multiproduct datasets by product

### DIFF
--- a/datacube_ows/ows_configuration.py
+++ b/datacube_ows/ows_configuration.py
@@ -565,7 +565,7 @@ class OWSNamedLayer(OWSExtensibleConfigEntry, OWSLayer):
             self.wcs = False
             return
         else:
-            self.wcs = True
+            self.wcs = not cfg.get("disable", False)
 
         if "native_resolution" in cfg:
             if not self.cfg_native_resolution:

--- a/datacube_ows/ows_configuration.py
+++ b/datacube_ows/ows_configuration.py
@@ -42,7 +42,7 @@ from datacube_ows.resource_limits import (OWSResourceManagementRules,
                                           parse_cache_age)
 from datacube_ows.styles import StyleDef
 from datacube_ows.tile_matrix_sets import TileMatrixSet
-from datacube_ows.utils import group_by_statistical
+from datacube_ows.utils import group_by_solar, group_by_statistical
 
 _LOG = logging.getLogger(__name__)
 
@@ -948,6 +948,12 @@ class OWSMultiProductLayer(OWSNamedLayer):
             "pq_names": pq_names,
             "pq_low_res_names": pq_low_res_names,
         }
+
+    def dataset_groupby(self):
+        if self.is_raw_time_res:
+            return group_by_solar(self.product_names)
+        else:
+            return group_by_statistical(self.product_names)
 
 
 def parse_ows_layer(cfg, global_cfg, parent_layer=None, sibling=0):

--- a/datacube_ows/utils.py
+++ b/datacube_ows/utils.py
@@ -66,7 +66,7 @@ def group_by_statistical(pnames: Optional[List[str]] = None) -> "datacube.api.qu
         sort_key=sort_key
     )
 
-def group_by_solar(pnames: Optional[List[str]]) -> "datacube.api.query.GroupBy":
+def group_by_solar(pnames: Optional[List[str]] = None) -> "datacube.api.query.GroupBy":
     from datacube.api.query import GroupBy, solar_day
     base_sort_key = lambda ds: ds.time.begin
     if pnames:

--- a/datacube_ows/utils.py
+++ b/datacube_ows/utils.py
@@ -6,7 +6,7 @@
 import logging
 from functools import wraps
 from time import monotonic
-from typing import Any, Callable, TypeVar
+from typing import Any, Callable, List, Optional, TypeVar
 
 F = TypeVar('F', bound=Callable[..., Any])
 
@@ -45,18 +45,45 @@ def time_call(func: F) -> F:
     return timing_wrapper
 
 
-def group_by_statistical() -> "datacube.api.query.GroupBy":
+def group_by_statistical(pnames: Optional[List[str]] = None) -> "datacube.api.query.GroupBy":
     """
     Returns an ODC GroupBy object, suitable for daily statistical/summary data.
     """
     from datacube.api.query import GroupBy
-
+    base_sort_key = lambda ds: ds.time.begin
+    if pnames:
+        index = {
+            pn: i
+            for i, pn in enumerate(pnames)
+        }
+        sort_key = lambda ds: (index[ds.type.name], base_sort_key(ds))
+    else:
+        sort_key = base_sort_key
     return GroupBy(
         dimension='time',
         group_by_func=lambda ds: ds.time.begin,
         units='seconds since 1970-01-01 00:00:00',
-        sort_key=lambda ds: ds.time.begin
+        sort_key=sort_key
     )
+
+def group_by_solar(pnames: Optional[List[str]]) -> "datacube.api.query.GroupBy":
+    from datacube.api.query import GroupBy, solar_day
+    base_sort_key = lambda ds: ds.time.begin
+    if pnames:
+        index = {
+            pn: i
+            for i, pn in enumerate(pnames)
+        }
+        sort_key = lambda ds: (index[ds.type.name], base_sort_key(ds))
+    else:
+        sort_key = base_sort_key
+    return GroupBy(
+        dimension='time',
+        group_by_func=solar_day,
+        units='seconds since 1970-01-01 00:00:00',
+        sort_key=sort_key
+    )
+
 
 
 def get_sqlconn(dc: "datacube.Datacube") -> "sqlalchemy.engine.base.Connection":

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,82 @@
+# This file is part of datacube-ows, part of the Open Data Cube project.
+# See https://opendatacube.org for more information.
+#
+# Copyright (c) 2017-2022 OWS Contributors
+# SPDX-License-Identifier: Apache-2.0
+import datetime
+import pytest
+
+from unittest.mock import MagicMock
+
+
+def mock_ds_for_sort(id_: str, st: datetime, ct: datetime, lon: float, prod_name):
+    ds = MagicMock()
+    ds.id = id_
+    ds.time.begin = st
+    ds.center_time = ct
+    ds.metadata.lon.begin = lon - 5.0
+    ds.metadata.lon.end = lon + 5.0
+    ds.type.name = prod_name
+    return ds
+
+
+@pytest.fixture
+def datasets_for_sorting():
+    utc = datetime.timezone.utc
+    DT = datetime.datetime
+    return [
+        mock_ds_for_sort("A", DT(2022, 7, 15, 0, 0, tzinfo=utc), DT(2022, 7, 15, 9, 45, tzinfo=utc), 148.0, "prod_a"),
+        mock_ds_for_sort("B", DT(2022, 7, 15, 0, 0, tzinfo=utc), DT(2022, 7, 15, 10, 45, tzinfo=utc), 148.0, "prod_a"),
+        mock_ds_for_sort("C", DT(2022, 7, 15, 5, 0, tzinfo=utc), DT(2022, 7, 15, 0, 5, tzinfo=utc), 128.0, "prod_a"),
+        mock_ds_for_sort("D", DT(2022, 7, 15, 5, 0, tzinfo=utc), DT(2022, 7, 15, 14, 45, tzinfo=utc), 128.0, "prod_a"),
+
+        mock_ds_for_sort("E", DT(2022, 7, 15, 0, 0, tzinfo=utc), DT(2022, 7, 15, 9, 45, tzinfo=utc), 128.0, "prod_b"),
+        mock_ds_for_sort("F", DT(2022, 7, 15, 0, 0, tzinfo=utc), DT(2022, 7, 15, 10, 45, tzinfo=utc), 128.0, "prod_b"),
+        mock_ds_for_sort("G", DT(2022, 7, 15, 5, 0, tzinfo=utc), DT(2022, 7, 15, 0, 5, tzinfo=utc), 148.0, "prod_b"),
+        mock_ds_for_sort("H", DT(2022, 7, 15, 5, 0, tzinfo=utc), DT(2022, 7, 15, 14, 45, tzinfo=utc), 148.0, "prod_b"),
+
+        mock_ds_for_sort("I", DT(2022, 7, 15, 0, 0, tzinfo=utc), DT(2022, 7, 15, 9, 45, tzinfo=utc), 128.0, "prod_c"),
+        mock_ds_for_sort("J", DT(2022, 7, 15, 0, 0, tzinfo=utc), DT(2022, 7, 15, 10, 45, tzinfo=utc), 128.0, "prod_c"),
+        mock_ds_for_sort("K", DT(2022, 7, 15, 5, 0, tzinfo=utc), DT(2022, 7, 15, 0, 45, tzinfo=utc), 148.0, "prod_c"),
+        mock_ds_for_sort("L", DT(2022, 7, 15, 5, 0, tzinfo=utc), DT(2022, 7, 15, 14, 45, tzinfo=utc), 148.0, "prod_c"),
+    ]
+
+
+def test_group_by_stat(datasets_for_sorting):
+    from datacube_ows.utils import group_by_statistical
+    from datacube import Datacube
+
+    gby = group_by_statistical()
+    date_only = Datacube.group_datasets(datasets_for_sorting, gby)
+    assert len(date_only) == 2
+    arrays = date_only.values
+    assert [ds.id for ds in arrays[0]] == ['A', 'B', 'E', 'F', 'I', 'J']
+    assert [ds.id for ds in arrays[1]] == ['C', 'D', 'G', 'H', 'K', 'L']
+
+
+    gby = group_by_statistical(["prod_c", "prod_b", "prod_a"])
+    date_only = Datacube.group_datasets(datasets_for_sorting, gby)
+    assert len(date_only) == 2
+    arrays = date_only.values
+    assert [ds.id for ds in arrays[0]] == ['I', 'J', 'E', 'F', 'A', 'B']
+    assert [ds.id for ds in arrays[1]] == ['K', 'L', 'G', 'H', 'C', 'D']
+
+
+def test_group_by_solar(datasets_for_sorting):
+    from datacube_ows.utils import group_by_solar
+    from datacube import Datacube
+
+    gby = group_by_solar()
+    date_only = Datacube.group_datasets(datasets_for_sorting, gby)
+    assert len(date_only) == 2
+    arrays = date_only.values
+    assert [ds.id for ds in arrays[0]] == ['A', 'B', 'E', 'F', 'I', 'J', 'C', 'D', 'G', 'K']
+    assert [ds.id for ds in arrays[1]] == ['H', 'L']
+
+
+    gby = group_by_solar(["prod_c", "prod_b", "prod_a"])
+    date_only = Datacube.group_datasets(datasets_for_sorting, gby)
+    assert len(date_only) == 2
+    arrays = date_only.values
+    assert [ds.id for ds in arrays[0]] == ['I', 'J', 'K', 'E', 'F', 'G', 'A', 'B', 'C', 'D']
+    assert [ds.id for ds in arrays[1]] == ['L', 'H']

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,9 +4,9 @@
 # Copyright (c) 2017-2022 OWS Contributors
 # SPDX-License-Identifier: Apache-2.0
 import datetime
-import pytest
-
 from unittest.mock import MagicMock
+
+import pytest
 
 
 def mock_ds_for_sort(id_: str, st: datetime, ct: datetime, lon: float, prod_name):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -43,8 +43,9 @@ def datasets_for_sorting():
 
 
 def test_group_by_stat(datasets_for_sorting):
-    from datacube_ows.utils import group_by_statistical
     from datacube import Datacube
+
+    from datacube_ows.utils import group_by_statistical
 
     gby = group_by_statistical()
     date_only = Datacube.group_datasets(datasets_for_sorting, gby)
@@ -63,8 +64,9 @@ def test_group_by_stat(datasets_for_sorting):
 
 
 def test_group_by_solar(datasets_for_sorting):
-    from datacube_ows.utils import group_by_solar
     from datacube import Datacube
+
+    from datacube_ows.utils import group_by_solar
 
     gby = group_by_solar()
     date_only = Datacube.group_datasets(datasets_for_sorting, gby)


### PR DESCRIPTION
Sort multiproduct datasets by product (according to the order of the provided product list)

Coupled with `manual_merge` and appropriate band aliases in the ODC metadata, this allows combining products from different families (e.g. a combined Landsat/Sentinel-2 layers, with Sentinel-2 always taking precedence where available).

Further work required to support band-mapping between heterogenous products.

On hold until Docker issues resolved.