### PR TITLE
Label metrics by endpoint not path

### DIFF
--- a/datacube_ows/startup_utils.py
+++ b/datacube_ows/startup_utils.py
@@ -203,7 +203,7 @@ def initialise_prometheus(app, log=None):
     if os.environ.get("prometheus_multiproc_dir", False):
         from prometheus_flask_exporter.multiprocess import \
             GunicornInternalPrometheusMetrics
-        metrics = GunicornInternalPrometheusMetrics(app)
+        metrics = GunicornInternalPrometheusMetrics(app, group_by="endpoint")
         if log:
             log.info("Prometheus metrics enabled")
         return metrics


### PR DESCRIPTION
Metrics are not logs!

Currently, OWS pods are exporting ~5k metrics each due to a misconfiguration, unreasonably requiring Prometheus to retain multiple separate time-series per HTTP path. High cardinality information (individual HTTP paths) belongs in logs but not metrics.

This change makes OWS consistent with datacube-explorer: 
https://github.com/opendatacube/datacube-explorer/commit/6051dd65dcbedef9bb007b50ed47461062b0b91d

<!-- readthedocs-preview datacube-ows start -->
----
:books: Documentation preview :books:: https://datacube-ows--978.org.readthedocs.build/en/978/

<!-- readthedocs-preview datacube-ows end -->