### PR TITLE
Prep for 1.8.41 release.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,6 +7,20 @@ History
 
 Datacube-ows version 1.8.x indicates that it is designed work with datacube-core versions 1.8.x.
 
+1.8.41 (2024-07-16)
+-------------------
+
+New Feature!  Multi-date handler aggregator functions for colour-ramp type styles can now receive
+either the results of the index function, or the raw band data by setting a config option.  (Previously
+they always received the results of the index function.)
+
+* Improved error messages when creating extents without materialised views (#1016)
+* Several minor bug-fixes and improved error handling in WCS code (#1027)
+* Automated updates (#1022)
+* Allow multi-date handler aggregator functions to receive raw data (#1033)
+
+This release includes contributions from @SpacemanPaul and @whatnick
+
 1.8.40 (2024-04-29)
 -------------------
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -18,6 +18,7 @@ they always received the results of the index function.)
 * Several minor bug-fixes and improved error handling in WCS code (#1027)
 * Automated updates (#1022)
 * Allow multi-date handler aggregator functions to receive raw data (#1033)
+* Update HISTORY.rst and increment default version for release (#1034)
 
 This release includes contributions from @SpacemanPaul and @whatnick
 

--- a/datacube_ows/__init__.py
+++ b/datacube_ows/__init__.py
@@ -6,4 +6,4 @@
 try:
     from ._version import version as __version__
 except ImportError:
-    __version__ = "1.8.40?"
+    __version__ = "1.8.41?"


### PR DESCRIPTION
Increment default version number and update HISTORY.rst for release.

<!-- readthedocs-preview datacube-ows start -->
----
📚 Documentation preview 📚: https://datacube-ows--1034.org.readthedocs.build/en/1034/

<!-- readthedocs-preview datacube-ows end -->