### PR TITLE
Smarter band mapping for hetrogenous multiproducts.  Passes unit tests.

### DIFF
--- a/datacube_ows/data.py
+++ b/datacube_ows/data.py
@@ -135,7 +135,7 @@ class DataStacker:
         elif bands:
             self._needed_bands = [self._product.band_idx.locale_band(b) for b in bands]
         else:
-            self._needed_bands = list(self._product.band_idx.native_bands.index)
+            self._needed_bands = list(self._product.band_idx.measurements.keys())
 
         for band in self._product.always_fetch_bands:
             if band not in self._needed_bands:

--- a/datacube_ows/ows_configuration.py
+++ b/datacube_ows/ows_configuration.py
@@ -124,12 +124,13 @@ class BandIndex(OWSMetadataConfig):
                     self.band_cfg[b] = [b]
                 self.add_aliases(self.band_cfg)
             try:
+                prod_measurements = product.lookup_measurements(list(self.band_cfg.keys()))
                 if first_product:
-                    self.measurements = product.lookup_measurements(self.band_cfg.keys())
+                    self.measurements = prod_measurements
                     self._nodata_vals = {name: floatify_nans(model.nodata) for name, model in self.measurements.items()}
                     self._dtypes = {name: model.dtype for name, model in self.measurements.items()}
                 else:
-                    prod_measurements = product.lookup_measurements(self.band_cfg.keys())
+                    prod_measurements = prod_measurements
                     for k in prod_measurements:
                         nodata = self._nodata_vals[k]
                         if ((numpy.isnan(nodata) and not numpy.isnan(floatify_nans(prod_measurements[k].nodata)))

--- a/datacube_ows/ows_configuration.py
+++ b/datacube_ows/ows_configuration.py
@@ -128,7 +128,7 @@ class BandIndex(OWSMetadataConfig):
                 if first_product:
                     self.measurements = prod_measurements
                     self._nodata_vals = {name: floatify_nans(model.nodata) for name, model in self.measurements.items()}
-                    self._dtypes = {name: model.dtype for name, model in self.measurements.items()}
+                    self._dtypes = {name: numpy.dtype(model.dtype) for name, model in self.measurements.items()}
                 else:
                     for k in prod_measurements:
                         nodata = self._nodata_vals[k]

--- a/datacube_ows/ows_configuration.py
+++ b/datacube_ows/ows_configuration.py
@@ -520,8 +520,8 @@ class OWSNamedLayer(OWSExtensibleConfigEntry, OWSLayer):
         self.data_manual_merge = cfg.get("manual_merge", False)
         if self.solar_correction and not self.data_manual_merge:
             raise ConfigException("Solar correction requires manual_merge.")
-        if self.data_manual_merge and not self.solar_correction:
-            _LOG.warning("Manual merge is only recommended where solar correction is required.")
+        if self.data_manual_merge and not self.solar_correction and not self.multi_product:
+            _LOG.warning("Manual merge is only recommended where solar correction is required and for multi-product layers.")
 
         if cfg.get("fuse_func"):
             self.fuse_func = FunctionWrapper(self, cfg["fuse_func"])
@@ -582,11 +582,14 @@ class OWSNamedLayer(OWSExtensibleConfigEntry, OWSLayer):
 
     # pylint: disable=attribute-defined-outside-init
     def parse_wcs(self, cfg):
-        if not self.global_cfg.wcs:
+        if cfg == False:
             self.wcs = False
-            return
+        elif not self.global_cfg.wcs:
+            self.wcs = False
         else:
             self.wcs = not cfg.get("disable", False)
+        if not self.wcs:
+            return
 
         if "native_resolution" in cfg:
             if not self.cfg_native_resolution:

--- a/datacube_ows/ows_configuration.py
+++ b/datacube_ows/ows_configuration.py
@@ -130,7 +130,6 @@ class BandIndex(OWSMetadataConfig):
                     self._nodata_vals = {name: floatify_nans(model.nodata) for name, model in self.measurements.items()}
                     self._dtypes = {name: model.dtype for name, model in self.measurements.items()}
                 else:
-                    prod_measurements = prod_measurements
                     for k in prod_measurements:
                         nodata = self._nodata_vals[k]
                         if ((numpy.isnan(nodata) and not numpy.isnan(floatify_nans(prod_measurements[k].nodata)))

--- a/datacube_ows/styles/base.py
+++ b/datacube_ows/styles/base.py
@@ -264,7 +264,7 @@ class StyleDefBase(OWSExtensibleConfigEntry, OWSMetadataConfig):
 
     def odc_needed_bands(self) -> Iterable[datacube.model.Measurement]:
         # pyre-ignore[16]
-        return [self.product.band_idx.native_bands.loc[b] for b in self.needed_bands]
+        return [self.product.band_idx.measurements[b] for b in self.needed_bands]
 
     def local_band(self, band: str) -> str:
         """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -54,19 +54,8 @@ def minimal_dc():
         if 'lookupfail' in s:
             return None
         mprod  = MagicMock()
-        flag_def = {
-            "moo": {"bits": 0},
-            "floop": {"bits": 1},
-            "blat": {"bits": 2},
-            "pow": {"bits": 3},
-            "zap": {"bits": 4},
-            "dang": {"bits": 5},
-        }
-        mprod.lookup_measurements.return_value = {
-            "band4": {
-                "flags_definition": flag_def
-            }
-        }
+        mprod.name = s
+
         mprod.definition = {"storage": {}}
         if 'nonativecrs' in s:
             pass
@@ -88,6 +77,33 @@ def minimal_dc():
                 "latitude": 0.001,
                 "longitude": 0.001,
             }
+
+        def lookup_measurements(ls):
+            from datacube.model import Measurement
+            if isinstance(ls, str):
+                ls = [ls]
+            out = {}
+            for s in ls:
+                if s == "bandx":
+                    raise KeyError("bandx")
+                m = {}
+                m["name"] = s
+                m["nodata"] = "nan"
+                m["dtype"] = "float32"
+                m["units"] = 1
+                if s == "band4":
+                    m["flags_definition"] = {
+                        "moo": {"bits": 0},
+                        "floop": {"bits": 1},
+                        "blat": {"bits": 2},
+                        "pow": {"bits": 3},
+                        "zap": {"bits": 4},
+                        "dang": {"bits": 5},
+                    }
+                out[s] = Measurement(s, **m)
+            return out
+
+        mprod.lookup_measurements = lookup_measurements
         return mprod
     dc.index.products.get_by_name = product_by_name
     return dc


### PR DESCRIPTION
There are separate band aliasing implementations in core and OWS and they don't play nicely together.  In particular it is difficult/impossible to create multiproduct layers from heterogeneous products (e.g. landsat and sentinel2).

This is a first attempt to address this.