### PR TITLE
CI: stop using set-output

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,24 +7,24 @@ on:
       - 'master'
     paths:
       - '**'
-      - '.github/workflows/lint.yml'
       - '!docs/**'
       - '!*.rst'
       - '!*.md'
       - '!datacube_ows/__init__.py'
       - '!.github/**'
+      - '.github/workflows/lint.yml'
 
   push:
     branches:
       - 'master'
     paths:
       - '**'
-      - '.github/workflows/lint.yml'
       - '!docs/**'
       - '!*.rst'
       - '!*.md'
       - '!datacube_ows/__init__.py'
       - '!.github/**'
+      - '.github/workflows/lint.yml'
 
 jobs:
   pylint:

--- a/.github/workflows/pyspy-profiling.yaml
+++ b/.github/workflows/pyspy-profiling.yaml
@@ -55,9 +55,9 @@ jobs:
         export LOCAL_UID=$(id -u $USER)
         export LOCAL_GID=$(id -g $USER)
         export $(grep -v '^#' .env_simple | xargs)
-        echo "::set-output name=PID::$(docker inspect --format '{{.State.Pid}}' $(docker inspect -f '{{.Name}}' \
+        echo "PID=$(docker inspect --format '{{.State.Pid}}' $(docker inspect -f '{{.Name}}' \
         $(docker compose -f docker-compose.yaml -f docker-compose.db.yaml -f docker-compose.pyspy.yaml ps -q ows_18) \
-        | cut -c2-))"
+        | cut -c2-))" >> $GITHUB_OUTPUT
 
     - name: Run py-spy profiling (stage 1 - run profiling service)
       timeout-minutes: 1

--- a/.github/workflows/pyspy-profiling.yaml
+++ b/.github/workflows/pyspy-profiling.yaml
@@ -7,24 +7,24 @@ on:
         - 'master'
     paths:
       - '**'
-      - '.github/workflows/pyspy-profiling.yaml'
       - '!docs/**'
       - '!*.rst'
       - '!*.md'
       - '!datacube_ows/__init__.py'
       - '!.github/**'
+      - '.github/workflows/pyspy-profiling.yaml'
 
   push:
     branches:
       - 'master'
     paths:
       - '**'
-      - '.github/workflows/pyspy-profiling.yaml'
       - '!docs/**'
       - '!*.rst'
       - '!*.md'
       - '!datacube_ows/__init__.py'
       - '!.github/**'
+      - '.github/workflows/pyspy-profiling.yaml'
 
 jobs:
   build:

--- a/.github/workflows/test-prod.yaml
+++ b/.github/workflows/test-prod.yaml
@@ -7,24 +7,24 @@ on:
         - 'master'
     paths:
       - '**'
-      - '.github/workflows/test-prod.yaml'
       - '!docs/**'
       - '!*.rst'
       - '!*.md'
       - '!datacube_ows/__init__.py'
       - '!.github/**'
+      - '.github/workflows/test-prod.yaml'
 
   push:
     branches:
       - 'master'
     paths:
       - '**'
-      - '.github/workflows/test-prod.yaml'
       - '!docs/**'
       - '!*.rst'
       - '!*.md'
       - '!datacube_ows/__init__.py'
       - '!.github/**'
+      - '.github/workflows/test-prod.yaml'
 
 env:
   ORG: opendatacube


### PR DESCRIPTION
The set-output command has been
deprecated for a couple of years
by now, switch to using GITHUB_OUTPUT
to reduce the noise in the CI logs.

<!-- readthedocs-preview datacube-ows start -->
----
📚 Documentation preview 📚: https://datacube-ows--1052.org.readthedocs.build/en/1052/

<!-- readthedocs-preview datacube-ows end -->