### PR TITLE
CI: check return values of cd

### DIFF
--- a/.github/workflows/complementary-config-test.yaml
+++ b/.github/workflows/complementary-config-test.yaml
@@ -63,5 +63,5 @@ jobs:
           docker compose -f docker-compose.yaml -f docker-compose.cleandb.yaml up -d --wait
           docker compose -f docker-compose.yaml -f docker-compose.cleandb.yaml exec -T ows_18 /bin/sh -c "datacube system init; datacube system check"
           docker compose -f docker-compose.yaml -f docker-compose.cleandb.yaml exec -T ows_18 /bin/sh -c "curl https://raw.githubusercontent.com/GeoscienceAustralia/dea-config/master/dev/services/wms/inventory.json -o /tmp/inventory.json"
-          docker compose -f docker-compose.yaml -f docker-compose.db.yaml exec -T ows_18 /bin/sh -c "cd /code; ./compare-cfg.sh"
+          docker compose -f docker-compose.yaml -f docker-compose.db.yaml exec -T ows_18 /bin/sh -c "cd /code && ./compare-cfg.sh"
           docker compose -f docker-compose.yaml -f docker-compose.cleandb.yaml down

--- a/.github/workflows/pyspy-profiling.yaml
+++ b/.github/workflows/pyspy-profiling.yaml
@@ -67,7 +67,7 @@ jobs:
         export LOCAL_GID=$(id -g $USER)
         export $(grep -v '^#' .env_simple | xargs)
         docker compose -f docker-compose.yaml -f docker-compose.db.yaml -f docker-compose.pyspy.yaml \
-        exec -T ows_18 /bin/sh -c "cd /code;./test_urls.sh &"
+        exec -T ows_18 /bin/sh -c "cd /code && ./test_urls.sh &"
         docker compose -f docker-compose.yaml -f docker-compose.db.yaml -f docker-compose.pyspy.yaml \
         run pyspy record -f speedscope -o ./artifacts/profile.json --duration 30 \
         --pid ${{steps.set-output-container-id.outputs.PID}} --subprocesses

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Test and lint dev OWS image
         run: |
           mkdir artifacts
-          docker run -e LOCAL_UID=$(id -u $USER) -e LOCAL_GID=$(id -g $USER) -v ${PWD}/artifacts:/mnt/artifacts ${ORG}/${IMAGE}:_builder /bin/sh -c "cd /code;./check-code.sh"
+          docker run -e LOCAL_UID=$(id -u $USER) -e LOCAL_GID=$(id -g $USER) -v ${PWD}/artifacts:/mnt/artifacts ${ORG}/${IMAGE}:_builder /bin/sh -c "cd /code && ./check-code.sh"
           mv ./artifacts/coverage.xml ./artifacts/coverage-unit.xml
 
       - name: Dockerized Integration Pytest
@@ -63,7 +63,7 @@ jobs:
           export LOCAL_GID=$(id -g $USER)
           export $(grep -v '^#' .env_simple | xargs)
           docker compose -f docker-compose.yaml -f docker-compose.db.yaml up -d --wait
-          docker compose -f docker-compose.yaml -f docker-compose.db.yaml exec -T ows_18 /bin/sh -c "cd /code;./check-code-all.sh"
+          docker compose -f docker-compose.yaml -f docker-compose.db.yaml exec -T ows_18 /bin/sh -c "cd /code && ./check-code-all.sh"
           docker compose -f docker-compose.yaml -f docker-compose.db.yaml down
 
       - name: Upload All coverage to Codecov


### PR DESCRIPTION
Only execute the script if the cd
was successful. This prevents the CI
from accidentally passing if there
is a script with the same name in
the default work directory.

<!-- readthedocs-preview datacube-ows start -->
----
📚 Documentation preview 📚: https://datacube-ows--1053.org.readthedocs.build/en/1053/

<!-- readthedocs-preview datacube-ows end -->