### PR TITLE
ramp: temporarily ignore type error

### DIFF
--- a/datacube_ows/styles/ramp.py
+++ b/datacube_ows/styles/ramp.py
@@ -248,8 +248,9 @@ class ColorRamp:
             "alpha": a
         }
 
+    # FIXME: this function can also return float64.
     def get_value(self, data: float | DataArray, band: str) -> numpy.ndarray:
-        return numpy.interp(data, self.values, self.components[band])
+        return numpy.interp(data, self.values, self.components[band])  # type: ignore[return-value]
 
     def get_8bit_value(self, data: DataArray, band: str) -> numpy.ndarray:
         val: numpy.ndarray = self.get_value(data, band)


### PR DESCRIPTION
Make the CI green again by ignoring
the type error.

Refs #1109

<!-- readthedocs-preview datacube-ows start -->
----
📚 Documentation preview 📚: https://datacube-ows--1112.org.readthedocs.build/en/1112/

<!-- readthedocs-preview datacube-ows end -->