### PR TITLE
Feature info enhancements

### DIFF
--- a/datacube_ows/data.py
+++ b/datacube_ows/data.py
@@ -889,8 +889,8 @@ def feature_info(args):
                         for k, f in mdh.feature_info_includes.items():
                             # Function signature: pass in:
                             # * a multi-date single pixel (1x1xn) multiband xarray Dataset,
-                            date_info[k] = f(pixel_ds)
-                        feature_json["data"].apppend(date_info)
+                            date_info[k] = f(data)
+                        feature_json["data"].append(date_info)
             feature_json["data_available_for_dates"] = []
             pt_native = None
             for d in all_time_datasets.coords["time"].values:

--- a/datacube_ows/data.py
+++ b/datacube_ows/data.py
@@ -853,12 +853,44 @@ def feature_info(args):
                     derived_band_dict = _make_derived_band_dict(pixel_ds, params.product.style_index)
                     if derived_band_dict:
                         date_info["band_derived"] = derived_band_dict
-                    # Add any custom-defined fields.
-                    for k, f in params.product.feature_info_custom_includes.items():
+                    # Add any legacy custom-defined layer fields.
+                    for k, f in params.product.legacy_feature_info_custom_includes.items():
+                        # legacy function signature: pass in band and index data as a dictionary
                         date_info[k] = f(date_info["bands"])
+
+                    # Any custom-defined layer fields
+                    # (entries from the legacy are overwritten by the new if both exist)
+                    for k, f in params.product.feature_info_custom_includes.items():
+                        # New function signature: pass in:
+                        # * a single pixel (1x1x1) multiband xarray Dataset, and
+                        # * the ODC Dataset model (i.e. full ODC metadata)
+                        date_info[k] = f(pixel_ds, ds)
+
+                    if params.style is not None:
+                        # Any custom-defined style fields
+                        # (style definitions override layer-level entries where both exist)
+                        for k, f in params.style.feature_info_includes.items():
+                            # Function signature: pass in:
+                            # * a single pixel (1x1x1) multiband xarray Dataset, and
+                            # * the ODC Dataset model (i.e. full ODC metadata)
+                            date_info[k] = f(pixel_ds, ds)
 
                     feature_json["data"].append(date_info)
                     fi_date_index[dt] = feature_json["data"][-1]
+                # Multidate custom includes reflect all selected times on multidate requests,
+                # and are added as an extra all-time data record after the date ones.
+                times = list(data.time.values)
+                if len(times) > 1 and params.style is not None:
+                    mdh = params.style.get_multi_date_handler(times)
+                    if mdh is not None:
+                        date_info = {
+                            "time": "all"
+                        }
+                        for k, f in mdh.feature_info_includes.items():
+                            # Function signature: pass in:
+                            # * a multi-date single pixel (1x1xn) multiband xarray Dataset,
+                            date_info[k] = f(pixel_ds)
+                        feature_json["data"].apppend(date_info)
             feature_json["data_available_for_dates"] = []
             pt_native = None
             for d in all_time_datasets.coords["time"].values:

--- a/datacube_ows/ows_configuration.py
+++ b/datacube_ows/ows_configuration.py
@@ -601,6 +601,12 @@ class OWSNamedLayer(OWSExtensibleConfigEntry, OWSLayer):
     def parse_feature_info(self, cfg):
         self.feature_info_include_utc_dates = cfg.get("include_utc_dates", False)
         custom = cfg.get("include_custom", {})
+        self.legacy_feature_info_custom_includes = {k: FunctionWrapper(self, v) for k, v in custom.items()}
+        if self.legacy_feature_info_custom_includes:
+            _LOG.warning("In layer %s: The 'include_custom' directive is deprecated and will be removed in version 1.9. "
+                         "Please refer to the documentation for information on how to migrate your configuration "
+                         "to the new 'custom_includes' directive.", self.name)
+        custom = cfg.get("custom_includes", {})
         self.feature_info_custom_includes = {k: FunctionWrapper(self, v) for k, v in custom.items()}
 
     # pylint: disable=attribute-defined-outside-init

--- a/datacube_ows/styles/base.py
+++ b/datacube_ows/styles/base.py
@@ -196,7 +196,10 @@ class StyleDefBase(OWSExtensibleConfigEntry, OWSMetadataConfig):
         self.raw_flag_bands: Set[str] = set()
         self.declare_unready("needed_bands")
         self.declare_unready("flag_bands")
