### PR TITLE
Timezone handling cleanup.

### DIFF
--- a/datacube_ows/data.py
+++ b/datacube_ows/data.py
@@ -859,15 +859,13 @@ def feature_info(args):
             pt_native = None
             for d in all_time_datasets.coords["time"].values:
                 dt_datasets = all_time_datasets.sel(time=d)
-                dt = datetime.utcfromtimestamp(d.astype(int) * 1e-9)
-                if params.product.time_resolution.is_solar():
-                    dt = solar_date(dt, tz)
                 for ds in dt_datasets.values.item():
                     if pt_native is None:
                         pt_native = geo_point.to_crs(ds.crs)
                     elif pt_native.crs != ds.crs:
                         pt_native = geo_point.to_crs(ds.crs)
                     if ds.extent and ds.extent.contains(pt_native):
+                        dt = stacker.group_by.group_by_func(ds)
                         if params.product.time_resolution.is_subday():
                             feature_json["data_available_for_dates"].append(dt.isoformat())
                         else:

--- a/datacube_ows/data.py
+++ b/datacube_ows/data.py
@@ -865,7 +865,7 @@ def feature_info(args):
                     elif pt_native.crs != ds.crs:
                         pt_native = geo_point.to_crs(ds.crs)
                     if ds.extent and ds.extent.contains(pt_native):
-                        dt = stacker.group_by.group_by_func(ds)
+                        dt = stacker.group_by.group_by_func(ds).tolist()
                         if params.product.time_resolution.is_subday():
                             feature_json["data_available_for_dates"].append(dt.isoformat())
                         else:

--- a/datacube_ows/data.py
+++ b/datacube_ows/data.py
@@ -865,6 +865,7 @@ def feature_info(args):
                     elif pt_native.crs != ds.crs:
                         pt_native = geo_point.to_crs(ds.crs)
                     if ds.extent and ds.extent.contains(pt_native):
+                        # tolist() converts a numpy datetime64 to a python datatime
                         dt = stacker.group_by.group_by_func(ds).tolist()
                         if params.product.time_resolution.is_subday():
                             feature_json["data_available_for_dates"].append(dt.isoformat())

--- a/datacube_ows/utils.py
+++ b/datacube_ows/utils.py
@@ -99,7 +99,10 @@ def group_by_solar(pnames: Optional[List[str]] = None) -> "datacube.api.query.Gr
     else:
         sort_key = base_sort_key
     # Wrap solar_day so we consistently get a datetime.
