### PR TITLE
Dockerfile: remove test deps from prod image

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,7 +47,7 @@ jobs:
       # the production image
       - name: Build dev OWS image
         run: |
-          docker build \
+          docker build --build-arg ENVIRONMENT=test \
             --tag    ${ORG}/${IMAGE}:_builder \
             .
 
@@ -62,7 +62,7 @@ jobs:
           export LOCAL_UID=$(id -u $USER)
           export LOCAL_GID=$(id -g $USER)
           export $(grep -v '^#' .env_simple | xargs)
-          docker compose -f docker-compose.yaml -f docker-compose.db.yaml up -d --wait
+          docker compose -f docker-compose.yaml -f docker-compose.db.yaml up -d --wait --build
           docker compose -f docker-compose.yaml -f docker-compose.db.yaml exec -T ows_18 /bin/sh -c "cd /code && ./check-code-all.sh"
           docker compose -f docker-compose.yaml -f docker-compose.db.yaml down
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
 # Note that this is now pinned to a fixed version.  Remember to check for new versions periodically.
 FROM ghcr.io/osgeo/gdal:ubuntu-small-3.9.1 AS builder
 
+# Environment is test or deployment.
+ARG ENVIRONMENT=deployment
+
 # Setup build env for postgresql-client-16
 USER root
 RUN apt-get update -y \
@@ -12,67 +15,58 @@ RUN apt-get update -y \
             python3-pip \
             postgresql-client-16 \
             # For Pyproj build \
-            proj-bin proj-data libproj-dev \
+            proj-bin libproj-dev \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /var/dpkg/* /var/tmp/* /var/log/dpkg.log
 
-ENV GDAL_DISABLE_READDIR_ON_OPEN="EMPTY_DIR"
+WORKDIR /build
 
-# Copy source code and install it
-WORKDIR /code
-COPY . /code
-
-RUN echo "version=\"$(python3 setup.py --version)\"" > datacube_ows/_version.py \
-    && pip --disable-pip-version-check install --no-cache-dir .[ops,test] --break-system-packages
-
-## Only install pydev requirements if arg PYDEV_DEBUG is set to 'yes'
-ARG PYDEV_DEBUG="no"
-RUN if [ "$PYDEV_DEBUG" = "yes" ]; then \
-    pip --disable-pip-version-check install --no-cache-dir .[dev] --break-system-packages \
-;fi
-
-RUN pip freeze
+RUN python3 -m pip --disable-pip-version-check -q wheel --no-binary psycopg2 psycopg2 \
+    && ([ "$ENVIRONMENT" = "deployment" ] || \
+          python3 -m pip --disable-pip-version-check -q wheel --no-binary pyproj pyproj)
 
 # Should match builder base.
 FROM ghcr.io/osgeo/gdal:ubuntu-small-3.9.1
 
-RUN apt-get update -y \
-    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+# Environment is test or deployment.
+ARG ENVIRONMENT=deployment
+RUN export DEBIAN_FRONTEND=noninteractive \
+    && apt-get update -y \
+    && apt-get install -y --no-install-recommends \
+            git \
             gosu \
+            python3-pip \
             tini \
+    && ([ "$ENVIRONMENT" = "deployment" ] || \
+          apt-get install -y --no-install-recommends \
+            proj-bin) \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /var/dpkg/* /var/tmp/* /var/log/dpkg.log
 
 # Add login-script for UID/GID-remapping.
 COPY --chown=root:root --link docker/files/remap-user.sh /usr/local/bin/remap-user.sh
 
-# all the python pip installed libraries
-COPY --from=builder  /usr/local/lib/python3.12/dist-packages /usr/local/lib/python3.12/dist-packages
-COPY --from=builder  /usr/lib/python3/dist-packages /usr/lib/python3/dist-packages
-# postgres client
-COPY --from=builder  /usr/lib/postgresql /usr/lib/postgresql
-COPY --from=builder  /usr/share/postgresql /usr/share/postgresql
-# perl5 is used for pg_isready
-COPY --from=builder  /usr/share/perl5 /usr/share/perl5
-COPY --from=builder  /usr/bin/pg_isready /usr/bin/pg_isready
-# datacube cli
-COPY --from=builder  /usr/local/bin/datacube /usr/local/bin/datacube
-# datacube-ows cli
-COPY --from=builder  /usr/local/bin/datacube-ows /usr/local/bin/datacube-ows
-# datacube-ows-update cli
-COPY --from=builder  /usr/local/bin/datacube-ows-update /usr/local/bin/datacube-ows-update
-# datacube-ows-cfg check
-COPY --from=builder  /usr/local/bin/datacube-ows-cfg /usr/local/bin/datacube-ows-cfg
-# flask cli
-COPY --from=builder  /usr/local/bin/flask /usr/local/bin/flask
-# gunicorn cli
-COPY --from=builder  /usr/local/bin/gunicorn /usr/local/bin/gunicorn
-# pybabel cli
-COPY --from=builder  /usr/local/bin/pybabel /usr/local/bin/pybabel
-
 # Copy source code and install it
 WORKDIR /code
 COPY . /code
+
+## Only install pydev requirements if arg PYDEV_DEBUG is set to 'yes'
+ARG PYDEV_DEBUG="no"
+COPY --from=builder --link /build/*.whl ./
+RUN EXTRAS=$([ "$ENVIRONMENT" = "deployment" ] || echo ",test") && \
+    python3 -m pip --disable-pip-version-check install ./*.whl --break-system-packages && \
+    rm ./*.whl && \
+    echo "version=\"$(python3 setup.py --version)\"" > datacube_ows/_version.py  && \
+    python3 -m pip --disable-pip-version-check install --no-cache-dir ".[ops$EXTRAS]" --break-system-packages && \
+    ([ "$PYDEV_DEBUG" != "yes" ] || \
+       python3 -m pip --disable-pip-version-check install --no-cache-dir .[dev] --break-system-packages) && \
+    python3 -m pip freeze && \
+    ([ "$ENVIRONMENT" != "deployment" ] || \
+       (rm -rf /code/* /code/.git* && \
+        apt-get purge -y \
+           git \
+           git-man \
+           python3-pip))
 
 # Configure user
 WORKDIR "/home/ubuntu"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -5,6 +5,7 @@ services:
       context: .
       args:
         PYDEV_DEBUG: "${PYDEV_DEBUG}"
+        ENVIRONMENT: test
       cache_from:
         - opendatacube/ows_18:_builder
     image: opendatacube/ows_18:latest


### PR DESCRIPTION
Only install the test dependencies in
in the image used by the CI.

<!-- readthedocs-preview datacube-ows start -->
----
📚 Documentation preview 📚: https://datacube-ows--1059.org.readthedocs.build/en/1059/

<!-- readthedocs-preview datacube-ows end -->