### PR TITLE
CI: fix complementary config test

### DIFF
--- a/complementary_config_test/.env_complementary_config_dea_dev
+++ b/complementary_config_test/.env_complementary_config_dea_dev
@@ -3,11 +3,17 @@
 ################
 # ODC DB Config
 # ##############
-DB_HOSTNAME=postgres
-DB_PORT=5434
-DB_USERNAME=opendatacubeusername
-DB_PASSWORD=opendatacubepassword
-DB_DATABASE=opendatacube
+ODC_DEFAULT_DB_URL=postgresql://opendatacubeusername:opendatacubepassword@postgres:5432/odc_postgres
+ODC_OWSPOSTGIS_DB_URL=postgresql://opendatacubeusername:opendatacubepassword@postgres:5432/odc_postgis
+
+# Needed for Docker db image and db readiness probe.
+POSTGRES_HOSTNAME=postgres
+POSTGRES_PORT=5434
+POSTGRES_USER=opendatacubeusername
+SERVER_DB_USERNAME=opendatacubeusername
+POSTGRES_PASSWORD=opendatacubepassword
+POSTGRES_DB="odc_postgres,odc_postgis"
+READY_PROBE_DB=odc_postgis
 
 #################
 # OWS CFG Config

--- a/docker-compose.cleandb.yaml
+++ b/docker-compose.cleandb.yaml
@@ -4,11 +4,12 @@ services:
     image: kartoza/postgis:16
     hostname: postgres
     environment:
-      - POSTGRES_DB=${DB_DATABASE}
-      - POSTGRES_PASSWORD=${DB_PASSWORD}
-      - POSTGRES_USER=${DB_USERNAME}
+      - POSTGRES_DB
+      - POSTGRES_PORT
+      - POSTGRES_PASSWORD
+      - POSTGRES_USER
     ports:
-      - "${DB_PORT}:5432"
+      - "${POSTGRES_PORT}:5432"
     restart: always
     healthcheck:
       test: ["CMD", "pg_isready", "-h", "postgres", "-q", "-d", "$POSTGRES_DB", "-U", "$POSTGRES_USER"]
@@ -20,7 +21,7 @@ services:
     ports:
       - 8000:8000
     environment:
-      DB_PORT: 5432
+      POSTGRES_PORT: 5432
     depends_on:
       postgres:
         condition: service_healthy


### PR DESCRIPTION
This mirrors commit 1c22b2c0a
for the complementary config
test.

<!-- readthedocs-preview datacube-ows start -->
----
📚 Documentation preview 📚: https://datacube-ows--1106.org.readthedocs.build/en/1106/

<!-- readthedocs-preview datacube-ows end -->