### PR TITLE
Only check if max_datasets is being exceeded if it's not set to 0

### DIFF
--- a/datacube_ows/resource_limits.py
+++ b/datacube_ows/resource_limits.py
@@ -188,7 +188,9 @@ class CacheControlRules(OWSConfigEntry):
         if not self.use_caching:
             return {}
         assert n_datasets >= 0
-        if n_datasets == 0 or n_datasets > self.max_datasets:
+        # If there are no datasets, don't cache. But if the max_datasets isn't 0, check
+        # we're not exceeding it, and in that case, don't cache either.
+        if n_datasets == 0 or (self.max_datasets > 0 and n_datasets > self.max_datasets):
             return cache_control_headers(0)
         rule = None
         for r in cast(list[CFG_DICT], self.rules):


### PR DESCRIPTION
This [bit of configuration](https://github.com/digitalearthafrica/config/blob/ea5234739effe5474508d291c57f1d0efb9e4711/services/ows_refactored/common/ows_reslim_cfg.py#L109C1-L109C61) in an old config file implies that the default for the `max_datasets` limit is effectively unlimited. Snippet here:

```python
reslim_continental = {
    "wms": {
        "zoomed_out_fill_colour": [150, 180, 200, 160],
        "min_zoom_factor": 10.0,
        # "max_datasets": 16, # Defaults to no dataset limit
        "dataset_cache_rules": dataset_cache_rules,
    },
    "wcs": {
        "max_datasets": 32,  # Defaults to no dataset limit
    },
}
```

But the code changed in this PR appears to not operate under that assumption.

This change aligns with the behaviour elsewhere in resource limits, e.g., in [code here](https://github.com/opendatacube/datacube-ows/blob/6ee46d195b536b3d0b6cd31d53c770d505427270/datacube_ows/resource_limits.py#L257-L258)

``` python
        if self.max_datasets_wms > 0 and n_datasets > self.max_datasets_wms:
            limits_exceeded.append("too many datasets")
```

I think this minor code change will mean caching behaves as expected when no `max_datasets` is provided in `wms` config.

<!-- readthedocs-preview datacube-ows start -->
----
📚 Documentation preview 📚: https://datacube-ows--1077.org.readthedocs.build/en/1077/

<!-- readthedocs-preview datacube-ows end -->