### PR TITLE
dependabot: update Dockerfile

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,8 @@ updates:
   schedule:
     interval: "daily"
   target-branch: "master"
+- package-ecosystem: docker
+  directory: "/"
+  schedule:
+    interval: "daily"
+  target-branch: "master"


### PR DESCRIPTION
Dependabot can apparently update versions
in Dockerfile, see trivy for examples:

https://github.com/aquasecurity/trivy/pulls?q=is%3Apr+is%3Aclosed+dependabot+label%3Adocker

<!-- readthedocs-preview datacube-ows start -->
----
:books: Documentation preview :books:: https://datacube-ows--975.org.readthedocs.build/en/975/

<!-- readthedocs-preview datacube-ows end -->