### PR TITLE
wsgi: use 1.9 config variable name

### DIFF
--- a/datacube_ows/wsgi.py
+++ b/datacube_ows/wsgi.py
@@ -13,7 +13,7 @@ import sys
 sys.path.append("/opt")
 
 # The location of the datcube config file.
-os.environ.setdefault("DATACUBE_CONFIG_PATH", "/opt/odc/.datacube.conf.local")
+os.environ.setdefault("ODC_CONFIG_PATH", "/opt/odc/.datacube.conf.local")
 
 from datacube_ows import __version__
 


### PR DESCRIPTION
The behavior is different when this variable
contains a list of paths, but that
is not the case here, so just replace
the old variable with the new variable.

<!-- readthedocs-preview datacube-ows start -->
----
📚 Documentation preview 📚: https://datacube-ows--1110.org.readthedocs.build/en/1110/

<!-- readthedocs-preview datacube-ows end -->