### PR TITLE
Pydev debug 

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v4.5.0
     hooks:
     -   id: check-yaml
     -   id: end-of-file-fixer
@@ -19,7 +19,7 @@ repos:
 #     hooks:
 #     -   id: bandit
 -   repo: https://github.com/PyCQA/pylint
-    rev: v3.0.0a7
+    rev: v3.0.1
     hooks:
       - id: pylint
         args: ["--disable=C,R,W,E1136"]

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -12,7 +12,7 @@ Datacube-ows version 1.8.x indicates that it is designed work with datacube-core
 
 Maintenance release.
 
-* Changes to depenency version pins (#983, #942, #948, #949)
+* Changes to dependency version pins (#983, #942, #948, #949)
 
 Includes contributions from @pindge, @emmaai and @SpacemanPaul.
 

--- a/datacube_ows/startup_utils.py
+++ b/datacube_ows/startup_utils.py
@@ -50,10 +50,11 @@ def initialise_ignorable_warnings():
 def initialise_debugging(log=None):
     # PYCHARM Debugging
     if os.environ.get("PYDEV_DEBUG"):
-        import pydevd_pycharm
-        pydevd_pycharm.settrace('172.17.0.1', port=12321, stdoutToServer=True, stderrToServer=True)
-        if log:
-            log.info("PyCharm Debugging enabled")
+        if os.environ["PYDEV_DEBUG"].lower() not in ("no", "false", "f", "n"):
+            import pydevd_pycharm
+            pydevd_pycharm.settrace('172.17.0.1', port=12321, stdoutToServer=True, stderrToServer=True)
+            if log:
+                log.info("PyCharm Debugging enabled")
 
 def before_send(event, hint):
     if 'exc_info' in hint:

--- a/docs/environment_variables.rst
+++ b/docs/environment_variables.rst
@@ -103,7 +103,7 @@ Dev Tools
 ---------
 
 PYDEV_DEBUG:
-    If set, activates PyDev remote debugging.
+    If set to anything other than "n", "f", "no" or "false" (case insensitive), activates PyDev remote debugging.
 
 DEFER_CFG_PARSE:
     If set, the configuration file is not read and parsed at startup.  This

--- a/tests/test_startup.py
+++ b/tests/test_startup.py
@@ -82,6 +82,12 @@ def test_initialise_nodebugging(monkeypatch):
     initialise_debugging()
 
 
+def test_initialise_explicit_nodebugging(monkeypatch):
+    monkeypatch.setenv("PYDEV_DEBUG", "no")
+    from datacube_ows.startup_utils import initialise_debugging
+    initialise_debugging()
+
+
 def test_initialise_debugging(monkeypatch):
     monkeypatch.setenv("PYDEV_DEBUG", "YES")
     from datacube_ows.startup_utils import initialise_debugging

--- a/wordlist.txt
+++ b/wordlist.txt
@@ -138,6 +138,7 @@ ee
 ef
 efd
 eg
+emmaai
 english
 entrypoint
 enum


### PR DESCRIPTION
As raised in #953, the `$PYDEV_DEBUG` environment variable's value was not checked  - setting it to anything other than an empty string resulted in debugging being turned on.  As the examples in documentation set it to "yes", this caused confusion with explicitly setting the environment variable to e.g. "no" resulted in debugging being turned on.

This PR checks for the following values: "N", "NO", F" and "FALSE" (evaluated case insensitively) and treats them as deactivating debugging.

(This PR also manually applies the pre-commit updates raised by pre-commit-ci in #951)

<!-- readthedocs-preview datacube-ows start -->
----
:books: Documentation preview :books:: https://datacube-ows--955.org.readthedocs.build/en/955/

<!-- readthedocs-preview datacube-ows end -->