### PR TITLE
Fix Docker image for debugging.

### DIFF
--- a/.env_ows_root
+++ b/.env_ows_root
@@ -12,7 +12,7 @@ DB_DATABASE=opendatacube
 #################
 # OWS CFG Config
 #################
-PYTHONPATH=/env/config
+PYTHONPATH=/src/config
 DATACUBE_OWS_CFG=ows_refactored.ows_root_cfg.ows_cfg
 
 ################
@@ -21,7 +21,7 @@ DATACUBE_OWS_CFG=ows_refactored.ows_root_cfg.ows_cfg
 # OWS_CFG_DIR config enables mounting an external CFG folder
 OWS_CFG_DIR=~/dea-config/dev/services/wms/ows_refactored
 # OWS_CFG_MOUNT_DIR defines the mount inside docker container
-OWS_CFG_MOUNT_DIR=/env/config/ows_refactored
+OWS_CFG_MOUNT_DIR=/src/config/ows_refactored
 
 ################
 # AWS S3 Config

--- a/.env_simple
+++ b/.env_simple
@@ -14,7 +14,7 @@ DB_DATABASE=opendatacube
 # OWS CFG Config
 #################
 DATACUBE_OWS_CFG=config.ows_test_cfg.ows_cfg
-PYTHONPATH=/env
+PYTHONPATH=/src
 
 ################
 # Docker Volume
@@ -22,7 +22,7 @@ PYTHONPATH=/env
 # OWS_CFG_DIR config enables mounting an external CFG folder
 OWS_CFG_DIR=./integration_tests/cfg
 # OWS_CFG_MOUNT_DIR defines the mount inside docker container
-OWS_CFG_MOUNT_DIR=/env/config
+OWS_CFG_MOUNT_DIR=/src/config
 
 ################
 # AWS S3 Config

--- a/.github/workflows/complementary-config-test.yaml
+++ b/.github/workflows/complementary-config-test.yaml
@@ -63,5 +63,5 @@ jobs:
           docker compose -f docker-compose.yaml -f docker-compose.cleandb.yaml up -d --wait
           docker compose -f docker-compose.yaml -f docker-compose.cleandb.yaml exec -T ows_18 /bin/sh -c "datacube system init; datacube system check"
           docker compose -f docker-compose.yaml -f docker-compose.cleandb.yaml exec -T ows_18 /bin/sh -c "curl https://raw.githubusercontent.com/GeoscienceAustralia/dea-config/master/dev/services/wms/inventory.json -o /tmp/inventory.json"
-          docker compose -f docker-compose.yaml -f docker-compose.db.yaml exec -T ows_18 /bin/sh -c "cd /code && ./compare-cfg.sh"
+          docker compose -f docker-compose.yaml -f docker-compose.db.yaml exec -T ows_18 /bin/sh -c "cd /src && ./compare-cfg.sh"
           docker compose -f docker-compose.yaml -f docker-compose.cleandb.yaml down

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Test and lint dev OWS image
         run: |
           mkdir artifacts
-          docker run -e LOCAL_UID=$(id -u $USER) -e LOCAL_GID=$(id -g $USER) -v ${PWD}/artifacts:/mnt/artifacts ${ORG}/${IMAGE}:_builder /bin/sh -c "cd /code && ./check-code.sh"
+          docker run -e LOCAL_UID=$(id -u $USER) -e LOCAL_GID=$(id -g $USER) -v ${PWD}/artifacts:/mnt/artifacts ${ORG}/${IMAGE}:_builder /bin/sh -c "cd /src && ./check-code.sh"
           mv ./artifacts/coverage.xml ./artifacts/coverage-unit.xml
 
       - name: Dockerized Integration Pytest
@@ -63,7 +63,7 @@ jobs:
           export LOCAL_GID=$(id -g $USER)
           export $(grep -v '^#' .env_simple | xargs)
           docker compose -f docker-compose.yaml -f docker-compose.db.yaml up -d --wait --build
-          docker compose -f docker-compose.yaml -f docker-compose.db.yaml exec -T ows_18 /bin/sh -c "cd /code && ./check-code-all.sh"
+          docker compose -f docker-compose.yaml -f docker-compose.db.yaml exec -T ows_18 /bin/sh -c "cd /src && ./check-code-all.sh"
           docker compose -f docker-compose.yaml -f docker-compose.db.yaml down
 
       - name: Upload All coverage to Codecov

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
     && ([ "$ENVIRONMENT" = "deployment" ] || \
           apt-get install -y --no-install-recommends \
             proj-bin) \
