### PR TITLE
For 1 8 37

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -18,6 +18,7 @@ Maintenance release.  Security updates and bug fixes around timezone handling.
 * Update dependencies to block upstream security issues (#973)
 * Label Prometheus metrics by endpoint, not path (#978)
 * Update base docker image and remove docker efficiency analysis GHA (#990)
+* Update HISTORY.rst and increment default version for release (#993)
 
 Contributions from @benjimin, @pjonsson, @SpacemanPaul and @dependabot.
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,6 +7,20 @@ History
 
 Datacube-ows version 1.8.x indicates that it is designed work with datacube-core versions 1.8.x.
 
+1.8.37 (2024-02-28)
+-------------------
+
+Maintenance release.  Security updates and bug fixes around timezone handling.
+
+* Fixes to timezone handling (#958, #982)
+* Various Github CI improvements (#959, #972, #974)
+* Automatic dependency updates (#966, #970, #971, #975, #976, #977, #980, #981, #984, #986, #988, #991, #992)
+* Update dependencies to block upstream security issues (#973)
+* Label Prometheus metrics by endpoint, not path (#978)
+* Update base docker image and remove docker efficiency analysis GHA (#990)
+
+Contributions from @benjimin, @pjonsson, @SpacemanPaul and @dependabot.
+
 1.8.36 (2023-10-24)
 -------------------
 

--- a/datacube_ows/__init__.py
+++ b/datacube_ows/__init__.py
@@ -6,4 +6,4 @@
 try:
     from ._version import version as __version__
 except ImportError:
-    __version__ = "1.8.36+?"
+    __version__ = "1.8.37+?"


### PR DESCRIPTION
Update HISTORY.rst and default version number, ready for 1.8.37 release.

<!-- readthedocs-preview datacube-ows start -->
----
📚 Documentation preview 📚: https://datacube-ows--993.org.readthedocs.build/en/993/

<!-- readthedocs-preview datacube-ows end -->