### PR TITLE
Update HISTORY.rst and default version for 1.8.35 release.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,6 +7,15 @@ History
 
 Datacube-ows version 1.8.x indicates that it is designed work with datacube-core versions 1.8.x.
 
+1.8.35 (2023-09-01)
+-------------------
+
+Maintenance release.
+
+* Changes to depenency version pins (#983, #942, #948, #949)
+
+Includes contributions from @pindge, @emmaai and @SpacemanPaul.
+
 1.8.34 (2023-03-21)
 -------------------
 

--- a/datacube_ows/__init__.py
+++ b/datacube_ows/__init__.py
@@ -6,4 +6,4 @@
 try:
     from ._version import version as __version__
 except ImportError:
-    __version__ = "1.8.34+?"
+    __version__ = "1.8.35+?"


### PR DESCRIPTION
Was hoping to squeeze in #945 but it requires too much other cleanup work.  Ready for maintenance release.

<!-- readthedocs-preview datacube-ows start -->
----
:books: Documentation preview :books:: https://datacube-ows--950.org.readthedocs.build/en/950/

<!-- readthedocs-preview datacube-ows end -->