### PR TITLE
Add proxy fix header handling for X-Forwarded-For etc.

### DIFF
--- a/datacube_ows/feature_info.py
+++ b/datacube_ows/feature_info.py
@@ -112,7 +112,7 @@ def _make_band_dict(prod_cfg: OWSNamedLayer, pixel_dataset: xarray.Dataset) -> d
 
 
 @log_call
-def _make_derived_band_dict(pixel_dataset: xarray.Dataset, style_index: dict[str, StyleDef]) -> dict[str, int | float]:
+def _make_derived_band_dict(pixel_dataset: xarray.Dataset, style_index: dict[str, StyleDef]) -> dict[str, int | float | str]:
     """Creates a dict of values for bands derived by styles.
     This only works for styles with an `index_function` defined.
 

--- a/datacube_ows/ogc.py
+++ b/datacube_ows/ogc.py
@@ -12,13 +12,28 @@ from flask import g, render_template, request
 from sqlalchemy import text
 
 from datacube_ows import __version__
-from datacube_ows.http_utils import (capture_headers, get_service_base_url,
-                                     lower_get_args, resp_headers)
+from datacube_ows.http_utils import (
+    capture_headers,
+    get_service_base_url,
+    lower_get_args,
+    resp_headers,
+)
 from datacube_ows.legend_generator import create_legend_for_style
 from datacube_ows.ogc_exceptions import OGCException, WMSException
 from datacube_ows.ows_configuration import get_config
 from datacube_ows.protocol_versions import supported_versions
-from datacube_ows.startup_utils import *  # pylint: disable=wildcard-import,unused-wildcard-import
+from datacube_ows.startup_utils import (
+    initialise_aws_credentials,
+    initialise_babel,
+    initialise_debugging,
+    initialise_flask,
+    initialise_ignorable_warnings,
+    initialise_logger,
+    initialise_prometheus,
+    initialise_sentry,
+    parse_config_file,
+    proxy_fix,
+)
 from datacube_ows.wcs1 import WCS_REQUESTS
 from datacube_ows.wms import WMS_REQUESTS
 
@@ -42,6 +57,9 @@ babel = initialise_babel(cfg, app)
 # Initialisation of external libraries that depend on Flask
 # (controlled by environment variables)
 metrics = initialise_prometheus(app, _LOG)
+
+# Add middleware to fix proxy headers, controlled by environment variables
+app = proxy_fix(app, _LOG)
 
 # Protocol/Version lookup table
 OWS_SUPPORTED = supported_versions()

--- a/datacube_ows/startup_utils.py
+++ b/datacube_ows/startup_utils.py
@@ -210,6 +210,15 @@ def initialise_prometheus(app, log=None):
         return metrics
     return FakeMetrics()
 
+def proxy_fix(app, log=None):
+    # Proxy Fix, to respect X-Forwarded-For headers
+    if os.environ.get("PROXY_FIX", False):
+        from werkzeug.middleware.proxy_fix import ProxyFix
+        app.wsgi_app = ProxyFix(app.wsgi_app, x_for=1, x_proto=1, x_host=1, x_port=1)
+        if log is not None:
+            log.info("ProxyFix was enabled")
+    return app
+
 def request_extractor():
     qreq = request.args.get('request')
     return qreq

--- a/docs/environment_variables.rst
+++ b/docs/environment_variables.rst
@@ -118,7 +118,7 @@ prometheus_multiproc_dir:
 
 PROXY_FIX:
     If ``$PROXY_FIX`` is set to "true", "yes", "on" or "1", the Flask application will trust the
-    X-Forwarded-For and X-Forwarded-Proto headers from a proxy server.
+    X-Forwarded-For and other headers from a proxy server.
 
     This is useful when running behind a reverse proxy server such as Nginx or CloudFront.
 

--- a/docs/environment_variables.rst
+++ b/docs/environment_variables.rst
@@ -116,6 +116,14 @@ prometheus_multiproc_dir:
     The `Prometheus event monitoring system <https://prometheus.io>`_ is activated by
     setting this lower case environment variable.
 
+PROXY_FIX:
+    If ``$PROXY_FIX`` is set to "true", "yes", "on" or "1", the Flask application will trust the
+    X-Forwarded-For and X-Forwarded-Proto headers from a proxy server.
+
+    This is useful when running behind a reverse proxy server such as Nginx or CloudFront.
+
+    NEVER use in production without a reverse proxy server.
+
 Dev Tools
 ---------
 


### PR DESCRIPTION
This is a low-risk and high-reward feature that adds another environment variable that turns on the "proxy_fix" middleware, which ensures the app understands what URLs it should return as part of the getCaps and other responses.

Tested in production for DE Pacific.

<!-- readthedocs-preview datacube-ows start -->
----
📚 Documentation preview 📚: https://datacube-ows--1085.org.readthedocs.build/en/1085/

<!-- readthedocs-preview datacube-ows end -->