### PR TITLE
Make Numpy 1.24.0+ compatible.

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -340,7 +340,7 @@ def dummy_raw_data():
 
 @pytest.fixture
 def null_mask():
-    return dummy_da(True, "mask", coords, dtype=np.bool)
+    return dummy_da(True, "mask", coords, dtype=bool)
 
 
 @pytest.fixture


### PR DESCRIPTION
np.bool is deprecated - use bool.

<!-- readthedocs-preview datacube-ows start -->
----
:books: Documentation preview :books:: https://datacube-ows--918.org.readthedocs.build/en/918/

<!-- readthedocs-preview datacube-ows end -->