-
+        self.feature_info_includes = {
+            k: FunctionWrapper(self, v)
+            for k, v in style_cfg.get("custom_includes", {}).items()
+        }
         self.legend_cfg = self.Legend(self, raw_cfg.get("legend", {}))
         if not defer_multi_date:
             self.parse_multi_date(raw_cfg)
@@ -525,6 +528,10 @@ class StyleDefBase(OWSExtensibleConfigEntry, OWSMetadataConfig):
                     raise ConfigException("Aggregator function is required for non-animated multi-date handlers.")
             self.legend_cfg = self.Legend(self, raw_cfg.get("legend", {}))
             self.preserve_user_date_order = cast(bool, cfg.get("preserve_user_date_order", False))
+            self.feature_info_includes = {
+                k: FunctionWrapper(self.style, v)
+                for k, v in cfg.get("custom_includes", {}).items()
+            }
 
         def applies_to(self, count: int) -> bool:
             """Does this multidate handler apply to a request with this number of dates?"""

--- a/datacube_ows/wms_utils.py
+++ b/datacube_ows/wms_utils.py
@@ -455,6 +455,7 @@ class GetFeatureInfoParameters(GetParameters):
                                "%s parameter" % coords[0])
         self.i = int(i)
         self.j = int(j)
+        self.style = single_style_from_args(self.product, args, required=False)
 
 
 # Solar angle correction functions

--- a/docs/cfg_layers.rst
+++ b/docs/cfg_layers.rst
@@ -1281,7 +1281,7 @@ Legacy Include Custom Feature Info (include_custom)
 The legacy ``include_custom`` entry is supported for backwards compatibility in favour
 of the ``custom_includes`` entry described above.
 
-The behavour is identical to ``custom_includes`` except that arguments passed to the function
+The behaviour is identical to ``custom_includes`` except that arguments passed to the function
 are different.  Instead of the arguments described above, the function(s) are passed a dictionary
 with a key for each known band, mapping to the numeric value of that band at the chosen pixel.
 

--- a/docs/cfg_layers.rst
+++ b/docs/cfg_layers.rst
@@ -1234,35 +1234,38 @@ days.
 This configuration option is provided to allow compatibility with other systems that
 do not use solar days and is not recommended for normal use.
 
-Include Custom Info (include_custom)
-++++++++++++++++++++++++++++++++++++
+Custom Layer Includes (custom_includes)
++++++++++++++++++++++++++++++++++++++++
 
-Determines how multiple dataset arrays are compressed into a
-single time array. Specified using OWS's `function configuration
-format <https://datacube-ows.readthedocs.io/en/latest/cfg_functions.html>`_.
-
-"include_custom" allows custom data to be included in GetFeatureInfo responses. It
+"custom_includes" allows custom data to be included in GetFeatureInfo responses. It
 is optional and defaults to an empty dictionary (i.e. no custom data.)
 
-The keys of the "include_custom" dictionary are the keys that will be included in the
-GetFeatureInfo responses.  They should therefore be keys that are not included by
-default (e.g. "data", "data_available_for_dates", "data_links") - if you use one of
-these keys, the defined custom data will REPLACE the default data for these keys.
-
-The values for the dictionary entries are Python functions specified using
+``custom_includes`` is dictionary mapping keys to functions specified with
 OWS's `function configuration format <https://datacube-ows.readthedocs.io/en/latest/cfg_functions.html>`_.
 
-The specified function(s) are expected to be passed a dictionary of band values
-(as parameter "data") and can return any data that can be serialised to JSON.
+The keys of the "custom_includes" dictionary are the keys that will be included in the
+GetFeatureInfo responses.  They should therefore be keys that are not included by
+default (i.e. "time", "bands", "band_derived") - if you use of these keys, the custom data
+will REPLACE the default values.
 
-E.g.
+Custom includes defined here may be over-ridden by custom includes set at the style level if
+the GetFeatureInfo request includes the style.
 
