### PR TITLE
dependabot: fix target branch names

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,9 +4,9 @@ updates:
   directory: "/"
   schedule:
     interval: "daily"
-  target-branch: "master"
+  target-branch: "develop"
 - package-ecosystem: docker
   directory: "/"
   schedule:
     interval: "daily"
-  target-branch: "master"
+  target-branch: "develop"


### PR DESCRIPTION


<!-- readthedocs-preview datacube-ows start -->
----
📚 Documentation preview 📚: https://datacube-ows--1101.org.readthedocs.build/en/1101/

<!-- readthedocs-preview datacube-ows end -->