+    && apt-get upgrade -y \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /var/dpkg/* /var/tmp/* /var/log/dpkg.log
 
@@ -47,8 +48,8 @@ RUN export DEBIAN_FRONTEND=noninteractive \
 COPY --chown=root:root --link docker/files/remap-user.sh /usr/local/bin/remap-user.sh
 
 # Copy source code and install it
-WORKDIR /code
-COPY . /code
+WORKDIR /src
+COPY . /src
 
 ## Only install pydev requirements if arg PYDEV_DEBUG is set to 'yes'
 ARG PYDEV_DEBUG="no"
@@ -62,7 +63,7 @@ RUN EXTRAS=$([ "$ENVIRONMENT" = "deployment" ] || echo ",test") && \
        python3 -m pip --disable-pip-version-check install --no-cache-dir .[dev] --break-system-packages) && \
     python3 -m pip freeze && \
     ([ "$ENVIRONMENT" != "deployment" ] || \
-       (rm -rf /code/* /code/.git* && \
+       (rm -rf /src/* /src/.git* && \
         apt-get purge -y \
            git \
            git-man \

--- a/datacube_ows/startup_utils.py
+++ b/datacube_ows/startup_utils.py
@@ -177,7 +177,7 @@ def parse_config_file(log=None):
 
 
 def initialise_flask(name):
-    app = Flask(name.split('.')[0])
+    app = Flask(name)
     return app
 
 def pass_through(undecorated):

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -10,7 +10,7 @@ services:
         - opendatacube/ows_18:_builder
     image: opendatacube/ows_18:latest
     # Uncomment for use with non-dockerised postgres (for docker-compose 1.x)
-    # network_mode: host
+    network_mode: host
     environment:
       LOCAL_UID: ${LOCAL_UID:-1000}
       LOCAL_GID: ${LOCAL_GID:-1000}
@@ -24,7 +24,7 @@ services:
       DB_USERNAME: ${DB_USERNAME}
       DB_PASSWORD: ${DB_PASSWORD}
       DB_DATABASE: ${DB_DATABASE}
-      # Path from the PYTHONPATH to the config object (default PYTHONPATH is /env)
+      # Path from the PYTHONPATH to the config object (default PYTHONPATH is /src)
       PYTHONPATH: ${PYTHONPATH}
       DATACUBE_OWS_CFG: ${DATACUBE_OWS_CFG}
       AWS_DEFAULT_REGION: ${AWS_REGION}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -10,7 +10,7 @@ services:
         - opendatacube/ows_18:_builder
     image: opendatacube/ows_18:latest
     # Uncomment for use with non-dockerised postgres (for docker-compose 1.x)
-    network_mode: host
+    # network_mode: host
     environment:
       LOCAL_UID: ${LOCAL_UID:-1000}
       LOCAL_GID: ${LOCAL_GID:-1000}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -33,13 +33,13 @@ services:
       # Enable Metrics
       prometheus_multiproc_dir: ${prometheus_multiproc_dir}
       # Dev flags
-      FLASK_APP: /code/datacube_ows/ogc.py
+      FLASK_APP: /src/datacube_ows/ogc.py
       FLASK_ENV: ${FLASK_ENV}
       PYDEV_DEBUG: "${PYDEV_DEBUG}"
       SENTRY_DSN: "${SENTRY_DSN}"
     volumes:
       - ${OWS_CFG_DIR}:${OWS_CFG_MOUNT_DIR}
-      - ./:/code/
+      - ./:/src/
       - ./artifacts:/mnt/artifacts
     restart: always
     command: ["flask", "run", "--host=0.0.0.0", "--port=8000"]

--- a/integration_tests/cfg/ows_test_cfg.py
+++ b/integration_tests/cfg/ows_test_cfg.py
@@ -12,7 +12,7 @@ if os.environ.get("DATACUBE_OWS_CFG", "").startswith("integration_tests"):
     trans_dir = "."
 else:
     cfgbase = "config."
-    trans_dir = "/code"
+    trans_dir = "/src"
 
 
 # THIS IS A TESTING FILE

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 # This file is part of datacube-ows, part of the Open Data Cube project.
 # See https://opendatacube.org for more information.
 #
-# Copyright (c) 2017-2023 OWS Contributors
+# Copyright (c) 2017-2024 OWS Contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from setuptools import find_packages, setup
@@ -49,11 +49,9 @@ test_requirements = [
 ]
 
 dev_requirements = [
-    'pydevd-pycharm~=221.5921.27', # For Pycharm 2022.1.3
-    'pylint==3.2.3',
+    'pydevd-pycharm~=242.23339.19',  # For Pycharm 2024.2.3
+    'pylint',
     'sphinx_click',
-    'pre-commit==2.13.0',
-    'pipdeptree'
 ]
 
 operational_requirements = [
@@ -115,7 +113,7 @@ Features
         'Intended Audience :: Developers',
         'License :: OSI Approved :: Apache Software License',
         'Natural Language :: English',
-        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.8',
     ],
     setup_requires=setup_requirements,
     use_scm_version={


### PR DESCRIPTION
Recent docker image changes broke debugging.  This fixes it.

Changes:

1) Call `apt-get upgrade -y`:  not strictly necessary, but seems like a good idea.
2) Change `/code` directory to `/src`.  This is the important one.  pydevd imports stuff from the standard library `code` which the `/code` directory hides.  Required some tweaks to GHAs.
3) Update to pydevd for most recent version of pycharm.
4) Other misc cleanup.
5) Remove `pipdeptree` as a dev dependency.  I can't remember why we needed it and it has pip version dependencies that cause issues because we can't upgrade the Debian-controlled pip.

This has been holding up OWS progress for ages and nearly driving me nuts.  Relieved to finally have it working again.

<!-- readthedocs-preview datacube-ows start -->
----
📚 Documentation preview 📚: https://datacube-ows--1080.org.readthedocs.build/en/1080/

<!-- readthedocs-preview datacube-ows end -->