-::
+The specified function(s) are passed:
+
+ * A single-pixel, single time-step, multi-band ``xarray.Dataset``.
+ * A ``datacube.model.Dataset``.  Note that if multiple datasets are available for the same area,
+   the one supplied to the function may not be the one the pixel was loaded from, depending on
+   the fuser function.  This will usually not be an issue.
+
+The specified function(s) can to return any data that can be serialised to JSON.
+
+E.g.::
 
     "feature_info": {
         "include_custom": {
             "timeseries": {
-                "function": "datacube_ows.ogc_utils.feature_info_url_template",
+                "function": "my_config_funcs.time_series_url",
                 "pass_product_cfg": False,
                 "kwargs": {
                     "template": "https://host.domain/path/{data['f_id']:06}.csv"
@@ -1270,6 +1273,23 @@ E.g.
             }
         }
     }
+
+
+Legacy Include Custom Feature Info (include_custom)
++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+The legacy ``include_custom`` entry is supported for backwards compatibility in favour
+of the ``custom_includes`` entry described above.
+
+The behavour is identical to ``custom_includes`` except that arguments passed to the function
+are different.  Instead of the arguments described above, the function(s) are passed a dictionary
+with a key for each known band, mapping to the numeric value of that band at the chosen pixel.
+
+"include_custom" allows custom data to be included in GetFeatureInfo responses. It
+is optional and defaults to an empty dictionary (i.e. no custom data.)
+
+Legacy ``include_custom`` entries can be over-ridden by new-style ``custom-includes``.
+
 
 -----------------------------------
 Styling Section (styling)

--- a/docs/cfg_styling.rst
+++ b/docs/cfg_styling.rst
@@ -231,6 +231,19 @@ E.g.
         # or invalid - all other pixels are displayed.
     ],
 
+
+Feature Info Custom Style Includes (custom_includes)
+++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+In addition to the custom includes defined `at the layer level
+<https://datacube-ows.readthedocs.io/en/latest/cfg_layers.html#custom-layer-includes-custom-includes>`_,
+custom includes can also be defined at the style level.  These are applied only if the GetFeatureInfo
+request specifies a style, and override and entries defined at the layer level.
+
+Style-level includes `behave identically
+<https://datacube-ows.readthedocs.io/en/latest/cfg_layers.html#custom-layer-includes-custom-includes>`_
+to layer level ``custom-includes`` entries.
+
 Legend
 ++++++
 
@@ -389,3 +402,19 @@ a multi-date handler with the "animate" flag set to True.  E.g.:
 This returns an animated image in the Animated PNG format, with one frame per requested date value.  The
 frame rate of the animation can be controlled with the optional ``frame_duration`` element, which is
 measured in milliseconds and defaults to 1000 if not supplied.
+
+Feature Info Multi-Date Custom Includes (custom_includes)
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+In addition to the custom includes defined `at the layer level
+<https://datacube-ows.readthedocs.io/en/latest/cfg_layers.html#custom-layer-includes-custom-includes>`_, and
+`at the style level, as described above<#feature-info-custom-style-includes-custom-includes>`_,
+If the GetFeatureInfo requests a style AND multiple dates, then the multi-date handler
+can define additional custom feature info.
+
+An additional dictionary is appended to the `propoerties::data` list, that already contains a dictionary
+for each date returned by the query. The additional dictionary has ``"time": "all"`` and the fields
+defined by the multi-date handler custom_includes entry.
+
+Unlike other ``custom_include`` entries, the functions specified by the mult-date version is passed
+a MULTI_DATE, single-pixel, multi-band ``xarray.Dataset``.  (Note that no ODC metadata is passed.)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -49,7 +49,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'datacube-ows'
-copyright = u"2020, Geoscience Australia"
+copyright = u"2017-2024, Open Data Cube Steering Council and contributors (Open Source License)"
 
 # The version info for the project you're documenting, acts as replacement
 # for |version| and |release|, also used in various other places throughout

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -22,5 +22,4 @@ Indices and tables
 ==================
 
 * :ref:`genindex`
-* :ref:`modindex`
 * :ref:`search`

--- a/integration_tests/cfg/ows_test_cfg.py
+++ b/integration_tests/cfg/ows_test_cfg.py
@@ -388,6 +388,10 @@ style_ls_ndvi_delta = {
         {"value": 0.9, "color": "#237100"},
         {"value": 1.0, "color": "#114D04"},
     ],
