### PR TITLE
Fix data links for products indexed with STAC metadata

### DIFF
--- a/datacube_ows/data.py
+++ b/datacube_ows/data.py
@@ -682,7 +682,7 @@ def get_s3_browser_uris(datasets, pt=None, s3url="", s3bucket=""):
     uris = list(chain.from_iterable(uris))
     unique_uris = set(uris)
 
-    regex = re.compile(r"s3:\/\/(?P<bucket>[a-zA-Z0-9_\-\.]+)\/(?P<prefix>[\S]+)/[a-zA-Z0-9_\-\.]+.yaml")
+    regex = re.compile(r"s3:\/\/(?P<bucket>[a-zA-Z0-9_\-\.]+)\/(?P<prefix>[\S]+)/[a-zA-Z0-9_\-\.]+.(yaml|json)")
 
     # convert to browsable link
     def convert(uri):


### PR DESCRIPTION
Data links for STAC indexed products currently point to the STAC JSON file, rather than being redirected to the overall data folder like we do for YAML files:
![image](https://github.com/opendatacube/datacube-ows/assets/17680388/c6d3a34b-ac33-408a-ba22-d7df091feff6)

This PR attempts to fix this by editing the regex that is used to identify the S3 folder to include JSON files.

<!-- readthedocs-preview datacube-ows start -->
----
📚 Documentation preview 📚: https://datacube-ows--1011.org.readthedocs.build/en/1011/

<!-- readthedocs-preview datacube-ows end -->