### PR TITLE
Block rasterio 1.3.0 which has broken warp implementation.

### DIFF
--- a/integration_tests/cfg/ows_test_cfg.py
+++ b/integration_tests/cfg/ows_test_cfg.py
@@ -734,7 +734,8 @@ ows_cfg = {
                             "product": "s2_l2a",
                             "ignore_time": False,
                             "ignore_info_flags": [],
-                            "manual_merge": True,
+                            # This band comes from main product, so cannot set flags manual_merge independently
+                            # "manual_merge": True,
                         },
                     ],
                     "native_crs": "EPSG:3857",

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ install_requirements = [
     'psycopg2',
     'python_dateutil',
     'pytz',
-    'rasterio>=1.0.9',
+    'rasterio>=1.0.9,!=1.3.0',
     'regex',
     'timezonefinderL',
     'python_slugify',


### PR DESCRIPTION
Rasterio-1.3.0 is buggy.  See #851.  1.2.x is fine and the main branch is fine at time of writing, so 1.3.1 should be fine too.

Also commented out a redundant config entry in the integration test config file.