### PR TITLE
Update Docker image

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,28 @@
+# Read the Docs configuration file for Sphinx projects
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+# Required
+version: 2
+
+
+# Set the OS, Python version and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.10"
+
+# Build documentation in the "docs/" directory with Sphinx
+sphinx:
+  configuration: docs/conf.py
+
+
+# Optionally build your docs in additional formats such as PDF and ePub
+# formats:
+#    - pdf
+#    - epub
+
+# Optional but recommended, declare the Python requirements required
+# to build your documentation
+# See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
+python:
+  install:
+  - requirements: docs/requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.10 as builder
+FROM ubuntu:22.04 as builder
 
 # Setup build env for postgresql-client-14
 USER root

--- a/check-code-all.sh
+++ b/check-code-all.sh
@@ -24,24 +24,24 @@ datacube product add https://raw.githubusercontent.com/GeoscienceAustralia/dea-c
 datacube product add https://raw.githubusercontent.com/GeoscienceAustralia/dea-config/master/products/baseline_satellite_data/geomedian-au/ga_ls8c_nbart_gm_cyear_3.odc-product.yaml
 
 # S2 multiproduct datasets
-datacube dataset add https://dea-public-data.s3.ap-southeast-2.amazonaws.com/baseline/ga_s2bm_ard_3/52/LGM/2017/07/19/20170719T030622/ga_s2bm_ard_3-2-1_52LGM_2017-07-19_final.odc-metadata.yaml --confirm-ignore-lineage
-datacube dataset add https://dea-public-data.s3.ap-southeast-2.amazonaws.com/baseline/ga_s2bm_ard_3/52/LGM/2017/07/29/20170729T081630/ga_s2bm_ard_3-2-1_52LGM_2017-07-29_final.odc-metadata.yaml --confirm-ignore-lineage
-datacube dataset add https://dea-public-data.s3.ap-southeast-2.amazonaws.com/baseline/ga_s2bm_ard_3/52/LGM/2017/08/08/20170818T192649/ga_s2bm_ard_3-2-1_52LGM_2017-08-08_final.odc-metadata.yaml --confirm-ignore-lineage
-datacube dataset add https://dea-public-data.s3.ap-southeast-2.amazonaws.com/baseline/ga_s2am_ard_3/52/LGM/2017/07/14/20170714T082022/ga_s2am_ard_3-2-1_52LGM_2017-07-14_final.odc-metadata.yaml --confirm-ignore-lineage
-datacube dataset add https://dea-public-data.s3.ap-southeast-2.amazonaws.com/baseline/ga_s2am_ard_3/52/LGM/2017/07/24/20170724T030641/ga_s2am_ard_3-2-1_52LGM_2017-07-24_final.odc-metadata.yaml --confirm-ignore-lineage
-datacube dataset add https://dea-public-data.s3.ap-southeast-2.amazonaws.com/baseline/ga_s2am_ard_3/52/LGM/2017/08/03/20170921T103758/ga_s2am_ard_3-2-1_52LGM_2017-08-03_final.odc-metadata.yaml --confirm-ignore-lineage
+datacube dataset add https://dea-public-data.s3.ap-southeast-2.amazonaws.com/baseline/ga_s2bm_ard_3/52/LGM/2017/07/19/20170719T030622/ga_s2bm_ard_3-2-1_52LGM_2017-07-19_final.odc-metadata.yaml --ignore-lineage
+datacube dataset add https://dea-public-data.s3.ap-southeast-2.amazonaws.com/baseline/ga_s2bm_ard_3/52/LGM/2017/07/29/20170729T081630/ga_s2bm_ard_3-2-1_52LGM_2017-07-29_final.odc-metadata.yaml --ignore-lineage
+datacube dataset add https://dea-public-data.s3.ap-southeast-2.amazonaws.com/baseline/ga_s2bm_ard_3/52/LGM/2017/08/08/20170818T192649/ga_s2bm_ard_3-2-1_52LGM_2017-08-08_final.odc-metadata.yaml --ignore-lineage
+datacube dataset add https://dea-public-data.s3.ap-southeast-2.amazonaws.com/baseline/ga_s2am_ard_3/52/LGM/2017/07/14/20170714T082022/ga_s2am_ard_3-2-1_52LGM_2017-07-14_final.odc-metadata.yaml --ignore-lineage
+datacube dataset add https://dea-public-data.s3.ap-southeast-2.amazonaws.com/baseline/ga_s2am_ard_3/52/LGM/2017/07/24/20170724T030641/ga_s2am_ard_3-2-1_52LGM_2017-07-24_final.odc-metadata.yaml --ignore-lineage
+datacube dataset add https://dea-public-data.s3.ap-southeast-2.amazonaws.com/baseline/ga_s2am_ard_3/52/LGM/2017/08/03/20170921T103758/ga_s2am_ard_3-2-1_52LGM_2017-08-03_final.odc-metadata.yaml --ignore-lineage
 
 # flag masking datasets
 datacube dataset add https://data.dea.ga.gov.au/projects/geodata_coast_100k/v2004/x_15/y_-40/COAST_100K_15_-40.yaml
 datacube dataset add https://data.dea.ga.gov.au/projects/geodata_coast_100k/v2004/x_8/y_-21/COAST_100K_8_-21.yaml
 