+    "custom_includes": {
+        "override": f"{cfgbase}utils.new_finfo_vars",  # Over-rides above
+        "platform": f"{cfgbase}utils.new_finfo_platform",  # from metadata
+    },
     "multi_date": [
         {
             "allowed_count_range": [2, 2],
@@ -412,6 +416,22 @@ style_ls_ndvi_delta = {
                     "0.0",
                     "1.0",
                 ]
+            },
+            "custom_includes": {
+                "red_diff": {
+                    "function": f"{cfgbase}utils.new_finfo_vars",
+                    "mapped_bands": True,
+                    "kwargs": {
+                        "band": "red"
+                    }
+                },
+                "nir_diff": {
+                    "function": f"{cfgbase}utils.new_finfo_vars",
+                    "mapped_bands": True,
+                    "kwargs": {
+                        "band": "nir"
+                    }
+                },
             },
             "feature_info_label": "ndvi_delta",
         },
@@ -784,6 +804,16 @@ ows_cfg = {
                             # "manual_merge": True,
                         },
                     ],
+                    "feature_info": {
+                        "include_custom": {
+                            "legacy_data": f"{cfgbase}utils.legacy_finfo_data",  # Will be kept
+                            "override": f"{cfgbase}utils.legacy_finfo_data",  # Will be overriden by non-legacy
+                        },
+                        "custom_includes": {
+                            "override": f"{cfgbase}utils.new_finfo_vars",  # Over-rides above
+                            "platform": f"{cfgbase}utils.new_finfo_platform",  # from metadata
+                        },
+                    },
                     "native_crs": "EPSG:3857",
                     "native_resolution": [30.0, -30.0],
                     "styling": {

--- a/integration_tests/cfg/ows_test_cfg.py
+++ b/integration_tests/cfg/ows_test_cfg.py
@@ -419,14 +419,14 @@ style_ls_ndvi_delta = {
             },
             "custom_includes": {
                 "red_diff": {
-                    "function": f"{cfgbase}utils.new_finfo_vars",
+                    "function": f"{cfgbase}utils.new_twodate_finfo",
                     "mapped_bands": True,
                     "kwargs": {
                         "band": "red"
                     }
                 },
                 "nir_diff": {
-                    "function": f"{cfgbase}utils.new_finfo_vars",
+                    "function": f"{cfgbase}utils.new_twodate_finfo",
                     "mapped_bands": True,
                     "kwargs": {
                         "band": "nir"

--- a/integration_tests/cfg/utils.py
+++ b/integration_tests/cfg/utils.py
@@ -13,7 +13,7 @@ def legacy_finfo_data(data):
 
 
 def new_finfo_vars(data, ds):
-    return list(data.data_vars)
+    return list(data.data_vars.keys())
 
 
 def new_finfo_platform(data, ds):
@@ -24,4 +24,4 @@ def new_twodate_finfo(data, band, band_mapper=None):
     if band_mapper is not None:
         band = band_mapper(band)
     data1, data2 = (data.sel(time=dt) for dt in data.coords["time"].values)
-    return data2[band] - data1[band]
+    return data2[band].item() - data1[band].item()

--- a/integration_tests/cfg/utils.py
+++ b/integration_tests/cfg/utils.py
@@ -6,3 +6,22 @@
 
 def trivial_identity(x):
     return x
+
+
+def legacy_finfo_data(data):
+    return data
+
+
+def new_finfo_vars(data, ds):
+    return list(data.data_vars)
+
+
+def new_finfo_platform(data, ds):
+    return ds.metadata.platform
+
+
+def new_twodate_finfo(data, band, band_mapper=None):
+    if band_mapper is not None:
+        band = band_mapper(band)
+    data1, data2 = (data.sel(time=dt) for dt in data.coords["time"].values)
+    return data2[band] - data1[band]

--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -48,17 +48,25 @@ def runner():
 
 
 @pytest.helpers.register
-def enclosed_bbox(bbox):
+def enclosed_bbox(bbox, flip=False):
     lon_min, lat_min, lon_max, lat_max = bbox
     lon_range = lon_max - lon_min
     lat_range = lat_max - lat_min
 
-    return (
-        lon_min + 0.45 * lon_range,
-        lat_min + 0.45 * lat_range,
-        lon_max - 0.45 * lon_range,
-        lat_max - 0.45 * lat_range,
-    )
+    if flip:
+        return (
+            lat_min + 0.45 * lat_range,
+            lon_min + 0.45 * lon_range,
+            lat_max - 0.45 * lat_range,
+            lon_max - 0.45 * lon_range,
+        )
+    else:
+        return (
+            lon_min + 0.45 * lon_range,
+            lat_min + 0.45 * lat_range,
+            lon_max - 0.45 * lon_range,
+            lat_max - 0.45 * lat_range,
+        )
 
 
 @pytest.helpers.register

--- a/integration_tests/test_wms_server.py
+++ b/integration_tests/test_wms_server.py
@@ -299,34 +299,45 @@ def test_wms_getfeatureinfo(ows_server):
     for test_layer_name in contents:
         test_layer = wms.contents[test_layer_name]
 
-        bbox = test_layer.boundingBoxWGS84
-        response = wms.getfeatureinfo(
-            layers=[test_layer_name],
-            srs="EPSG:4326",
-            bbox=pytest.helpers.enclosed_bbox(bbox),
-            size=(256, 256),
-            format="image/png",
-            query_layers=[test_layer_name],
-            info_format="application/json",
-            xy=(250, 250),
-        )
+        test_times = test_layer.timepositions
+        if test_times is None:
+            test_times = [None]
+        elif len(test_times) > 8:
+            test_times = [test_times[0], test_times[6], test_times[-1]]
+        elif len(test_times) == 1 and '/' in test_times[0]:
+            test_times = test_times[0].split('/')
+            test_times = list(test_times[0:2])
+        for test_time in test_times:
+            bbox = test_layer.boundingBoxWGS84
+            response = wms.getfeatureinfo(
+                layers=[test_layer_name],
+                srs="EPSG:4326",
+                bbox=pytest.helpers.enclosed_bbox(bbox),
+                size=(256, 256),
+                format="image/png",
+                query_layers=[test_layer_name],
+                info_format="application/json",
+                times=test_time,
+                xy=(250, 250),
+            )
 
-        assert response
-        assert response.info()["Content-Type"] == "application/json"
+            assert response
+            assert response.info()["Content-Type"] == "application/json"
 
-        response = wms.getfeatureinfo(
-            layers=[test_layer_name],
-            srs="EPSG:4326",
-            bbox=pytest.helpers.enclosed_bbox(bbox),
-            size=(256, 256),
-            format="image/png",
-            query_layers=[test_layer_name],
-            info_format="text/html",
-            xy=(250, 250),
-        )
+            response = wms.getfeatureinfo(
+                layers=[test_layer_name],
+                srs="EPSG:4326",
+                bbox=pytest.helpers.enclosed_bbox(bbox),
+                size=(256, 256),
+                format="image/png",
+                query_layers=[test_layer_name],
+                info_format="text/html",
+                times=test_time,
+                xy=(250, 250),
+            )
 
-        assert response
-        assert response.info()["Content-Type"] == "text/html"
+            assert response
+            assert response.info()["Content-Type"] == "text/html"
 
 
 def test_wms_getlegend(ows_server):

--- a/wordlist.txt
+++ b/wordlist.txt
@@ -168,6 +168,7 @@ FeatureListURLs
 fqn
 fs
 func
+fuser
 gda
 gdal
 geobase
@@ -403,6 +404,7 @@ wholeworld
 WholeWorld
 wkid
 wkss
+WKT
 wms
 wmts
 wofs


### PR DESCRIPTION
Significant overhaul of custom feature info includes.

1) Old `include_custom` entries still supported by deprecated.
2) New `custom_includes` entries, similar to the old `include_custom`,  but:
    a) Get passed a single-date xarray Dataset (for data) and an ODC Dataset (for metadata) (instead of a dictionary for data) 
    b) Can be defined at the layer or the style level (Style overrides layer if both are provided)
3) New multi-date `custom_includes` entry at the multi-date handler level:
    * Gets passed a multi-date xarray Dataset (no metadata).

Fixes #983 and provides multi-date behaviour requested by @robbibt 

<!-- readthedocs-preview datacube-ows start -->
----
📚 Documentation preview 📚: https://datacube-ows--1039.org.readthedocs.build/en/1039/

<!-- readthedocs-preview datacube-ows end -->