### PR TITLE
Attempt to fix notebook rendering - Issue #861

### DIFF
--- a/datacube_ows/styles/api/base.py
+++ b/datacube_ows/styles/api/base.py
@@ -3,11 +3,12 @@
 #
 # Copyright (c) 2017-2021 OWS Contributors
 # SPDX-License-Identifier: Apache-2.0
-import matplotlib
 import xarray
 
 from datacube_ows.startup_utils import initialise_ignorable_warnings
 from datacube_ows.styles.base import StandaloneProductProxy, StyleDefBase
+from datacube_ows.styles.ramp import ColorRamp
+
 
 initialise_ignorable_warnings()
 
@@ -147,8 +148,6 @@ def plot_image(xr_image, x="x", y="y", size=10, aspect=None):
     rgb = xr_image.to_array(dim="color")
     rgb = rgb.transpose(*(rgb.dims[1:] + rgb.dims[:1]))
     rgb = rgb / 255
-    # Use notebook backend
-    matplotlib.use("nbAgg")
     rgb.plot.imshow(x=x, y=y, size=size, aspect=aspect)
 
 

--- a/datacube_ows/styles/api/base.py
+++ b/datacube_ows/styles/api/base.py
@@ -8,7 +8,6 @@ import xarray
 from datacube_ows.startup_utils import initialise_ignorable_warnings
 from datacube_ows.styles.base import StandaloneProductProxy, StyleDefBase
 
-
 initialise_ignorable_warnings()
 
 

--- a/datacube_ows/styles/api/base.py
+++ b/datacube_ows/styles/api/base.py
@@ -3,6 +3,7 @@
 #
 # Copyright (c) 2017-2021 OWS Contributors
 # SPDX-License-Identifier: Apache-2.0
+import matplotlib
 import xarray
 
 from datacube_ows.startup_utils import initialise_ignorable_warnings

--- a/datacube_ows/styles/api/base.py
+++ b/datacube_ows/styles/api/base.py
@@ -146,6 +146,8 @@ def plot_image(xr_image, x="x", y="y", size=10, aspect=None):
     rgb = xr_image.to_array(dim="color")
     rgb = rgb.transpose(*(rgb.dims[1:] + rgb.dims[:1]))
     rgb = rgb / 255
+    # Use notebook backend
+    matplotlib.use("nbAgg")
     rgb.plot.imshow(x=x, y=y, size=size, aspect=aspect)
 
 

--- a/datacube_ows/styles/api/base.py
+++ b/datacube_ows/styles/api/base.py
@@ -7,7 +7,6 @@ import xarray
 
 from datacube_ows.startup_utils import initialise_ignorable_warnings
 from datacube_ows.styles.base import StandaloneProductProxy, StyleDefBase
-from datacube_ows.styles.ramp import ColorRamp
 
 
 initialise_ignorable_warnings()

--- a/datacube_ows/styles/ramp.py
+++ b/datacube_ows/styles/ramp.py
@@ -30,7 +30,6 @@ from datacube_ows.styles.base import StyleDefBase
 from datacube_ows.styles.expression import Expression
 
 _LOG = logging.getLogger(__name__)
-matplotlib.use('Agg')
 
 RAMP_SPEC = List[CFG_DICT]
 


### PR DESCRIPTION
Attempt to fix legends-not-rendering in notebooks issue #861.

Setting `nbAgg` programmatically caused too many issues with testing, but I've removed the `use("Agg")` call from the top of ramp.py, so hopefully that will address the issue also.