### PR TITLE
CI: set permissions for docpreview

### DIFF
--- a/.github/workflows/docpreview.yaml
+++ b/.github/workflows/docpreview.yaml
@@ -12,6 +12,9 @@ on:
 
   workflow_dispatch:
 
+permissions:
+  pull-requests: write
+
 jobs:
 
   documentation-preview:


### PR DESCRIPTION
This is part of the documentation for the action:

https://github.com/readthedocs/actions/tree/v1/preview