### PR TITLE
Prep for 1.8.40 release

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,6 +7,20 @@ History
 
 Datacube-ows version 1.8.x indicates that it is designed work with datacube-core versions 1.8.x.
 
+1.8.40 (2024-04-29)
+-------------------
+
+Bug fix release
+
+* Loading now uses `skip_broken_datasets=True` by default. (#1001)
+* Bump base osgeo/gdal docker image version. (#1003)
+* Update versions of several upstream packages to avoid known security issues (#1004, #1005, #1008)
+* pre-commit autoupdate (#1006)
+* Make S3 URL rewriting work with metadata indexed from STAC (#1011)
+* Update HISTORY.rst and increment default version for release and some tests. (#1013)
+
+This release includes contributions from @whatnick, @pjonsson, @SpacemanPaul, and various automatic updater bots.
+
 1.8.39 (2024-03-13)
 -------------------
 

--- a/datacube_ows/__init__.py
+++ b/datacube_ows/__init__.py
@@ -6,4 +6,4 @@
 try:
     from ._version import version as __version__
 except ImportError:
-    __version__ = "1.8.39+?"
+    __version__ = "1.8.40?"

--- a/datacube_ows/data.py
+++ b/datacube_ows/data.py
@@ -393,8 +393,7 @@ def user_date_sorter(layer, odc_dates, geom, user_dates):
         elif time_res.is_summary():
             norm_date = date(ts.year,
                              ts.month,
-                             ts.day,
-                             tzinfo=pytz.utc)
+                             ts.day)
             return norm_date == user_date
         else:
             norm_date = datetime(ts.year,

--- a/datacube_ows/data.py
+++ b/datacube_ows/data.py
@@ -13,7 +13,6 @@ from itertools import chain
 import datacube
 import numpy
 import numpy.ma
-import pytz
 import xarray
 from datacube.utils import geometry
 from datacube.utils.masking import mask_to_dict

--- a/integration_tests/utils.py
+++ b/integration_tests/utils.py
@@ -304,7 +304,8 @@ class ODCExtent:
             crs_extent = extent.to_crs(crs)
         crs_bbox = crs_extent.boundingbox
         return {
-            "bbox": f"{min(crs_bbox.left,crs_bbox.right)},{min(crs_bbox.top,crs_bbox.bottom)},{max(crs_bbox.left,crs_bbox.right)},{max(crs_bbox.top,crs_bbox.bottom)}",
+            "bbox": f"{min(crs_bbox.left, crs_bbox.right)},{min(crs_bbox.top, crs_bbox.bottom)},"
+                    f"{max(crs_bbox.left, crs_bbox.right)},{max(crs_bbox.top, crs_bbox.bottom)}",
             "times": ",".join(time_strs),
         }
 

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -30,12 +30,16 @@ def s3_url_datasets():
             "s3://test-bucket/hello_world/data.yaml"
     ])
     d2 = TestDataset([
-            "s3://test-bucket/hello.word/foo.bar/hello.test.yaml",
-            "s3://test-bucket/hello.word/foo.bar/hello-test.yaml"
+        "s3://test-bucket/hello.word/foo.bar/hello.test.yaml",
+        "s3://test-bucket/hello.word/foo.bar/hello-test.yaml"
+    ])
+    d3 = TestDataset([
+            "s3://test-bucket/this.is/from.stac/hello.test.json",
     ])
 
     datasets.append(d1)
     datasets.append(d2)
+    datasets.append(d3)
 
     class DataSetMock:
         def __init__(self, datasets):
@@ -67,6 +71,7 @@ def test_s3_browser_uris(s3_url_datasets):
 
     assert "http://test-bucket.s3-website-ap-southeast-2.amazonaws.com/?prefix=hello_world" in uris
     assert "http://test-bucket.s3-website-ap-southeast-2.amazonaws.com/?prefix=hello.word/foo.bar" in uris
+    assert "http://test-bucket.s3-website-ap-southeast-2.amazonaws.com/?prefix=this.is/from.stac" in uris
 
 # TODO: read_data is now a method of the DataStacker class. This test needs a rewrite.
 # @patch('xarray.Dataset')


### PR DESCRIPTION
Ready for 1.8.40 release.

* Increment default version number
* Update HISTORY.rst
* Add unit test for Robbi's PR #1011
* Reformatting to keep lint happy.

<!-- readthedocs-preview datacube-ows start -->
----
📚 Documentation preview 📚: https://datacube-ows--1013.org.readthedocs.build/en/1013/

<!-- readthedocs-preview datacube-ows end -->