### PR TITLE
Dockerfile: fix casing warning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Note that this is now pinned to a fixed version.  Remember to check for new versions periodically.
-FROM ghcr.io/osgeo/gdal:ubuntu-small-3.8.5 as builder
+FROM ghcr.io/osgeo/gdal:ubuntu-small-3.8.5 AS builder
 
 # Setup build env for postgresql-client-14
 USER root


### PR DESCRIPTION
This fixes the warning:

- FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 2)

emitted by recent Docker releases.

<!-- readthedocs-preview datacube-ows start -->
----
📚 Documentation preview 📚: https://datacube-ows--1035.org.readthedocs.build/en/1035/

<!-- readthedocs-preview datacube-ows end -->