### PR TITLE
Make feature info output GeoJSON compatible.

### DIFF
--- a/check-code-all.sh
+++ b/check-code-all.sh
@@ -21,7 +21,7 @@ datacube product add https://raw.githubusercontent.com/GeoscienceAustralia/dea-c
 
 # Geomedian for summary product testing
 
-datacube product add https://raw.githubusercontent.com/GeoscienceAustralia/dea-config/master/products/baseline_satellite_data/geomedian-au/ga_ls8c_nbart_gm_cyear_3.odc-product.yaml
+datacube product add https://raw.githubusercontent.com/GeoscienceAustralia/dea-config/master/products/baseline_satellite_data/geomedian-au/ga_ls8cls9c_gm_cyear_3.odc-product.yaml
 
 # S2 multiproduct datasets
 datacube dataset add https://dea-public-data.s3.ap-southeast-2.amazonaws.com/baseline/ga_s2bm_ard_3/52/LGM/2017/07/19/20170719T030622/ga_s2bm_ard_3-2-1_52LGM_2017-07-19_final.odc-metadata.yaml --ignore-lineage

--- a/check-code-all.sh
+++ b/check-code-all.sh
@@ -21,7 +21,7 @@ datacube product add https://raw.githubusercontent.com/GeoscienceAustralia/dea-c
 
 # Geomedian for summary product testing
 
-datacube product add https://raw.githubusercontent.com/GeoscienceAustralia/dea-config/master/products/baseline_satellite_data/geomedian-au/ga_ls8cls9c_gm_cyear_3.odc-product.yaml
+datacube product add https://explorer-aws.dea.ga.gov.au/products/ga_ls8c_nbart_gm_cyear_3.odc-product.yaml
 
 # S2 multiproduct datasets
 datacube dataset add https://dea-public-data.s3.ap-southeast-2.amazonaws.com/baseline/ga_s2bm_ard_3/52/LGM/2017/07/19/20170719T030622/ga_s2bm_ard_3-2-1_52LGM_2017-07-19_final.odc-metadata.yaml --ignore-lineage

--- a/datacube_ows/data.py
+++ b/datacube_ows/data.py
@@ -898,7 +898,7 @@ def feature_info(args):
                 "properties": feature_json,
                 "geometry": {
                     "type": "Point",
-                    "coordinates": [feature_json["lon"], feature_json["lat"]]
+                    "coordinates": geo_point.coords[0]
                 }
             }
         ]

--- a/datacube_ows/data.py
+++ b/datacube_ows/data.py
@@ -895,7 +895,11 @@ def feature_info(args):
         "features": [
             {
                 "type": "Feature",
-                "properties": feature_json
+                "properties": feature_json,
+                "geometry": {
+                    "type": "Point",
+                    "coordinates": [feature_json["lon"], feature_json["lat"]]
+                }
             }
         ]
     }

--- a/datacube_ows/ows_configuration.py
+++ b/datacube_ows/ows_configuration.py
@@ -770,7 +770,7 @@ class OWSNamedLayer(OWSExtensibleConfigEntry, OWSLayer):
                 native_bounding_box = self.bboxes[self.native_CRS]
             except KeyError:
                 if not self.global_cfg.called_from_update_ranges:
-                    _LOG.warning("Layer: %s No bounding box in ranges for native CRS %s - rerun update_ranges.py",
+                    _LOG.warning("Layer: %s No bounding box in ranges for native CRS %s - rerun datacube-ows-update",
                                  self.name,
                                  self.native_CRS)
                 self.hide = True


### PR DESCRIPTION
This should render our feature_info output geojson compliant.

Also remove reference to `update_ranges` in error messages

Also update test db setup to reflect DEA collection changes.

Closes #892 and #985

<!-- readthedocs-preview datacube-ows start -->
----
📚 Documentation preview 📚: https://datacube-ows--995.org.readthedocs.build/en/995/

<!-- readthedocs-preview datacube-ows end -->