### PR TITLE
Consolidate recent dependabot PRs, resolve broken GH Checks

### DIFF
--- a/.github/workflows/dockerfile-lint.yml
+++ b/.github/workflows/dockerfile-lint.yml
@@ -28,7 +28,7 @@ jobs:
           fetch-depth: 0
 
       - name: lint Dockerfile
-        uses: hadolint/hadolint-action@v1.5.0
+        uses: hadolint/hadolint-action@v3.1.0
         with:
           dockerfile: Dockerfile
           ignore: DL3008 DL3002 DL3013 DL3059 SC2102

--- a/.github/workflows/dockerfile-lint.yml
+++ b/.github/workflows/dockerfile-lint.yml
@@ -31,4 +31,4 @@ jobs:
         uses: hadolint/hadolint-action@v3.1.0
         with:
           dockerfile: Dockerfile
-          ignore: DL3008 DL3002 DL3013 DL3059 SC2102
+          ignore: DL3008,DL3002,DL3013,DL3059,SC2102

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -48,12 +48,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.9
       - run: python -m pip install flake8
       - name: flake8 cleanup imported but unused
-        uses: liskin/gh-problem-matcher-wrap@v1
+        uses: liskin/gh-problem-matcher-wrap@v2
         with:
           linters: flake8
           run: |
@@ -65,7 +65,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.9
       - run: python -m pip install isort

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Fetch all history for all tags and branches
         run: git fetch --prune --unshallow
       - name: Set up Python 3.7
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: 3.7
       - name: Install pypa/build

--- a/.github/workflows/pyspy-profiling.yaml
+++ b/.github/workflows/pyspy-profiling.yaml
@@ -72,7 +72,7 @@ jobs:
         docker-compose -f docker-compose.yaml -f docker-compose.db.yaml -f docker-compose.pyspy.yaml down
 
     - name: Upload profile to artifact (stage 1 - Upload profiling svg to artifacts)
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: profile.json
         path: ./artifacts/profile.json

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Build unstable + latest Docker image tag
         if: github.event_name != 'release'
-        uses: whoan/docker-build-with-cache-action@v4
+        uses: whoan/docker-build-with-cache-action@v8
         with:
           image_name: ${{ env.IMAGE_NAME }}
           image_tag: ${{ env.UNSTABLE_TAG }},latest


### PR DESCRIPTION
Some github checks are broken.  This PR consolidates recent dependabot updates into a single PR so I can figure out why checks are failing.  

Later commits will hopefully fix the broken checks as well.

<!-- readthedocs-preview datacube-ows start -->
----
:books: Documentation preview :books:: https://datacube-ows--966.org.readthedocs.build/en/966/

<!-- readthedocs-preview datacube-ows end -->