-    solar_day_py = lambda x: datetime.datetime.fromtimestamp(solar_day(x).astype(int) * 1e-9, tz=datetime.timezone.utc)
+    solar_day_py = lambda x: datetime.datetime.fromtimestamp(
+        solar_day(x).astype(int) * 1e-9,
+        tz=datetime.timezone.utc
+    )
     return GroupBy(
         dimension='time',
         group_by_func=solar_day_py,

--- a/datacube_ows/utils.py
+++ b/datacube_ows/utils.py
@@ -8,8 +8,6 @@ import logging
 from functools import wraps
 from time import monotonic
 from typing import Any, Callable, List, Optional, TypeVar
-
-import numpy as np
 import pytz
 
 F = TypeVar('F', bound=Callable[..., Any])

--- a/datacube_ows/utils.py
+++ b/datacube_ows/utils.py
@@ -99,8 +99,7 @@ def group_by_solar(pnames: Optional[List[str]] = None) -> "datacube.api.query.Gr
     else:
         sort_key = base_sort_key
     # Wrap solar_day so we consistently get a datetime.
-    solar_day_py = lambda x: datetime.utcfromtimestamp(solar_day(x).astype(int) * 1e-9)
-    # dt = datetime.utcfromtimestamp(d.astype(int) * 1e-9)
+    solar_day_py = lambda x: datetime.datetime.fromtimestamp(solar_day(x).astype(int) * 1e-9, tz=datetime.timezone.utc)
     return GroupBy(
         dimension='time',
         group_by_func=solar_day_py,

--- a/datacube_ows/utils.py
+++ b/datacube_ows/utils.py
@@ -87,13 +87,6 @@ def group_by_begin_datetime(pnames: Optional[List[str]] = None,
     )
 
 
-def group_by_subday() -> "datacube.api.query.GroupBy":
-    """
-    Returns an ODC GroupBy object, suitable for sub-day level data
-
-    :return:
-    """
-
 def group_by_solar(pnames: Optional[List[str]] = None) -> "datacube.api.query.GroupBy":
     from datacube.api.query import GroupBy, solar_day
     base_sort_key = lambda ds: ds.time.begin
@@ -105,9 +98,12 @@ def group_by_solar(pnames: Optional[List[str]] = None) -> "datacube.api.query.Gr
         sort_key = lambda ds: (index.get(ds.type.name), base_sort_key(ds))
     else:
         sort_key = base_sort_key
+    # Wrap solar_day so we consistently get a datetime.
+    solar_day_py = lambda x: datetime.utcfromtimestamp(solar_day(x).astype(int) * 1e-9)
+    # dt = datetime.utcfromtimestamp(d.astype(int) * 1e-9)
     return GroupBy(
         dimension='time',
-        group_by_func=solar_day,
+        group_by_func=solar_day_py,
         units='seconds since 1970-01-01 00:00:00',
         sort_key=sort_key
     )

--- a/datacube_ows/utils.py
+++ b/datacube_ows/utils.py
@@ -5,11 +5,11 @@
 # SPDX-License-Identifier: Apache-2.0
 import datetime
 import logging
-import numpy as np
 from functools import wraps
 from time import monotonic
 from typing import Any, Callable, List, Optional, TypeVar
 
+import numpy as np
 import pytz
 
 F = TypeVar('F', bound=Callable[..., Any])

--- a/datacube_ows/utils.py
+++ b/datacube_ows/utils.py
@@ -8,6 +8,7 @@ import logging
 from functools import wraps
 from time import monotonic
 from typing import Any, Callable, List, Optional, TypeVar
+
 import pytz
 
 F = TypeVar('F', bound=Callable[..., Any])

--- a/datacube_ows/utils.py
+++ b/datacube_ows/utils.py
@@ -10,6 +10,7 @@ from time import monotonic
 from typing import Any, Callable, List, Optional, TypeVar
 
 import pytz
+from numpy import datetime64 as npdt64
 
 F = TypeVar('F', bound=Callable[..., Any])
 
@@ -65,20 +66,20 @@ def group_by_begin_datetime(pnames: Optional[List[str]] = None,
     else:
         sort_key = base_sort_key
     if truncate_dates:
-        grp_by = lambda ds: datetime.datetime(
+        grp_by = lambda ds: npdt64(datetime.datetime(
             ds.time.begin.year,
             ds.time.begin.month,
             ds.time.begin.day,
-            tzinfo=pytz.utc)
+            tzinfo=pytz.utc))
     else:
-        grp_by = lambda ds: datetime.datetime(
+        grp_by = lambda ds: npdt64(datetime.datetime(
             ds.time.begin.year,
             ds.time.begin.month,
             ds.time.begin.day,
             ds.time.begin.hour,
             ds.time.begin.minute,
             ds.time.begin.second,
-            tzinfo=ds.time.begin.tzinfo)
+            tzinfo=ds.time.begin.tzinfo))
     return GroupBy(
         dimension='time',
         group_by_func=grp_by,
@@ -98,12 +99,9 @@ def group_by_solar(pnames: Optional[List[str]] = None) -> "datacube.api.query.Gr
         sort_key = lambda ds: (index.get(ds.type.name), base_sort_key(ds))
     else:
         sort_key = base_sort_key
-    # Wrap solar_day so we consistently get a datetime.
-    # (Don't know why I have to disable pylint for GHA check - passes fine locally.)
-    solar_day_py = lambda x: solar_day(x).tolist()
     return GroupBy(
         dimension='time',
-        group_by_func=solar_day_py,
+        group_by_func=solar_day,
         units='seconds since 1970-01-01 00:00:00',
         sort_key=sort_key
     )
@@ -122,7 +120,7 @@ def group_by_mosaic(pnames: Optional[List[str]] = None) -> "datacube.api.query.G
         sort_key = lambda ds: (solar_day(ds), base_sort_key(ds))
     return GroupBy(
         dimension='time',
-        group_by_func=lambda n: datetime.datetime(1970, 1, 1, tzinfo=datetime.timezone.utc),
+        group_by_func=lambda n: npdt64(datetime.datetime(1970, 1, 1, tzinfo=datetime.timezone.utc)),
         units='seconds since 1970-01-01 00:00:00',
         sort_key=sort_key
     )

--- a/datacube_ows/utils.py
+++ b/datacube_ows/utils.py
@@ -99,8 +99,9 @@ def group_by_solar(pnames: Optional[List[str]] = None) -> "datacube.api.query.Gr
     else:
         sort_key = base_sort_key
     # Wrap solar_day so we consistently get a datetime.
+    # (Don't know why I have to disable pylint for GHA check - passes fine locally.)
     solar_day_py = lambda x: datetime.datetime.fromtimestamp(
-        solar_day(x).astype(int) * 1e-9,
+        (solar_day(x).astype(int) * 1e-9),  # pylint: disable=too-many-function-args
         tz=datetime.timezone.utc
     )
     return GroupBy(

--- a/datacube_ows/utils.py
+++ b/datacube_ows/utils.py
@@ -5,6 +5,7 @@
 # SPDX-License-Identifier: Apache-2.0
 import datetime
 import logging
+import numpy as np
 from functools import wraps
 from time import monotonic
 from typing import Any, Callable, List, Optional, TypeVar
@@ -100,10 +101,7 @@ def group_by_solar(pnames: Optional[List[str]] = None) -> "datacube.api.query.Gr
         sort_key = base_sort_key
     # Wrap solar_day so we consistently get a datetime.
     # (Don't know why I have to disable pylint for GHA check - passes fine locally.)
-    solar_day_py = lambda x: datetime.datetime.fromtimestamp(
-        (solar_day(x).astype(int) * 1e-9),  # pylint: disable=too-many-function-args
-        tz=datetime.timezone.utc
-    )
+    solar_day_py = lambda x: solar_day(x).tolist()
     return GroupBy(
         dimension='time',
         group_by_func=solar_day_py,


### PR DESCRIPTION
Some minor cleanup that I made while investigating #979.

Clean up when we use numpy `datetime64`s and when we use python `datetime`s

NB. I think the complete fix for #979 will require https://github.com/opendatacube/datacube-core/pull/1521