### PR TITLE
Changes to materialised view definition to prevent errors on databases with WKT CRSs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -38,6 +38,18 @@ Features
 * Supports WCS versions 1.0.0, 2.0.0 and 2.1.0.
 * Richly featured styling engine for serving data visualisations via WMS and WMTS.
 
+Known CRS Limitations
+---------------------
+
+1. ODC datasets with WKT-format CRSs will not work with OWS - data from such datasets
+   will never be displayed. OWS currently only works with EPSG format CRSs.
+
+2. Datasets that straddle the anti-meridian or the north or south polar region will
+   cause issues with the legacy postgres driver.
+
+These are fundamental limitation of the way OWS works with the postgres ODC index driver.
+These limitations will be addressed in v1.9.0, but only for the new ODC postgis index driver.
+
 Community
 ---------
 

--- a/datacube_ows/sql/extent_views/create/011_create_new_space_view_raw.sql
+++ b/datacube_ows/sql/extent_views/create/011_create_new_space_view_raw.sql
@@ -28,6 +28,7 @@ eo3_ranges as
    from agdc.dataset where
       metadata_type_ref in (select id from metadata_lookup where name='eo3')
       and archived is null
+      and substr(metadata #>> '{crs}', 1, 5) = 'EPSG:'
   ),
 -- This is eo spatial (Uses ALOS-PALSAR over Africa as a sample product)
 eo_corners as
@@ -97,4 +98,5 @@ select id,
       ) as spatial_extent
  from agdc.dataset where
         metadata_type_ref in (select id from metadata_lookup where name like 'eo3_%')
+        and substr(metadata #>> '{grid_spatial, projection, spatial_reference}', 1, 5) = 'EPSG:'
         and archived is null

--- a/datacube_ows/sql/extent_views/create/011_create_new_space_view_raw.sql
+++ b/datacube_ows/sql/extent_views/create/011_create_new_space_view_raw.sql
@@ -28,7 +28,7 @@ eo3_ranges as
    from agdc.dataset where
       metadata_type_ref in (select id from metadata_lookup where name='eo3')
       and archived is null
-      and substr(metadata #>> '{crs}', 1, 5) = 'EPSG:'
+      and upper(substr(metadata #>> '{crs}', 1, 5)) = 'EPSG:'
   ),
 -- This is eo spatial (Uses ALOS-PALSAR over Africa as a sample product)
 eo_corners as
@@ -46,7 +46,7 @@ eo_corners as
         and archived is null
    and (metadata #>> '{grid_spatial, projection, valid_data}' is null
        or
-        substr(metadata #>> '{grid_spatial, projection, spatial_reference}', 1, 4) <> 'EPSG'
+        upper(substr(metadata #>> '{grid_spatial, projection, spatial_reference}', 1, 5)) <> 'EPSG:'
    )
 ),
 eo_geoms as
@@ -63,8 +63,8 @@ eo_geoms as
    from agdc.dataset where
         metadata_type_ref in (select id from metadata_lookup where name in ('eo','eo_s2_nrt','gqa_eo','eo_plus', 'boku'))
         and archived is null
-   and metadata #>> '{grid_spatial, projection, valid_data}' is not null
-   and substr(metadata #>> '{grid_spatial, projection, spatial_reference}', 1, 5) = 'EPSG:'
+        and metadata #>> '{grid_spatial, projection, valid_data}' is not null
+        and upper(substr(metadata #>> '{grid_spatial, projection, spatial_reference}', 1, 5)) = 'EPSG:'
 )
 select id,format('POLYGON(( %s %s, %s %s, %s %s, %s %s, %s %s))',
                  lon_begin, lat_begin, lon_end, lat_begin,  lon_end, lat_end,
@@ -98,5 +98,5 @@ select id,
       ) as spatial_extent
  from agdc.dataset where
         metadata_type_ref in (select id from metadata_lookup where name like 'eo3_%')
-        and substr(metadata #>> '{grid_spatial, projection, spatial_reference}', 1, 5) = 'EPSG:'
+        and upper(substr(metadata #>> '{grid_spatial, projection, spatial_reference}', 1, 5)) = 'EPSG:'
         and archived is null


### PR DESCRIPTION
As discussed in #1002, creation of OWS materialised views fails on indexes that contain datasets with WKT-format CRSs, even if the datasets in question belong to products not included in the OWS config.

This PR explicitly excludes non-EPSG CRS datasets from the materialised view.  This means that such datasets can NEVER be returned by OWS, but it will at least be able to possible to use OWS for other products in the same index.

Viewing non-EPSG CRS datasets will be possible in 1.9.0, with the new postgis ODC driver.

This (and other CRS-related) limitations of 1.8/postgres OWS are now documented in the README.

<!-- readthedocs-preview datacube-ows start -->
----
📚 Documentation preview 📚: https://datacube-ows--1037.org.readthedocs.build/en/1037/

<!-- readthedocs-preview datacube-ows end -->