### PR TITLE
Bump to datacube-1.8.10

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@
 from setuptools import find_packages, setup
 
 install_requirements = [
-    'datacube[performance,s3]>=1.8.7',
+    'datacube[performance,s3]>=1.8.10',
     'flask',
     'flask_log_request_id',
     'requests',


### PR DESCRIPTION
Use latest datacube version to remove sqlalchemy-2.0 from build images.

<!-- readthedocs-preview datacube-ows start -->
----
:books: Documentation preview :books:: https://datacube-ows--923.org.readthedocs.build/en/923/

<!-- readthedocs-preview datacube-ows end -->