-datacube dataset add https://data.dea.ga.gov.au/derivative/ga_ls_wo_3/1-6-0/094/077/2018/02/08/ga_ls_wo_3_094077_2018-02-08_final.odc-metadata.yaml --confirm-ignore-lineage
-datacube dataset add https://data.dea.ga.gov.au/derivative/ga_ls_fc_3/2-5-1/094/077/2018/02/08/ga_ls_fc_3_094077_2018-02-08_final.odc-metadata.yaml --confirm-ignore-lineage
+datacube dataset add https://data.dea.ga.gov.au/derivative/ga_ls_wo_3/1-6-0/094/077/2018/02/08/ga_ls_wo_3_094077_2018-02-08_final.odc-metadata.yaml --ignore-lineage
+datacube dataset add https://data.dea.ga.gov.au/derivative/ga_ls_fc_3/2-5-1/094/077/2018/02/08/ga_ls_fc_3_094077_2018-02-08_final.odc-metadata.yaml --ignore-lineage
 
 # Geomedian datasets
-datacube dataset add https://dea-public-data.s3.ap-southeast-2.amazonaws.com/derivative/ga_ls8c_nbart_gm_cyear_3/3-0-0/x17/y37/2019--P1Y/ga_ls8c_nbart_gm_cyear_3_x17y37_2019--P1Y_final.odc-metadata.yaml --confirm-ignore-lineage
-datacube dataset add https://dea-public-data.s3.ap-southeast-2.amazonaws.com/derivative/ga_ls8c_nbart_gm_cyear_3/3-0-0/x17/y37/2020--P1Y/ga_ls8c_nbart_gm_cyear_3_x17y37_2020--P1Y_final.odc-metadata.yaml --confirm-ignore-lineage
-datacube dataset add https://dea-public-data.s3.ap-southeast-2.amazonaws.com/derivative/ga_ls8c_nbart_gm_cyear_3/3-0-0/x17/y37/2021--P1Y/ga_ls8c_nbart_gm_cyear_3_x17y37_2021--P1Y_final.odc-metadata.yaml --confirm-ignore-lineage
+datacube dataset add https://dea-public-data.s3.ap-southeast-2.amazonaws.com/derivative/ga_ls8c_nbart_gm_cyear_3/3-0-0/x17/y37/2019--P1Y/ga_ls8c_nbart_gm_cyear_3_x17y37_2019--P1Y_final.odc-metadata.yaml --ignore-lineage
+datacube dataset add https://dea-public-data.s3.ap-southeast-2.amazonaws.com/derivative/ga_ls8c_nbart_gm_cyear_3/3-0-0/x17/y37/2020--P1Y/ga_ls8c_nbart_gm_cyear_3_x17y37_2020--P1Y_final.odc-metadata.yaml --ignore-lineage
+datacube dataset add https://dea-public-data.s3.ap-southeast-2.amazonaws.com/derivative/ga_ls8c_nbart_gm_cyear_3/3-0-0/x17/y37/2021--P1Y/ga_ls8c_nbart_gm_cyear_3_x17y37_2021--P1Y_final.odc-metadata.yaml --ignore-lineage
 
 # create material view for ranges extents
 datacube-ows-update --schema --role $DB_USERNAME

--- a/datacube_ows/ogc.py
+++ b/datacube_ows/ogc.py
@@ -8,7 +8,6 @@ import traceback
 from time import monotonic
 
 from flask import g, render_template, request
-from flask_log_request_id import current_request_id
 from sqlalchemy import text
 
 from datacube_ows import __version__
@@ -224,13 +223,6 @@ def legend(layer, style, dates=None):
     return img
 
 # Flask middleware
-
-
-@app.after_request
-def append_request_id(response):
-    response.headers.add("X-REQUEST-ID", current_request_id())
-    return response
-
 
 @app.before_request
 def start_timer():

--- a/datacube_ows/startup_utils.py
+++ b/datacube_ows/startup_utils.py
@@ -12,7 +12,6 @@ import warnings
 from botocore.credentials import RefreshableCredentials
 from datacube.utils.aws import configure_s3_access
 from flask import Flask, request
-from flask_log_request_id import RequestID, RequestIDLogFilter
 from rasterio.errors import NotGeoreferencedWarning
 
 from datacube_ows.ows_configuration import get_config
@@ -33,7 +32,6 @@ __all__ = [
 def initialise_logger(name=None):
     handler = logging.StreamHandler()
     handler.setFormatter(logging.Formatter('[%(asctime)s] [%(levelname)s] %(message)s'))
-    handler.addFilter(RequestIDLogFilter())
     _LOG = logging.getLogger(name)
     _LOG.addHandler(handler)
     # If invoked using Gunicorn, link our root logger to the gunicorn logger
@@ -181,7 +179,6 @@ def parse_config_file(log=None):
 
 def initialise_flask(name):
     app = Flask(name.split('.')[0])
-    RequestID(app)
     return app
 
 def pass_through(undecorated):

--- a/docker/database/Dockerfile
+++ b/docker/database/Dockerfile
@@ -1,2 +1,2 @@
-FROM kartoza/postgis:13-3.1
+FROM kartoza/postgis:15
 COPY s2_dump.sql /docker-entrypoint-initdb.d/

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,6 @@ from setuptools import find_packages, setup
 install_requirements = [
     'datacube[performance,s3]>=1.8.12',
     'flask',
-    'flask_log_request_id',
     'requests',
     'affine',
     'click',


### PR DESCRIPTION
1. Docker image builder was based on unsupported Ubuntu 22.10 - switch back to LTS release 22.04
2. Remove dependency on `flask-log-request-id` package.  This package appears to be orphaned (not updated since 2019), no longer supports the most recent versions of Flask, and has never been used by DEA.  This means that the X-REQUEST-ID response header will no longer be set.  If you make use of this header in your OWS deployments, please raise an issue and we will find another way to populate it.
3. Changed test db build to use `--ignore-lineage` instead of `--confirm-ignore-lineage`.

<!-- readthedocs-preview datacube-ows start -->
----
:books: Documentation preview :books:: https://datacube-ows--954.org.readthedocs.build/en/954/

<!-- readthedocs-preview datacube-ows end -->