### PR TITLE
refine sentry ignore

### DIFF
--- a/.env_ows_root
+++ b/.env_ows_root
@@ -21,4 +21,4 @@ FLASK_DEBUG=
 prometheus_multiproc_dir=/tmp
 PYTHONPATH=/env/config
 DATACUBE_OWS_CFG=ows_refactored.ows_root_cfg.ows_cfg
-SENTRY_DSN=https://key@sentry.local/2
+SENTRY_DSN=

--- a/.env_ows_root
+++ b/.env_ows_root
@@ -21,4 +21,4 @@ FLASK_DEBUG=
 prometheus_multiproc_dir=/tmp
 PYTHONPATH=/env/config
 DATACUBE_OWS_CFG=ows_refactored.ows_root_cfg.ows_cfg
-SENTRY_DSN=https://key@sentry.local/projid
+SENTRY_DSN=https://key@sentry.local/2

--- a/.env_ows_root
+++ b/.env_ows_root
@@ -21,3 +21,4 @@ FLASK_DEBUG=
 prometheus_multiproc_dir=/tmp
 PYTHONPATH=/env/config
 DATACUBE_OWS_CFG=ows_refactored.ows_root_cfg.ows_cfg
+SENTRY_DSN=https://key@sentry.local/projid

--- a/.env_simple
+++ b/.env_simple
@@ -21,4 +21,4 @@ FLASK_DEBUG=
 prometheus_multiproc_dir=/tmp
 PYTHONPATH=/env
 DATACUBE_OWS_CFG=config.ows_test_cfg.ows_cfg
-SENTRY_DSN=https://key@sentry.local/projid
+SENTRY_DSN=https://key@sentry.local/2

--- a/.env_simple
+++ b/.env_simple
@@ -21,4 +21,4 @@ FLASK_DEBUG=
 prometheus_multiproc_dir=/tmp
 PYTHONPATH=/env
 DATACUBE_OWS_CFG=config.ows_test_cfg.ows_cfg
-SENTRY_DSN=https://key@sentry.local/2
+SENTRY_DSN=

--- a/.env_simple
+++ b/.env_simple
@@ -21,3 +21,4 @@ FLASK_DEBUG=
 prometheus_multiproc_dir=/tmp
 PYTHONPATH=/env
 DATACUBE_OWS_CFG=config.ows_test_cfg.ows_cfg
+SENTRY_DSN=https://key@sentry.local/projid

--- a/datacube_ows/startup_utils.py
+++ b/datacube_ows/startup_utils.py
@@ -61,7 +61,7 @@ def initialise_debugging(log=None):
 def before_send(event, hint):
     if 'exc_info' in hint:
         exc_type, exc_value, tb = hint['exc_info']
-        if isinstance(exc_value, AttributeError) and "'LGEOS380' has no attribute 'GEOSGeom_destroy'" in str(exc_value):
+        if isinstance(exc_value, AttributeError) and "'LGEOS380'" in str(exc_value) and "'GEOSGeom_destroy'" in str(exc_value):
             return None
     return event
 

--- a/datacube_ows/startup_utils.py
+++ b/datacube_ows/startup_utils.py
@@ -61,7 +61,7 @@ def initialise_debugging(log=None):
 def before_send(event, hint):
     if 'exc_info' in hint:
         exc_type, exc_value, tb = hint['exc_info']
-        if isinstance(exc_value, AttributeError) and "'LGEOS380'" in str(exc_value) and "'GEOSGeom_destroy'" in str(exc_value):
+        if isinstance(exc_value, AttributeError) and "object has no attribute 'GEOSGeom_destroy'" in str(exc_value):
             return None
     return event
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -37,6 +37,7 @@ services:
       FLASK_APP: /code/datacube_ows/ogc.py
       FLASK_ENV: ${FLASK_ENV}
       PYDEV_DEBUG: "${PYDEV_DEBUG}"
+      SENTRY_DSN: "${SENTRY_DSN}"
     volumes:
       - ${OWS_CFG_FOLDER}:${OWS_CFG_CONTAINER_FOLDER}
       - ./docker/ows/wait-for-db:/usr/local/bin/wait-for-db

--- a/tests/test_startup.py
+++ b/tests/test_startup.py
@@ -161,6 +161,7 @@ def test_init_babel_off(babel_cfg, flask_app):
 
 def test_sentry_before_send():
     from datacube_ows.startup_utils import before_send
+
     class LGEOS380():
         def __init__(self, a=5):
             self.a = a

--- a/tests/test_startup.py
+++ b/tests/test_startup.py
@@ -161,12 +161,12 @@ def test_init_babel_off(babel_cfg, flask_app):
 
 def test_sentry_before_send():
     from datacube_ows.startup_utils import before_send
-
-    class LGEOS380:
-        x = 5
+    class LGEOS380():
+        def __init__(self, a=5):
+            self.a = a
 
     try:
-        string = LGEOS380.GEOSGeom_destroy()
+        string = LGEOS380().GEOSGeom_destroy()
     except Exception:
         hint = {'exc_info': sys.exc_info()}
         assert 'exc_info' in hint


### PR DESCRIPTION
Fixes: https://github.com/opendatacube/datacube-ows/issues/869

captured error message: "'LGEOS380' object has no attribute 'GEOSGeom_destroy'"

- add SENTRY_DSN to `.env`

- fix the test case to reflect the correct reported error
```
where 'event' = <function before_send at 0x7f16f99064d0>('event', {'exc_info': (<class 'AttributeError'>, AttributeError("type object 'LGEOS380' has no attribute 'GEOSGeom_destroy'"), <traceback object at 0x7f16ec3cff40>)})
```

- simplify the condition to allow all the `GEOSGEOM_destroy`
![image](https://user-images.githubusercontent.com/24644475/196094809-07f3d324-c3e0-4744-9e97-f35b6e231b5b.png)

https://github.com/shapely/shapely/blob/f02c4c72d29862ade0708ce777d0316fbba44fef/shapely/geos.py#L633
https://github.com/shapely/shapely/blob/f02c4c72d29862ade0708ce777d0316fbba44fef/shapely/geos.py#L766
https://github.com/shapely/shapely/blob/f02c4c72d29862ade0708ce777d0316fbba44fef/shapely/geos.py#L778
https://github.com/shapely/shapely/blob/f02c4c72d29862ade0708ce777d0316fbba44fef/shapely/geos.py#L790
https://github.com/shapely/shapely/blob/f02c4c72d29862ade0708ce777d0316fbba44fef/shapely/geos.py#L801