### PR TITLE
Check for invalid OGC version parameters and make them valid.

### DIFF
--- a/datacube_ows/protocol_versions.py
+++ b/datacube_ows/protocol_versions.py
@@ -56,7 +56,7 @@ class SupportedSvc:
             except ValueError as e:
                 pass
             try:
-                clean.append(int(re.split("[^\d]", part)[0]))
+                clean.append(int(re.split(r"[^\d]", part)[0]))
             except ValueError as e:
                 pass
             break

--- a/datacube_ows/protocol_versions.py
+++ b/datacube_ows/protocol_versions.py
@@ -3,7 +3,11 @@
 #
 # Copyright (c) 2017-2021 OWS Contributors
 # SPDX-License-Identifier: Apache-2.0
-from datacube_ows.ogc_exceptions import (WCS1Exception, WCS2Exception,
+
+import re
+from typing import Callable, Iterable, List, Mapping, Optional, Sequence, Tuple
+
+from datacube_ows.ogc_exceptions import (OGCException, WCS1Exception, WCS2Exception,
                                          WMSException, WMTSException)
 from datacube_ows.ows_configuration import get_config
 from datacube_ows.wcs1 import handle_wcs1
@@ -11,9 +15,12 @@ from datacube_ows.wcs2 import handle_wcs2
 from datacube_ows.wms import handle_wms
 from datacube_ows.wmts import handle_wmts
 
+FlaskResponse = Tuple
+FlaskHandler = Callable[[Mapping[str, str]], FlaskResponse]
 
-class SupportedSvcVersion(object):
-    def __init__(self, service, version, router, exception_class):
+
+class SupportedSvcVersion:
+    def __init__(self, service: str, version: str, router, exception_class: OGCException) -> None:
         self.service = service.lower()
         self.service_upper = service.upper()
         self.version = version
@@ -23,8 +30,8 @@ class SupportedSvcVersion(object):
         self.exception_class = exception_class
 
 
-class SupportedSvc(object):
-    def __init__(self, versions, default_exception_class=None):
+class SupportedSvc:
+    def __init__(self, versions: Sequence[SupportedSvcVersion], default_exception_class: Optional[OGCException] = None):
         self.versions = sorted(versions, key=lambda x: x.version_parts)
         assert len(self.versions) > 0
         self.service = self.versions[0].service
@@ -39,10 +46,26 @@ class SupportedSvc(object):
         else:
             self.default_exception_class = self.versions[0].exception_class
 
-    def negotiated_version(self, request_version):
+    def _clean_version_parts(self, unclean: Iterable[str]) -> Sequence[int]:
+        clean = []
+        for part in unclean:
+            try:
+                clean.append(int(part))
+                continue
+            except ValueError as e:
+                pass
+            try:
+                clean.append(int(re.split("[^\d]", part)[0]))
+            except ValueError as e:
+                pass
+            break
+        return clean
+
+    def negotiated_version(self, request_version: str) -> SupportedSvcVersion:
         if not request_version:
             return self.versions[-1]
-        rv_parts = [int(i) for i in request_version.split(".")]
+        parts: List[str] = list(request_version.split("."))
+        rv_parts: List[int] = self._clean_version_parts(parts)
         while len(rv_parts) < 3:
             rv_parts.append(0)
         for v in reversed(self.versions):
@@ -52,9 +75,9 @@ class SupportedSvc(object):
         #pylint: disable=undefined-loop-variable
         return v
 
-    def activated(self):
+    def activated(self) -> bool:
         cfg = get_config()
-        return getattr(cfg, self.service)
+        return bool(getattr(cfg, self.service))
 
 
 OWS_SUPPORTED = {

--- a/datacube_ows/protocol_versions.py
+++ b/datacube_ows/protocol_versions.py
@@ -7,8 +7,9 @@
 import re
 from typing import Callable, Iterable, List, Mapping, Optional, Sequence, Tuple
 
-from datacube_ows.ogc_exceptions import (OGCException, WCS1Exception, WCS2Exception,
-                                         WMSException, WMTSException)
+from datacube_ows.ogc_exceptions import (OGCException, WCS1Exception,
+                                         WCS2Exception, WMSException,
+                                         WMTSException)
 from datacube_ows.ows_configuration import get_config
 from datacube_ows.wcs1 import handle_wcs1
 from datacube_ows.wcs2 import handle_wcs2

--- a/tests/test_protocol_versions.py
+++ b/tests/test_protocol_versions.py
@@ -23,6 +23,7 @@ def supported_service():
 def test_default_exception(supported_service):
     assert supported_service.default_exception_class == TestException2
 
+
 def test_version_negotiation(supported_service):
     assert supported_service.negotiated_version("1.0").version == "1.2.7"
     assert supported_service.negotiated_version("1.2").version == "1.2.7"
@@ -34,3 +35,11 @@ def test_version_negotiation(supported_service):
     assert supported_service.negotiated_version("1.13.100").version == "1.13.0"
     assert supported_service.negotiated_version("2.0").version == "2.0.0"
     assert supported_service.negotiated_version("2.7.22").version == "2.0.0"
+
+
+def test_version_cleaner(supported_service):
+    assert supported_service._clean_version_parts(["0", "1", "2"]) == [0, 1, 2]
+    assert supported_service._clean_version_parts(["0", "1", "2/spam"]) == [0, 1, 2]
+    assert supported_service._clean_version_parts(["0", "1spam", "2"]) == [0, 1]
+    assert supported_service._clean_version_parts(["0?bacon", "1/eggs", "2/spam"]) == [0]
+    assert supported_service._clean_version_parts(["spam", "spam", "spam"]) == []


### PR DESCRIPTION
Invalid version request parameters in an otherwise OGC-like request previously resulted in unhandled 500 errors.

A fairly brute force approach that tends towards using the lowest available version.