### PR TITLE
Remove checking against crs valid extent

### DIFF
--- a/datacube_ows/index/postgis/product_ranges.py
+++ b/datacube_ows/index/postgis/product_ranges.py
@@ -10,6 +10,7 @@ from datetime import date, datetime, timezone
 from typing import Callable
 import click
 
+from antimeridian import fix_shape
 import datacube
 import odc.geo
 import sqlalchemy.exc
@@ -168,7 +169,10 @@ def create_range_entry(layer: OWSNamedLayer, cache: dict[LayerSignature, list[st
                 base_extent = prod_extent
             else:
                 base_extent = base_extent | prod_extent
-        assert base_extent is not None
+        if base_extent is None:
+            click.echo(f"Layer {layer.name} has no extent in CRS {base_crs}.  Skipping.")
+            return
+
         all_bboxes = bbox_projections(base_extent, layer.global_cfg.crses)
 
         conn.execute(text("""
@@ -197,19 +201,8 @@ def create_range_entry(layer: OWSNamedLayer, cache: dict[LayerSignature, list[st
 def bbox_projections(starting_box: odc.geo.Geometry, crses: dict[str, odc.geo.CRS]) -> dict[str, dict[str, float]]:
    result = {}
    for crsid, crs in crses.items():
-       if crs.valid_region is not None:
-           test_box = starting_box.to_crs("epsg:4326")
-           clipped_crs_region = (test_box & crs.valid_region)
-           if clipped_crs_region.wkt == 'POLYGON EMPTY':
-               continue
-           clipped_crs_bbox = clipped_crs_region.to_crs(crs).boundingbox
-       else:
-           clipped_crs_bbox = None
-       if clipped_crs_bbox is not None:
-           result[crsid] = jsonise_bbox(clipped_crs_bbox)
-       else:
-           projbbox = starting_box.to_crs(crs).boundingbox
-           result[crsid] = sanitise_bbox(projbbox)
+        projbbox = starting_box.to_crs(crs).boundingbox
+        result[crsid] = sanitise_bbox(projbbox)
    return result
 
 

--- a/datacube_ows/index/postgis/product_ranges.py
+++ b/datacube_ows/index/postgis/product_ranges.py
@@ -10,7 +10,6 @@ from datetime import date, datetime, timezone
 from typing import Callable
 import click
 
-from antimeridian import fix_shape
 import datacube
 import odc.geo
 import sqlalchemy.exc


### PR DESCRIPTION
Some code here was doing a similar thing to what we fixed in `datacube-core` here: https://github.com/opendatacube/datacube-core/pull/1635


<!-- readthedocs-preview datacube-ows start -->
----
📚 Documentation preview 📚: https://datacube-ows--1076.org.readthedocs.build/en/1076/

<!-- readthedocs-preview datacube-ows end -->