### PR TITLE
Generalise eo3-compatible product handling in materialised view definition

### DIFF
--- a/datacube_ows/sql/extent_views/create/011_create_new_space_view_raw.sql
+++ b/datacube_ows/sql/extent_views/create/011_create_new_space_view_raw.sql
@@ -23,7 +23,6 @@ eo3_ranges as
         substr(
           metadata #>> '{crs}',6)::integer
         ),
-
         4326
       ) as valid_geom
    from agdc.dataset where

--- a/datacube_ows/sql/extent_views/create/011_create_new_space_view_raw.sql
+++ b/datacube_ows/sql/extent_views/create/011_create_new_space_view_raw.sql
@@ -23,6 +23,7 @@ eo3_ranges as
         substr(
           metadata #>> '{crs}',6)::integer
         ),
+
         4326
       ) as valid_geom
    from agdc.dataset where
@@ -96,5 +97,5 @@ select id,
         4326
       ) as spatial_extent
  from agdc.dataset where
-        metadata_type_ref in (select id from metadata_lookup where name in ('eo3_landsat_ard', 'eo3_sentinel_ard'))
+        metadata_type_ref in (select id from metadata_lookup where name like 'eo3_%')
         and archived is null

--- a/datacube_ows/templates/wmts_capabilities.xml
+++ b/datacube_ows/templates/wmts_capabilities.xml
@@ -162,6 +162,7 @@
                     {% for t in product_ranges.times %}
                         <Value>{{ t }}</Value>
                     {% endfor %}
+                    <Default>{{ product_ranges.times[-1] }}</Default>
                 </Dimension>
             {% endif %}
 


### PR DESCRIPTION
The space materialised view definition previously required all supported metadata types to be explicitly included in the view definition.  A catch-all has been added for all metadata types starting with `eo3_`.

 Note that a non-eo3-compatible metadata type with a name starting with `eo3_` will now break OWS, but this is better than any metadata type with a name not in  a whitelist breaking OWS.
 
 Also fixes a bug in WMTS - exposed by more thorough WMTS validation in newer versions of OWSLib.

<!-- readthedocs-preview datacube-ows start -->
----
📚 Documentation preview 📚: https://datacube-ows--996.org.readthedocs.build/en/996/

<!-- readthedocs-preview datacube-ows end -->