### PR TITLE
CI: disable progress meter

### DIFF
--- a/.github/workflows/complementary-config-test.yaml
+++ b/.github/workflows/complementary-config-test.yaml
@@ -68,7 +68,7 @@ jobs:
           export LOCAL_GID=$(id -g $USER)
           cd ./datacube-ows
           export $(grep -v '^#' ./complementary_config_test/.env_complementary_config_dea_dev | xargs)
-          docker compose -f docker-compose.yaml -f docker-compose.cleandb.yaml up -d --wait
+          docker compose -f docker-compose.yaml -f docker-compose.cleandb.yaml up --quiet-pull -d --wait
           docker compose -f docker-compose.yaml -f docker-compose.cleandb.yaml exec -T ows /bin/sh -c "datacube system init; datacube system check"
           docker compose -f docker-compose.yaml -f docker-compose.cleandb.yaml exec -T ows /bin/sh -c "curl https://raw.githubusercontent.com/GeoscienceAustralia/dea-config/master/dev/services/wms/inventory.json -o /tmp/inventory.json"
           docker compose -f docker-compose.yaml -f docker-compose.db.yaml exec -T ows /bin/sh -c "cd /src && ./compare-cfg.sh"

--- a/.github/workflows/pyspy-profiling.yaml
+++ b/.github/workflows/pyspy-profiling.yaml
@@ -50,7 +50,7 @@ jobs:
         export LOCAL_UID=$(id -u $USER)
         export LOCAL_GID=$(id -g $USER)
         export $(grep -v '^#' .env_simple | xargs)
-        docker compose -f docker-compose.yaml -f docker-compose.db.yaml -f docker-compose.pyspy.yaml up -d
+        docker compose -f docker-compose.yaml -f docker-compose.db.yaml -f docker-compose.pyspy.yaml up --quiet-pull -d
 
     - name: Sleep for 10 seconds (stage 1 - wait for services to be ready)
       uses: whatnick/wait-action@master

--- a/.github/workflows/test-prod.yaml
+++ b/.github/workflows/test-prod.yaml
@@ -65,7 +65,7 @@ jobs:
           export LOCAL_UID=$(id -u $USER)
           export LOCAL_GID=$(id -g $USER)
           export $(grep -v '^#' .env_simple | xargs)
-          docker compose -f docker-compose.yaml -f docker-compose.db.yaml -f docker-compose.prod.yaml up -d --wait
+          docker compose -f docker-compose.yaml -f docker-compose.db.yaml -f docker-compose.prod.yaml up --quiet-pull -d --wait
 
       # Run some tests on the images
       # These tests require a working database

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,7 +70,7 @@ jobs:
           export LOCAL_UID=$(id -u $USER)
           export LOCAL_GID=$(id -g $USER)
           export $(grep -v '^#' .env_simple | xargs)
-          docker compose -f docker-compose.yaml -f docker-compose.db.yaml up -d --wait --build
+          docker compose -f docker-compose.yaml -f docker-compose.db.yaml up --quiet-pull -d --wait --build
           docker compose -f docker-compose.yaml -f docker-compose.db.yaml exec -T ows /bin/sh -c "cd /src && ./check-code-all.sh"
           docker compose -f docker-compose.yaml -f docker-compose.db.yaml down
 


### PR DESCRIPTION
This avoids flooding the CI logs
with a progress meter when the postgis
image is downloaded.

<!-- readthedocs-preview datacube-ows start -->
----
📚 Documentation preview 📚: https://datacube-ows--1107.org.readthedocs.build/en/1107/

<!-- readthedocs-preview datacube-ows end -->