### PR TITLE
Dockerfile: remove pg_isready

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,9 +52,6 @@ COPY --from=builder  /usr/lib/python3/dist-packages /usr/lib/python3/dist-packag
 # postgres client
 COPY --from=builder  /usr/lib/postgresql /usr/lib/postgresql
 COPY --from=builder  /usr/share/postgresql /usr/share/postgresql
-# perl5 is used for pg_isready
-COPY --from=builder  /usr/share/perl5 /usr/share/perl5
-COPY --from=builder  /usr/bin/pg_isready /usr/bin/pg_isready
 # datacube cli
 COPY --from=builder  /usr/local/bin/datacube /usr/local/bin/datacube
 # datacube-ows cli


### PR DESCRIPTION
After adding health checks to docker compose,
this command is no longer used anywhere else.

<!-- readthedocs-preview datacube-ows start -->
----
📚 Documentation preview 📚: https://datacube-ows--1057.org.readthedocs.build/en/1057/

<!-- readthedocs-preview datacube-ows end -->