### PR TITLE
Use non-deprecated PROMETHEUS_MULTIPROC_DIR

### DIFF
--- a/.env_ows_root
+++ b/.env_ows_root
@@ -38,5 +38,5 @@ PYDEV_DEBUG=
 # Will not work with pydev
 # Note that FLASK_ENV is now deprecated.
 FLASK_DEBUG=
-prometheus_multiproc_dir=/tmp
+PROMETHEUS_MULTIPROC_DIR=/tmp
 SENTRY_DSN=

--- a/.env_simple
+++ b/.env_simple
@@ -44,5 +44,5 @@ PYDEV_DEBUG=
 # Will not work with pydev
 # Note FLASK_ENV is now deprecated.
 FLASK_DEBUG=
-prometheus_multiproc_dir=/tmp
+PROMETHEUS_MULTIPROC_DIR=/tmp
 SENTRY_DSN=

--- a/complementary_config_test/.env_complementary_config_dea_dev
+++ b/complementary_config_test/.env_complementary_config_dea_dev
@@ -44,5 +44,5 @@ PYDEV_DEBUG=
 # Will not work with pydev
 # Note that FLASK_ENV is now deprecated.
 FLASK_DEBUG=
-prometheus_multiproc_dir=/tmp
+PROMETHEUS_MULTIPROC_DIR=/tmp
 SENTRY_DSN=

--- a/datacube_ows/gunicorn_config.py
+++ b/datacube_ows/gunicorn_config.py
@@ -13,5 +13,5 @@ from prometheus_flask_exporter.multiprocess import \
 
 
 def child_exit(server, worker):
-    if os.environ.get("prometheus_multiproc_dir", False):
+    if os.environ.get("PROMETHEUS_MULTIPROC_DIR", False):
         GunicornInternalPrometheusMetrics.mark_process_dead_on_child_exit(worker.pid)

--- a/datacube_ows/startup_utils.py
+++ b/datacube_ows/startup_utils.py
@@ -202,7 +202,7 @@ class FakeMetrics:
 
 def initialise_prometheus(app, log=None):
     # Prometheus
-    if os.environ.get("prometheus_multiproc_dir", False):
+    if os.environ.get("PROMETHEUS_MULTIPROC_DIR", False):
         from prometheus_flask_exporter.multiprocess import \
             GunicornInternalPrometheusMetrics
         metrics = GunicornInternalPrometheusMetrics(app, group_by="endpoint")

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -39,7 +39,7 @@ services:
       # Talk to AWS without using credentials
       AWS_NO_SIGN_REQUEST: "${AWS_NO_SIGN_REQUEST}"
       # Enable Metrics
-      prometheus_multiproc_dir: ${prometheus_multiproc_dir}
+      PROMETHEUS_MULTIPROC_DIR: ${PROMETHEUS_MULTIPROC_DIR}
       # Dev flags
       FLASK_APP: /src/datacube_ows/ogc.py
       FLASK_ENV: ${FLASK_ENV}

--- a/docs/environment_variables.rst
+++ b/docs/environment_variables.rst
@@ -112,9 +112,9 @@ SENTRY_DSN:
     system is activated and configured with the ``$SENTRY_DSN``
     environment variables.
 
-prometheus_multiproc_dir:
+PROMETHEUS_MULTIPROC_DIR:
     The `Prometheus event monitoring system <https://prometheus.io>`_ is activated by
-    setting this lower case environment variable.
+    setting this environment variable.
 
 PROXY_FIX:
     If ``$PROXY_FIX`` is set to "true", "yes", "on" or "1", the Flask application will trust the

--- a/tests/test_startup.py
+++ b/tests/test_startup.py
@@ -111,7 +111,7 @@ def test_initialise_sentry(monkeypatch):
 
 
 def test_prometheus_inactive(monkeypatch):
-    monkeypatch.setenv("prometheus_multiproc_dir", "")
+    monkeypatch.setenv("PROMETHEUS_MULTIPROC_DIR", "")
     from datacube_ows.startup_utils import initialise_prometheus
     initialise_prometheus(None)
 


### PR DESCRIPTION
The variable has been renamed to
the upper case variable with the same
name, so switch to using that name.
This fixes some deprecation warnings
in the tests.

<!-- readthedocs-preview datacube-ows start -->
----
📚 Documentation preview 📚: https://datacube-ows--1115.org.readthedocs.build/en/1115/

<!-- readthedocs-preview datacube-ows end -->