### PR TITLE
Remove whitespace from WMS GetCaps date lists.

### DIFF
--- a/datacube_ows/templates/wms_capabilities.xml
+++ b/datacube_ows/templates/wms_capabilities.xml
@@ -90,7 +90,7 @@
         <Dimension name="time" units="ISO8601" default="{{ lyr.default_time.isoformat() }}">{{ lyr.time_axis_representation() }}</Dimension>
         {% elif lyr_ranges.times|length > 1 %}
         <Dimension name="time" units="ISO8601" default="{{ lyr.default_time.isoformat() }}">
-            {% for t in lyr_ranges.times %}{{ t.isoformat() }}{% if not loop.last %}, {% endif %}{% endfor %}
+            {% for t in lyr_ranges.times %}{{ t.isoformat() }}{% if not loop.last %},{% endif %}{% endfor %}
         </Dimension>
         {% endif %}
 


### PR DESCRIPTION
The previously merged PR (#933) added white space to time value lists in WMS GetCaps responses.

This was intended to make GetCaps documents including layers with large numbers of time slices more easily navigable and perusable by human readers.  While it succeeded on this count, padding lists like this is not discussed in the WMS standard and client applications are well within their rights to fail when confronted with them.

This PR reverts this change and restores standards-compliance in GetCaps documents.

<!-- readthedocs-preview datacube-ows start -->
----
:books: Documentation preview :books:: https://datacube-ows--936.org.readthedocs.build/en/936/

<!-- readthedocs-preview datacube-ows end -->