### PR TITLE
pin docutils version

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,3 @@
 click
 sphinx_click
+docutils=0.16

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,3 @@
 click
 sphinx_click
-docutils=0.16
+docutils==0.16

--- a/wordlist.txt
+++ b/wordlist.txt
@@ -197,6 +197,7 @@ gunicorn
 haesler
 handyness
 heigth
+heliosynchronous
 heterogenous
 hoc
 hostname


### PR DESCRIPTION
fix history page not rendering list correctly, see https://datacube-ows.readthedocs.io/en/latest/history.html

<!-- readthedocs-preview datacube-ows start -->
----
:books: Documentation preview :books:: https://datacube-ows--938.org.readthedocs.build/en/938/

<!-- readthedocs-preview datacube-ows end -->