### PR TITLE
Miscellaneous cleanup/code maintenance

### DIFF
--- a/datacube_ows/data.py
+++ b/datacube_ows/data.py
@@ -174,10 +174,7 @@ class DataStacker:
             ]
         elif self.style:
             # we have a style - lets go with that.
-            queries = ProductBandQuery.style_queries(
-                self.style,
-                self.resource_limited
-            )
+            queries = ProductBandQuery.style_queries(self.style)
         elif all_flag_bands:
             queries = ProductBandQuery.full_layer_queries(self._product, self.needed_bands())
         else:
@@ -431,7 +428,19 @@ def get_map(args):
                 stacker.resource_limited = True
                 qprof["resource_limited"] = str(e)
             if qprof.active:
-                qprof["datasets"] = {str(q): ids for q, ids in stacker.datasets(dc.index, mode=MVSelectOpts.IDS).items()}
+                q_ds_dict = stacker.datasets(dc.index, mode=MVSelectOpts.DATASETS)
+                qprof["datasets"] = []
+                for q, dss in q_ds_dict.items():
+                    query_res = {}
+                    query_res["query"] = str(q)
+                    query_res["datasets"] = [
+                        [
+                            f"{ds.id} ({ds.type.name})"
+                            for ds in tdss
+                        ]
+                        for tdss in dss.values
+                    ]
+                    qprof["datasets"].append(query_res)
             if stacker.resource_limited and not params.product.low_res_product_names:
                 qprof.start_event("extent-in-query")
                 extent = stacker.datasets(dc.index, mode=MVSelectOpts.EXTENT)

--- a/datacube_ows/query_profiler.py
+++ b/datacube_ows/query_profiler.py
@@ -21,6 +21,9 @@ class QueryProfiler:
     def __setitem__(self, name, val):
         self._stats[name] = val
 
+    def __getitem__(self, name):
+        return self._stats[name]
+
     def end_event(self, name):
         if self.active:
             if name in self._events:

--- a/datacube_ows/startup_utils.py
+++ b/datacube_ows/startup_utils.py
@@ -232,7 +232,7 @@ def initialise_babel(cfg, app):
                       default_domain=cfg.message_domain,
                       configure_jinja=False
                       )
-        babel.locale_selector(generate_locale_selector(cfg.locales))
+        babel.localeselector(generate_locale_selector(cfg.locales))
         return babel
     else:
         return None

--- a/datacube_ows/startup_utils.py
+++ b/datacube_ows/startup_utils.py
@@ -230,9 +230,9 @@ def initialise_babel(cfg, app):
         babel = Babel(app,
                       default_locale=cfg.locales[0],
                       default_domain=cfg.message_domain,
-                      configure_jinja=False
+                      configure_jinja=False,
+                      locale_selector=generate_locale_selector(cfg.locales)
                       )
-        babel.localeselector(generate_locale_selector(cfg.locales))
         return babel
     else:
         return None

--- a/datacube_ows/startup_utils.py
+++ b/datacube_ows/startup_utils.py
@@ -230,9 +230,9 @@ def initialise_babel(cfg, app):
         babel = Babel(app,
                       default_locale=cfg.locales[0],
                       default_domain=cfg.message_domain,
-                      configure_jinja=False,
-                      locale_selector=generate_locale_selector(cfg.locales)
+                      configure_jinja=False
                       )
+        babel.locale_selector(generate_locale_selector(cfg.locales))
         return babel
     else:
         return None

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ install_requirements = [
     'scipy',
     'Pillow',
     'Babel',
-    'Flask-Babel>=3.0.0',
+    'Flask-Babel<3.0.0',
     'psycopg2',
     'python_dateutil',
     'pytz',

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ install_requirements = [
     'scipy',
     'Pillow',
     'Babel',
-    'Flask-Babel',
+    'Flask-Babel>=3.0.0',
     'psycopg2',
     'python_dateutil',
     'pytz',

--- a/tests/test_startup.py
+++ b/tests/test_startup.py
@@ -147,9 +147,10 @@ def flask_app():
 
 def test_init_babel_on(babel_cfg, flask_app):
     from datacube_ows.startup_utils import initialise_babel
-    bab = initialise_babel(babel_cfg, flask_app)
-    assert bab is not None
-    assert bab.default_locale.language == "en"
+    with flask_app.app_context():
+        bab = initialise_babel(babel_cfg, flask_app)
+        assert bab is not None
+        assert bab.default_locale.language == "en"
 
 
 def test_init_babel_off(babel_cfg, flask_app):


### PR DESCRIPTION
1. Query Profile objects can now be read like a dictionary.
2. Access SQLAlchemy connection object as a context manager in mv_index.py to ensure proper resource cleanup.
3. Improve ows_stats output for multi-product layers.

Initially I also tried some changes to use flask-babel-3.0.0 but encountered [Flask-Babel Issue #213](https://github.com/python-babel/flask-babel/issues/213)) so I have pinned to `<3.0`

<!-- readthedocs-preview datacube-ows start -->
----
:books: Documentation preview :books:: https://datacube-ows--922.org.readthedocs.build/en/922/

<!-- readthedocs-preview datacube-ows end -->