### PR TITLE
Dockerfile: enable switching UID/GID

### DIFF
--- a/.github/workflows/complementary-config-test.yaml
+++ b/.github/workflows/complementary-config-test.yaml
@@ -56,6 +56,8 @@ jobs:
 
       - name: Config parser check
         run: |
+          export LOCAL_UID=$(id -u $USER)
+          export LOCAL_GID=$(id -g $USER)
           cd ./datacube-ows
           export $(grep -v '^#' ./complementary_config_test/.env_complementary_config_dea_dev | xargs)
           docker compose -f docker-compose.yaml -f docker-compose.cleandb.yaml up -d

--- a/.github/workflows/pyspy-profiling.yaml
+++ b/.github/workflows/pyspy-profiling.yaml
@@ -39,6 +39,8 @@ jobs:
     # Run performance profiling
     - name: setup performance profiling with py-spy (stage 1 - run profiling containers)
       run: |
+        export LOCAL_UID=$(id -u $USER)
+        export LOCAL_GID=$(id -g $USER)
         export $(grep -v '^#' .env_simple | xargs)
         docker compose -f docker-compose.yaml -f docker-compose.db.yaml -f docker-compose.pyspy.yaml up -d
 
@@ -50,6 +52,8 @@ jobs:
     - name: set output container pid (stage 1 - get ows container pid)
       id: set-output-container-id
       run: |
+        export LOCAL_UID=$(id -u $USER)
+        export LOCAL_GID=$(id -g $USER)
         export $(grep -v '^#' .env_simple | xargs)
         echo "::set-output name=PID::$(docker inspect --format '{{.State.Pid}}' $(docker inspect -f '{{.Name}}' \
         $(docker compose -f docker-compose.yaml -f docker-compose.db.yaml -f docker-compose.pyspy.yaml ps -q ows_18) \
@@ -59,6 +63,8 @@ jobs:
       timeout-minutes: 1
       continue-on-error: true
       run: |
+        export LOCAL_UID=$(id -u $USER)
+        export LOCAL_GID=$(id -g $USER)
         export $(grep -v '^#' .env_simple | xargs)
         docker compose -f docker-compose.yaml -f docker-compose.db.yaml -f docker-compose.pyspy.yaml \
         exec -T ows_18 /bin/sh -c "cd /code;./test_urls.sh &"

--- a/.github/workflows/test-prod.yaml
+++ b/.github/workflows/test-prod.yaml
@@ -54,6 +54,8 @@ jobs:
       # Build prod image and tag as latest, connect to pre-indexed database
       - name: Build and run prod OWS images (stage 2)
         run: |
+          export LOCAL_UID=$(id -u $USER)
+          export LOCAL_GID=$(id -g $USER)
           export $(grep -v '^#' .env_simple | xargs)
           docker compose -f docker-compose.yaml -f docker-compose.db.yaml -f docker-compose.prod.yaml up -d
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,12 +54,13 @@ jobs:
       - name: Test and lint dev OWS image
         run: |
           mkdir artifacts
-          docker run -v ${PWD}/artifacts:/mnt/artifacts ${ORG}/${IMAGE}:_builder /bin/sh -c "cd /code;./check-code.sh"
+          docker run -e LOCAL_UID=$(id -u $USER) -e LOCAL_GID=$(id -g $USER) -v ${PWD}/artifacts:/mnt/artifacts ${ORG}/${IMAGE}:_builder /bin/sh -c "cd /code;./check-code.sh"
           mv ./artifacts/coverage.xml ./artifacts/coverage-unit.xml
 
       - name: Dockerized Integration Pytest
         run: |
-          chmod a+rw artifacts
+          export LOCAL_UID=$(id -u $USER)
+          export LOCAL_GID=$(id -g $USER)
           export $(grep -v '^#' .env_simple | xargs)
           docker compose -f docker-compose.yaml -f docker-compose.db.yaml up -d
           docker compose -f docker-compose.yaml -f docker-compose.db.yaml exec -T ows_18 /bin/sh -c "cd /code;./check-code-all.sh"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -13,6 +13,8 @@ services:
     # Uncomment for use with non-dockerised postgres (for docker-compose 1.x)
     # network_mode: host
     environment:
+      LOCAL_UID: ${LOCAL_UID:-1000}
+      LOCAL_GID: ${LOCAL_GID:-1000}
       # Defaults are defined in .env file
       AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
       AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}

--- a/docker/files/remap-user.sh
+++ b/docker/files/remap-user.sh
@@ -1,0 +1,13 @@
+#!/bin/bash -e
+
+# Script that gives the container user uid $LOCAL_UID and gid $LOCAL_GID.
+# If $LOCAL_UID or $LOCAL_GID are not set, they default to 1000 (default
+# for the first user created in Ubuntu).
+
+USER_ID=${LOCAL_UID:-1000}
+GROUP_ID=${LOCAL_GID:-1000}
+
+[[ "$USER_ID" == "1000" ]] || usermod -u $USER_ID -o -m -d /home/ows ows
+[[ "$GROUP_ID" == "1000" ]] || groupmod -g $GROUP_ID ows
+[[ $(id -u) != "0" ]] || GOSU="/usr/sbin/gosu ows"
+exec /usr/bin/tini -- $GOSU "$@"


### PR DESCRIPTION
Add a script for switching UID/GID
of the user inside the container.
Use this to avoid making the directories
the CI uses world-writable.

<!-- readthedocs-preview datacube-ows start -->
----
📚 Documentation preview 📚: https://datacube-ows--1047.org.readthedocs.build/en/1047/

<!-- readthedocs-preview datacube-ows end -->