### PR TITLE
Ignore WCS style parameter.

### DIFF
--- a/datacube_ows/wcs2_utils.py
+++ b/datacube_ows/wcs2_utils.py
@@ -215,10 +215,12 @@ def get_coverage_data(request, styles, qprof):
                     start = band_labels.index(range_subset.start)
                     end = band_labels.index(range_subset.end)
                     bands.extend(band_labels[start:(end + 1) if end > start else (end - 1)])
-        elif styles:
-            bands = get_bands_from_styles(styles, layer, version=2)
-            if not bands:
-                bands = band_labels
+        # Uncomment to restore original styles parameter hack.
+        #
+        # elif styles:
+        #     bands = get_bands_from_styles(styles, layer, version=2)
+        #     if not bands:
+        #         bands = band_labels
         else:
             bands = band_labels
 

--- a/datacube_ows/wcs2_utils.py
+++ b/datacube_ows/wcs2_utils.py
@@ -20,7 +20,7 @@ from datacube_ows.ogc_exceptions import WCS2Exception
 from datacube_ows.ows_configuration import get_config
 from datacube_ows.resource_limits import ResourceLimited
 from datacube_ows.wcs_scaler import WCSScaler, WCSScalerUnknownDimension
-from datacube_ows.wcs_utils import get_bands_from_styles
+# from datacube_ows.wcs_utils import get_bands_from_styles
 
 _LOG = logging.getLogger(__name__)
 

--- a/integration_tests/test_wcs_server.py
+++ b/integration_tests/test_wcs_server.py
@@ -1627,21 +1627,22 @@ def test_wcs2_getcov_styles(ows_server):
         },
     )
     assert r.status_code == 200
-    r = requests.get(
-        ows_server.url + "/wcs",
-        params={
-            "request": "GetCoverage",
-            "coverageid": layer.name,
-            "version": "2.1.0",
-            "service": "WCS",
-            "format": "image/geotiff",
-            "subsettingcrs": "EPSG:4326",
-            "scalesize": "x(400),y(400)",
-            "styles": "simple_rgb,pure_red",
-            "subset": subsets,
-        },
-    )
-    assert r.status_code == 400
+# WCS2 style parameter disabled.
+#    r = requests.get(
+#       ows_server.url + "/wcs",
+#        params={
+#            "request": "GetCoverage",
+#            "coverageid": layer.name,
+#            "version": "2.1.0",
+#            "service": "WCS",
+#            "format": "image/geotiff",
+#            "subsettingcrs": "EPSG:4326",
+#            "scalesize": "x(400),y(400)",
+#            "styles": "simple_rgb,pure_red",
+#            "subset": subsets,
+#        },
+#    )
+#    assert r.status_code == 400
 
 
 def test_wcs2_getcov_bands(ows_server):


### PR DESCRIPTION
Making WCS2 ignore style parameter again, as @robbibt prefers it that way.

<!-- readthedocs-preview datacube-ows start -->
----
:books: Documentation preview :books:: https://datacube-ows--915.org.readthedocs.build/en/915/

<!-- readthedocs-preview datacube-ows end -->