### PR TITLE
Add new S2C3 metadata type to MV definitions.

### DIFF
--- a/datacube_ows/sql/extent_views/create/010_create_new_time_view.sql
+++ b/datacube_ows/sql/extent_views/create/010_create_new_time_view.sql
@@ -42,5 +42,5 @@ select
     '[]'
    ) as temporal_extent
 from agdc.dataset where
-    metadata_type_ref in (select id from metadata_lookup where name in ('eo3_landsat_ard','eo3'))
+    metadata_type_ref in (select id from metadata_lookup where name in ('eo3_landsat_ard','eo3', 'eo3_sentinel_ard'))
     and archived is null

--- a/datacube_ows/sql/extent_views/create/011_create_new_space_view_raw.sql
+++ b/datacube_ows/sql/extent_views/create/011_create_new_space_view_raw.sql
@@ -96,5 +96,5 @@ select id,
         4326
       ) as spatial_extent
  from agdc.dataset where
-        metadata_type_ref in (select id from metadata_lookup where name in ('eo3_landsat_ard'))
+        metadata_type_ref in (select id from metadata_lookup where name in ('eo3_landsat_ard', 'eo3_sentinal_ard'))
         and archived is null

--- a/datacube_ows/sql/extent_views/create/011_create_new_space_view_raw.sql
+++ b/datacube_ows/sql/extent_views/create/011_create_new_space_view_raw.sql
@@ -96,5 +96,5 @@ select id,
         4326
       ) as spatial_extent
  from agdc.dataset where
-        metadata_type_ref in (select id from metadata_lookup where name in ('eo3_landsat_ard', 'eo3_sentinal_ard'))
+        metadata_type_ref in (select id from metadata_lookup where name in ('eo3_landsat_ard', 'eo3_sentinel_ard'))
         and archived is null


### PR DESCRIPTION
New DEA Sentinel2 Collection3 products use an extended EO3 metadata type, which needs to be added to the MV definitions.