### PR TITLE
Eo3 generalised in Time MV - and 1.8.39 release

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,6 +7,20 @@ History
 
 Datacube-ows version 1.8.x indicates that it is designed work with datacube-core versions 1.8.x.
 
+1.8.39 (2024-03-13)
+-------------------
+
+Emergency release to complete half-implemented new feature.
+
+The changes to the spatial materialised view introduced in the previous release are now also implemented
+in the time materialised view.
+
+Please run `datacube-ows-update --schema --role <ows_db_username>` again with this new release
+to access the new behaviour.
+
+* Fix materialised view definition to handle all eo3 compatible metadata types (#998)
+* Update HISTORY.rst and increment default version for release (#998)
+
 1.8.38 (2024-03-12)
 -------------------
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -18,6 +18,7 @@ in the time materialised view.
 Please run `datacube-ows-update --schema --role <ows_db_username>` again with this new release
 to access the new behaviour.
 
+* Automatic CI action update (#998)
 * Fix materialised view definition to handle all eo3 compatible metadata types (#999)
 * Update HISTORY.rst and increment default version for release (#999)
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -18,8 +18,8 @@ in the time materialised view.
 Please run `datacube-ows-update --schema --role <ows_db_username>` again with this new release
 to access the new behaviour.
 
-* Fix materialised view definition to handle all eo3 compatible metadata types (#998)
-* Update HISTORY.rst and increment default version for release (#998)
+* Fix materialised view definition to handle all eo3 compatible metadata types (#999)
+* Update HISTORY.rst and increment default version for release (#999)
 
 1.8.38 (2024-03-12)
 -------------------

--- a/datacube_ows/__init__.py
+++ b/datacube_ows/__init__.py
@@ -6,4 +6,4 @@
 try:
     from ._version import version as __version__
 except ImportError:
-    __version__ = "1.8.38+?"
+    __version__ = "1.8.39+?"

--- a/datacube_ows/sql/extent_views/create/010_create_new_time_view.sql
+++ b/datacube_ows/sql/extent_views/create/010_create_new_time_view.sql
@@ -42,5 +42,5 @@ select
     '[]'
    ) as temporal_extent
 from agdc.dataset where
-    metadata_type_ref in (select id from metadata_lookup where name in ('eo3_landsat_ard','eo3', 'eo3_sentinel_ard'))
+    metadata_type_ref in (select id from metadata_lookup where name like 'eo3_%')
     and archived is null

--- a/datacube_ows/sql/extent_views/create/010_create_new_time_view.sql
+++ b/datacube_ows/sql/extent_views/create/010_create_new_time_view.sql
@@ -42,5 +42,5 @@ select
     '[]'
    ) as temporal_extent
 from agdc.dataset where
-    metadata_type_ref in (select id from metadata_lookup where name like 'eo3_%')
+    metadata_type_ref in (select id from metadata_lookup where name like 'eo3%')
     and archived is null


### PR DESCRIPTION
The Space view changes in #996 don't work without these parallel changes in the time view.

Plus ready for 1.8.39 release.

<!-- readthedocs-preview datacube-ows start -->
----
📚 Documentation preview 📚: https://datacube-ows--999.org.readthedocs.build/en/999/

<!-- readthedocs-preview datacube-ows end -->