### PR TITLE
Dockerfile: update to GDAL 3.8.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04 as builder
+FROM ghcr.io/osgeo/gdal:ubuntu-small-3.8.0 as builder
 
 # Setup build env for postgresql-client-14
 USER root
@@ -36,7 +36,7 @@ RUN if [ "$PYDEV_DEBUG" = "yes" ]; then \
 
 RUN pip freeze
 
-FROM osgeo/gdal:ubuntu-small-latest
+FROM ghcr.io/osgeo/gdal:ubuntu-small-3.8.0
 
 # all the python pip installed libraries
 COPY --from=builder  /usr/local/lib/python3.10/dist-packages /usr/local/lib/python3.10/dist-packages

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,6 @@ RUN apt-get update -y \
 
 ENV GDAL_DISABLE_READDIR_ON_OPEN="EMPTY_DIR"
 
-# make folders
-RUN mkdir -p /code
 # Copy source code and install it
 WORKDIR /code
 COPY . /code
@@ -62,8 +60,6 @@ COPY --from=builder  /usr/local/bin/flask /usr/local/bin/flask
 COPY --from=builder  /usr/local/bin/gunicorn /usr/local/bin/gunicorn
 # pybabel cli
 COPY --from=builder  /usr/local/bin/pybabel /usr/local/bin/pybabel
-# make folders for testing and keep code in image
-RUN mkdir -p /code
 # Copy source code and install it
 WORKDIR /code
 COPY . /code


### PR DESCRIPTION
Use the same version of the image for the builder
and the main image.
