### PR TITLE
For 1.9.0 rc1

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,10 +2,46 @@
 History
 =======
 
+1.9.x Releases
+==============
+
+Datacube-ows version 1.9.x indicates that it is designed work with datacube-core versions 1.9.x.
+
+1.9.0-rc1 (2024-08-01)
+----------------------
+
+* Compatibility with datacube-1.9 and postgres index driver (#1009)
+* Cleanup (#1012)
+* ODC environment configuration (#1015)
+* Postgres ranges rebuild (#1017)
+* Cherry picks of bug fixes and new features from 1.8 branch (#1018, #1028, #1040)
+* Test database build (#1021)
+* Index driver abstraction (#1020)
+* Postgis driver support (#1032)
+* Prepare for 1.9.0-rc1 release (#1044)
+
+This release includes contributions from @SpacemanPaul
+
 1.8.x Releases
 ==============
 
 Datacube-ows version 1.8.x indicates that it is designed work with datacube-core versions 1.8.x.
+
+1.8.42 (2024-08-01)
+-------------------
+
+Bug fixes and major extensions for defining custom feature info includes - refer to the documentation
+for details.
+
+* Fix dockerfile casing warning (#1035)
+* Add --version argument to datacube-ows CLI entry point (#1036)
+* Auto-add implicit single top-level folder to ensure strict WMS standard compliance (#1036)
+* Changes to materialised view definition to prevent errors on databases with WKT CRS (#1037)
+* Custom Feature Info enhancements (#1039)
+* Miscellaneous cleanup and backported fixes from 1.9 branch (#1042)
+* Update default version number and HISTORY.rst for release (#1043)
+
+This release includes contributions from @SpacemanPaul and @pjonsson.
 
 1.8.41 (2024-07-16)
 -------------------

--- a/datacube_ows/__init__.py
+++ b/datacube_ows/__init__.py
@@ -7,4 +7,4 @@
 try:
     from ._version import version as __version__
 except ImportError:
-    __version__ = "1.8.41?"
+    __version__ = "1.9.0-rc1?"

--- a/docs/cfg_styling.rst
+++ b/docs/cfg_styling.rst
@@ -412,9 +412,9 @@ In addition to the custom includes defined `at the layer level
 If the GetFeatureInfo requests a style AND multiple dates, then the multi-date handler
 can define additional custom feature info.
 
-An additional dictionary is appended to the `propoerties::data` list, that already contains a dictionary
+An additional dictionary is appended to the `properties::data` list, that already contains a dictionary
 for each date returned by the query. The additional dictionary has ``"time": "all"`` and the fields
 defined by the multi-date handler custom_includes entry.
 
-Unlike other ``custom_include`` entries, the functions specified by the mult-date version is passed
+Unlike other ``custom_include`` entries, the functions specified by the multi-date version is passed
 a MULTI_DATE, single-pixel, multi-band ``xarray.Dataset``.  (Note that no ODC metadata is passed.)

--- a/wordlist.txt
+++ b/wordlist.txt
@@ -43,6 +43,7 @@ autoupdate
 awk
 aws
 ba
+backported
 bafdcc
 balancer
 bb


### PR DESCRIPTION
Update default version number and HISTORY.rst for 1.9.0-rc1 release.

Fix documentation typos fixed in #1042 in 1.8.

<!-- readthedocs-preview datacube-ows start -->
----
📚 Documentation preview 📚: https://datacube-ows--1044.org.readthedocs.build/en/1044/

<!-- readthedocs-preview datacube-ows end -->