### PR TITLE
update dependency timezonefinder

### DIFF
--- a/datacube_ows/ogc_utils.py
+++ b/datacube_ows/ogc_utils.py
@@ -19,7 +19,7 @@ from dateutil.parser import parse
 from flask import request
 from PIL import Image
 from pytz import timezone, utc
-from timezonefinderL import TimezoneFinder
+from timezonefinder import TimezoneFinder
 
 _LOG: logging.Logger = logging.getLogger(__name__)
 tf = TimezoneFinder(in_memory=True)

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ install_requirements = [
     'pytz',
     'rasterio>=1.3.2',
     'regex',
-    'timezonefinderL',
+    'timezonefinder',
     'python_slugify',
     'geoalchemy2',
     'lark',


### PR DESCRIPTION
Since `timezonefinderL` is deprecated and the same functionality was migrated to https://github.com/jannikmi/timezonefinder

related to #947 

<!-- readthedocs-preview datacube-ows start -->
----
:books: Documentation preview :books:: https://datacube-ows--948.org.readthedocs.build/en/948/

<!-- readthedocs-preview datacube-ows end -->