### PR TITLE
Update to numpy 1.22

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ install_requirements = [
     'deepdiff',
     'matplotlib',
     'pyparsing',
-    'numpy',
+    'numpy>=1.22',
     'scipy',
     'Pillow',
     'Babel',


### PR DESCRIPTION
This fixes CVE-2021-34141.

<!-- readthedocs-preview datacube-ows start -->
----
📚 Documentation preview 📚: https://datacube-ows--1005.org.readthedocs.build/en/1005/

<!-- readthedocs-preview datacube-ows end -->