### PR TITLE
Stop passing --threads to gunicorn

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -77,4 +77,4 @@ ENV GDAL_DISABLE_READDIR_ON_OPEN="EMPTY_DIR" \
     GDAL_HTTP_RETRY_DELAY="1"
 
 ENTRYPOINT ["/usr/local/bin/remap-user.sh"]
-CMD ["gunicorn", "-b", "0.0.0.0:8000", "--workers=3", "--threads=2", "-k", "gevent", "--timeout", "121", "--pid", "/home/ubuntu/gunicorn.pid", "--log-level", "info", "--worker-tmp-dir", "/dev/shm", "--config", "python:datacube_ows.gunicorn_config", "datacube_ows.wsgi"]
+CMD ["gunicorn", "-b", "0.0.0.0:8000", "--workers=3", "-k", "gevent", "--timeout", "121", "--pid", "/home/ubuntu/gunicorn.pid", "--log-level", "info", "--worker-tmp-dir", "/dev/shm", "--config", "python:datacube_ows.gunicorn_config", "datacube_ows.wsgi"]

--- a/docker-compose.prod.yaml
+++ b/docker-compose.prod.yaml
@@ -2,4 +2,4 @@
 
 services:
   ows_18:
-    command: gunicorn -b '0.0.0.0:8000' --workers=3 --threads=2 -k gevent --timeout 121 --pid /home/ubuntu/gunicorn.pid --log-level info --worker-tmp-dir /dev/shm --config python:datacube_ows.gunicorn_config datacube_ows.wsgi
+    command: gunicorn -b '0.0.0.0:8000' --workers=3 -k gevent --timeout 121 --pid /home/ubuntu/gunicorn.pid --log-level info --worker-tmp-dir /dev/shm --config python:datacube_ows.gunicorn_config datacube_ows.wsgi


### PR DESCRIPTION
This setting only applies to gthread
according to the documentation:

https://docs.gunicorn.org/en/23.0.0/settings.html#threads

<!-- readthedocs-preview datacube-ows start -->
----
📚 Documentation preview 📚: https://datacube-ows--1061.org.readthedocs.build/en/1061/

<!-- readthedocs-preview datacube-ows end -->