### PR TITLE
CI: cancel ongoing jobs on PR update

### DIFF
--- a/.github/workflows/complementary-config-test.yaml
+++ b/.github/workflows/complementary-config-test.yaml
@@ -30,6 +30,12 @@ env:
   ORG: opendatacube
   IMAGE: ows
 
+# When a PR is updated, cancel the jobs from the previous version. Merges
+# do not define head_ref, so use run_id to never cancel those jobs.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   dea-config:
     runs-on: ubuntu-latest

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -19,6 +19,12 @@ env:
   ORG: opendatacube
   IMAGE: ows
 
+# When a PR is updated, cancel the jobs from the previous version. Merges
+# do not define head_ref, so use run_id to never cancel those jobs.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   docker:
     runs-on: ubuntu-latest

--- a/.github/workflows/dockerfile-lint.yml
+++ b/.github/workflows/dockerfile-lint.yml
@@ -17,6 +17,12 @@ on:
       - '.github/workflows/dockerfile-lint.yml'
 
 
+# When a PR is updated, cancel the jobs from the previous version. Merges
+# do not define head_ref, so use run_id to never cancel those jobs.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   dockerfile-lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/docpreview.yaml
+++ b/.github/workflows/docpreview.yaml
@@ -9,6 +9,12 @@ on:
 permissions:
   pull-requests: write
 
+# When a PR is updated, cancel the jobs from the previous version. Merges
+# do not define head_ref, so use run_id to never cancel those jobs.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
 
   documentation-preview:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,6 +26,12 @@ on:
       - '!.github/**'
       - '.github/workflows/lint.yml'
 
+# When a PR is updated, cancel the jobs from the previous version. Merges
+# do not define head_ref, so use run_id to never cancel those jobs.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   pylint:
     runs-on: ubuntu-latest

--- a/.github/workflows/pyspy-profiling.yaml
+++ b/.github/workflows/pyspy-profiling.yaml
@@ -26,6 +26,12 @@ on:
       - '!.github/**'
       - '.github/workflows/pyspy-profiling.yaml'
 
+# When a PR is updated, cancel the jobs from the previous version. Merges
+# do not define head_ref, so use run_id to never cancel those jobs.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -22,6 +22,12 @@ on:
 env:
   IMAGE_NAME: opendatacube/ows
 
+# When a PR is updated, cancel the jobs from the previous version. Merges
+# do not define head_ref, so use run_id to never cancel those jobs.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   cve-scanner:
     runs-on: ubuntu-latest

--- a/.github/workflows/spellcheck.yaml
+++ b/.github/workflows/spellcheck.yaml
@@ -19,6 +19,12 @@ on:
       - '*.md'
       - '.github/workflows/spellcheck.yaml'
 
+# When a PR is updated, cancel the jobs from the previous version. Merges
+# do not define head_ref, so use run_id to never cancel those jobs.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
 
   pyspellcheck:

--- a/.github/workflows/test-prod.yaml
+++ b/.github/workflows/test-prod.yaml
@@ -30,6 +30,12 @@ env:
   ORG: opendatacube
   IMAGE: ows
 
+# When a PR is updated, cancel the jobs from the previous version. Merges
+# do not define head_ref, so use run_id to never cancel those jobs.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   prod-docker-compose-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,6 +30,12 @@ env:
   ORG: opendatacube
   IMAGE: ows_18
 
+# When a PR is updated, cancel the jobs from the previous version. Merges
+# do not define head_ref, so use run_id to never cancel those jobs.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   unit-integration-performance-tests:
     runs-on: ubuntu-latest

--- a/wordlist.txt
+++ b/wordlist.txt
@@ -92,6 +92,7 @@ coverages
 cp
 createdb
 credentialling
+christophfriedrich
 crs
 crss
 CRSs
@@ -263,6 +264,7 @@ multiproduct
 mv
 mysecretpassword
 namespace
+NaNs
 natively
 ncols
 ndays


### PR DESCRIPTION
This cancels the running CI jobs
when a PR gets updated, so the CI
runners aren't occupied on testing
something that is no longer relevant.

<!-- readthedocs-preview datacube-ows start -->
----
📚 Documentation preview 📚: https://datacube-ows--1091.org.readthedocs.build/en/1091/

<!-- readthedocs-preview datacube-ows end -->