### PR TITLE
Update to Python 3.10 syntax

### DIFF
--- a/datacube_ows/band_utils.py
+++ b/datacube_ows/band_utils.py
@@ -4,8 +4,6 @@
 # Copyright (c) 2017-2024 OWS Contributors
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import division
-
 import numpy
 
 # Style index functions

--- a/datacube_ows/cfg_parser_impl.py
+++ b/datacube_ows/cfg_parser_impl.py
@@ -238,7 +238,7 @@ def translation(languages: list[str], msg_file: str | None, new: bool,
     try:
         fp = open(msg_file, "rb")
         fp.close()
-    except IOError:
+    except OSError:
         click.echo("Message file {msg_file} does not exist or cannot be read.")
         sys.exit(1)
     for language in languages:

--- a/datacube_ows/config_utils.py
+++ b/datacube_ows/config_utils.py
@@ -9,7 +9,8 @@ import logging
 import os
 from importlib import import_module
 from itertools import chain
-from typing import Any, Callable, Iterable, Optional, Sequence, cast
+from typing import Any, Optional, cast
+from collections.abc import Callable, Iterable, Sequence
 from urllib.parse import urlparse
 
 import fsspec
@@ -649,7 +650,7 @@ class OWSFlagBandStandalone:
         self.pq_names: list[str] = []
         self.pq_ignore_time = False
         self.pq_manual_merge = False
-        self.pq_fuse_func: Optional[FunctionWrapper] = None
+        self.pq_fuse_func: FunctionWrapper | None = None
 
 
 class OWSFlagBand(OWSConfigEntry):
@@ -674,7 +675,7 @@ class OWSFlagBand(OWSConfigEntry):
         self.pq_band = str(cfg["band"])
         self.canonical_band_name = self.pq_band # Update for aliasing on make_ready
         if "fuse_func" in cfg:
-            self.pq_fuse_func: Optional[FunctionWrapper] = FunctionWrapper(self.layer, cast(CFG_DICT, cfg["fuse_func"]))
+            self.pq_fuse_func: FunctionWrapper | None = FunctionWrapper(self.layer, cast(CFG_DICT, cfg["fuse_func"]))
         else:
             self.pq_fuse_func = None
         self.pq_ignore_time = bool(cfg.get("ignore_time", False))
@@ -824,7 +825,7 @@ class FlagProductBands(OWSConfigEntry):
         :param layer: A named layer object
         :return: A list of FlagProductBands objects
         """
-        flag_products: list["FlagProductBands"] = []
+        flag_products: list[FlagProductBands] = []
         for mask in masks:
             handled = False
             for fp in flag_products:
@@ -848,7 +849,7 @@ class FlagProductBands(OWSConfigEntry):
         :param layer: A named layer object
         :return: A list of FlagProductBands objects
         """
-        flag_products: list["FlagProductBands"] = []
+        flag_products: list[FlagProductBands] = []
         for fb in flagbands:
             handled = False
             for fp in flag_products:

--- a/datacube_ows/feature_info.py
+++ b/datacube_ows/feature_info.py
@@ -8,7 +8,8 @@ import logging
 import re
 from datetime import datetime
 from itertools import chain
-from typing import cast, Iterable
+from typing import cast
+from collections.abc import Iterable
 
 import numpy
 import xarray

--- a/datacube_ows/index/api.py
+++ b/datacube_ows/index/api.py
@@ -7,7 +7,8 @@
 import dataclasses
 from abc import ABC, abstractmethod
 from datetime import datetime, date
-from typing import NamedTuple, Iterable, Type
+from typing import NamedTuple
+from collections.abc import Iterable
 from uuid import UUID
 
 from datacube import Datacube
@@ -180,7 +181,7 @@ class OWSAbstractIndex(ABC):
 class OWSAbstractIndexDriver(ABC):
     @classmethod
     @abstractmethod
-    def ows_index_class(cls) -> Type[OWSAbstractIndex]:
+    def ows_index_class(cls) -> type[OWSAbstractIndex]:
         ...
 
     @classmethod

--- a/datacube_ows/index/postgis/api.py
+++ b/datacube_ows/index/postgis/api.py
@@ -8,7 +8,8 @@ import click
 import datetime
 
 from threading import Lock
-from typing import Any, Iterable, Type
+from typing import Any
+from collections.abc import Iterable
 from uuid import UUID
 
 from odc.geo import Geometry, CRS
@@ -151,7 +152,7 @@ pgisdriverlock = Lock()
 class OWSPostgisIndexDriver(OWSAbstractIndexDriver):
     _driver = None
     @classmethod
-    def ows_index_class(cls) -> Type[OWSAbstractIndex]:
+    def ows_index_class(cls) -> type[OWSAbstractIndex]:
         return OWSPostgisIndex
 
     @classmethod

--- a/datacube_ows/index/postgis/product_ranges.py
+++ b/datacube_ows/index/postgis/product_ranges.py
@@ -7,7 +7,7 @@
 import logging
 import math
 from datetime import date, datetime, timezone
-from typing import Callable
+from collections.abc import Callable
 import click
 
 import datacube

--- a/datacube_ows/index/postgres/api.py
+++ b/datacube_ows/index/postgres/api.py
@@ -7,7 +7,8 @@
 import click
 
 from threading import Lock
-from typing import cast, Iterable, Type
+from typing import cast
+from collections.abc import Iterable
 from uuid import UUID
 
 from odc.geo import Geometry, CRS
@@ -107,7 +108,7 @@ pgdriverlock = Lock()
 class OWSPostgresIndexDriver(OWSAbstractIndexDriver):
     _driver = None
     @classmethod
-    def ows_index_class(cls) -> Type[OWSAbstractIndex]:
+    def ows_index_class(cls) -> type[OWSAbstractIndex]:
         return OWSPostgresIndex
 
     @classmethod

--- a/datacube_ows/index/postgres/mv_index.py
+++ b/datacube_ows/index/postgres/mv_index.py
@@ -8,7 +8,8 @@ import datetime
 import json
 from enum import Enum
 from types import UnionType
-from typing import Iterable, Type, cast
+from typing import cast
+from collections.abc import Iterable
 from uuid import UUID as UUID_
 
 import pytz
@@ -74,7 +75,7 @@ class MVSelectOpts(Enum):
         raise AssertionError("Invalid selection option")
 
 
-selection_return_types: dict[MVSelectOpts, Type | UnionType] = {
+selection_return_types: dict[MVSelectOpts, type | UnionType] = {
     MVSelectOpts.ALL: Iterable[Row],
     MVSelectOpts.IDS: Iterable[UUID_],
     MVSelectOpts.DATASETS: Iterable[Dataset],

--- a/datacube_ows/index/postgres/product_ranges.py
+++ b/datacube_ows/index/postgres/product_ranges.py
@@ -8,7 +8,8 @@ import logging
 import math
 import click
 from datetime import date, datetime, timezone
-from typing import cast, Callable
+from typing import cast
+from collections.abc import Callable
 
 import datacube
 import odc.geo

--- a/datacube_ows/legend_utils.py
+++ b/datacube_ows/legend_utils.py
@@ -6,8 +6,6 @@
 
 import io
 import logging
-from typing import Optional
-
 import requests
 from PIL import Image
 
@@ -16,7 +14,7 @@ from datacube_ows.ogc_exceptions import WMSException
 _LOG = logging.getLogger(__name__)
 
 
-def get_image_from_url(url: str) -> Optional[Image.Image]:
+def get_image_from_url(url: str) -> Image.Image | None:
     """
     Fetch image a png from external URL, and return it as an Image.
 

--- a/datacube_ows/loading.py
+++ b/datacube_ows/loading.py
@@ -7,7 +7,8 @@
 import datetime
 import logging
 from collections import OrderedDict
-from typing import Iterable, Mapping, cast
+from typing import cast
+from collections.abc import Iterable, Mapping
 from uuid import UUID
 
 import datacube
@@ -41,7 +42,7 @@ class ProductBandQuery:
         self.ignore_time = ignore_time
         self.main = main
         self.key = (
-            tuple((p.id for p in self.products)),
+            tuple(p.id for p in self.products),
             tuple(bands)
         )
 

--- a/datacube_ows/ows_configuration.py
+++ b/datacube_ows/ows_configuration.py
@@ -19,7 +19,8 @@ import os
 from collections.abc import Mapping
 from enum import Enum
 from importlib import import_module
-from typing import Any, Iterable, Optional, Union, cast
+from typing import Any, Optional, Union, cast
+from collections.abc import Iterable
 
 import numpy
 from babel.messages.catalog import Catalog
@@ -249,7 +250,7 @@ class OWSLayer(OWSMetadataConfig):
     def __init__(self, cfg: CFG_DICT, object_label: str, parent_layer: Optional["OWSLayer"]=None, **kwargs):
         super().__init__(cfg, **kwargs)
         self.object_label = object_label
-        self.global_cfg: "OWSConfig" = kwargs["global_cfg"]
+        self.global_cfg: OWSConfig = kwargs["global_cfg"]
         self.parent_layer = parent_layer
         self._cached_local_env: ODCEnvironment | None = None
         self._cached_dc: Datacube | None = None
@@ -1252,7 +1253,7 @@ class OWSConfig(OWSMetadataConfig):
     METADATA_CONTACT_INFO = True
 
     @property
-    def default_abstract(self) -> Optional[str]:
+    def default_abstract(self) -> str | None:
         return ""
 
     @property

--- a/datacube_ows/protocol_versions.py
+++ b/datacube_ows/protocol_versions.py
@@ -6,7 +6,7 @@
 
 
 import re
-from typing import Callable, Mapping, Sequence, Tuple
+from collections.abc import Callable, Mapping, Sequence
 
 from datacube_ows.ogc_exceptions import (OGCException, WCS1Exception,
                                          WCS2Exception, WMSException,
@@ -17,7 +17,7 @@ from datacube_ows.wcs2 import handle_wcs2
 from datacube_ows.wms import handle_wms
 from datacube_ows.wmts import handle_wmts
 
-FlaskResponse = Tuple
+FlaskResponse = tuple
 FlaskHandler = Callable[[Mapping[str, str]], FlaskResponse]
 
 

--- a/datacube_ows/resource_limits.py
+++ b/datacube_ows/resource_limits.py
@@ -5,7 +5,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import math
-from typing import Any, Iterable, Mapping, cast
+from typing import Any, cast
+from collections.abc import Iterable, Mapping
 
 import affine
 import numpy as np

--- a/datacube_ows/styles/base.py
+++ b/datacube_ows/styles/base.py
@@ -6,8 +6,8 @@
 
 import io
 import logging
-from typing import (Any, Iterable, Mapping, MutableMapping, Optional, Sized,
-                    Type, Union, cast)
+from typing import Any, Optional, Union, cast
+from collections.abc import Iterable, Mapping, MutableMapping, Sized
 
 import datacube.model
 import numpy as np
@@ -111,11 +111,11 @@ class StyleDefBase(OWSExtensibleConfigEntry, OWSMetadataConfig):
 
     # For OWSMetaDataConfig
     @property
-    def default_title(self) -> Optional[str]:
+    def default_title(self) -> str | None:
         return "Stand-Alone Style"
 
     @property
-    def default_abstract(self) -> Optional[str]:
+    def default_abstract(self) -> str | None:
         return "Stand-Alone Style"
 
     # Over-ridden by subclasses that support auto-legends
@@ -124,7 +124,7 @@ class StyleDefBase(OWSExtensibleConfigEntry, OWSMetadataConfig):
     include_in_feature_info: bool = False
 
     def __new__(cls, product: Optional["datacube_ows.ows_configuration.OWSNamedLayer"] = None,
-                style_cfg: Optional[CFG_DICT] = None,
+                style_cfg: CFG_DICT | None = None,
                 stand_alone: bool = False,
                 defer_multi_date: bool = False,
                 user_defined: bool = False) -> "StyleDefBase":
@@ -183,7 +183,7 @@ class StyleDefBase(OWSExtensibleConfigEntry, OWSMetadataConfig):
         self.local_band_map = cast(MutableMapping[str, str], raw_cfg.get("band_map", {}))
         if self.local_band_map:
             pass
-        self.product: "datacube_ows.ows_configuration.OWSNamedLayer" = product
+        self.product: datacube_ows.ows_configuration.OWSNamedLayer = product
         if self.stand_alone:
             self.name = cast(str, raw_cfg.get("name", "stand_alone"))
         else:
@@ -296,7 +296,7 @@ class StyleDefBase(OWSExtensibleConfigEntry, OWSMetadataConfig):
 
     def parse_multi_date(self, cfg: CFG_DICT) -> None:
         """Used by __init__()"""
-        self.multi_date_handlers: list["StyleDefBase.MultiDateHandler"] = []
+        self.multi_date_handlers: list[StyleDefBase.MultiDateHandler] = []
         for mb_cfg in cast(list[CFG_DICT], cfg.get("multi_date", [])):
             self.multi_date_handlers.append(self.MultiDateHandler(self, mb_cfg))
 
@@ -329,7 +329,7 @@ class StyleDefBase(OWSExtensibleConfigEntry, OWSMetadataConfig):
                 result = result & mask_data
         return result
 
-    def apply_mask_to_image(self, img_data: xr.Dataset, mask: Optional[xr.DataArray],
+    def apply_mask_to_image(self, img_data: xr.Dataset, mask: xr.DataArray | None,
                             input_date_count: int, output_date_count: int) -> xr.Dataset:
         """
         Apply a mask to an image xarray.
@@ -353,7 +353,7 @@ class StyleDefBase(OWSExtensibleConfigEntry, OWSMetadataConfig):
             alpha = img_data.alpha
         if mask is not None:
             if output_date_count == 1 and input_date_count > 1:
-                flat_mask: Optional[xr.DataArray] = None
+                flat_mask: xr.DataArray | None = None
                 for coord in mask.coords["time"].values:
                     mask_slice = mask.sel(time=coord)
                     if flat_mask is None:
@@ -365,7 +365,7 @@ class StyleDefBase(OWSExtensibleConfigEntry, OWSMetadataConfig):
         img_data = img_data.assign({"alpha": alpha})
         return img_data
 
-    def transform_data(self, data: xr.Dataset, mask: Optional[xr.DataArray]) -> xr.Dataset:
+    def transform_data(self, data: xr.Dataset, mask: xr.DataArray | None) -> xr.Dataset:
         """
         Apply style to raw data to make an RGBA image xarray (time aware-ish)
 
@@ -408,7 +408,7 @@ class StyleDefBase(OWSExtensibleConfigEntry, OWSMetadataConfig):
         if not legend.show_legend:
             return None
         if legend.legend_urls:
-            locale: Optional[str] = None
+            locale: str | None = None
             if self.global_config().internationalised:
                 locale = get_locale().language
             if locale not in self.global_config().locales:
@@ -459,7 +459,7 @@ class StyleDefBase(OWSExtensibleConfigEntry, OWSMetadataConfig):
         raise WMSException(f"Style {self.name} does not support requests with {count} dates")
 
     @classmethod
-    def register_subclass(cls, subclass: Type["StyleDefBase"], triggers: Iterable[str], priority: bool = False) -> None:
+    def register_subclass(cls, subclass: type["StyleDefBase"], triggers: Iterable[str], priority: bool = False) -> None:
         """
         Register a subclass with the base class
 
@@ -475,7 +475,7 @@ class StyleDefBase(OWSExtensibleConfigEntry, OWSMetadataConfig):
             style_class_reg.append((subclass, triggers))
 
     @classmethod
-    def determine_subclass(cls, cfg: CFG_DICT) -> Optional[Type["StyleDefBase"]]:
+    def determine_subclass(cls, cfg: CFG_DICT) -> type["StyleDefBase"] | None:
         """
         Determine the subclass to use from a raw configuration
         :param cfg: The configuration for some StyleDef subclass
@@ -582,7 +582,7 @@ class StyleDefBase(OWSExtensibleConfigEntry, OWSMetadataConfig):
     def lookup_impl(cls,
                     cfg: "datacube_ows.ows_configuration.OWSConfig",
                     keyvals: Mapping[str, Any],
-                    subs: Optional[Mapping[str, Any]] = None) -> OWSIndexedConfigEntry:
+                    subs: Mapping[str, Any] | None = None) -> OWSIndexedConfigEntry:
         """
         Lookup a config entry of this type by identifying label(s)
 
@@ -610,8 +610,8 @@ class StyleDefBase(OWSExtensibleConfigEntry, OWSMetadataConfig):
 
 
 # Style class registries
-style_class_priority_reg: list[tuple[Type[StyleDefBase], Iterable[str]]] = []
-style_class_reg: list[tuple[Type[StyleDefBase], Iterable[str]]] = []
+style_class_priority_reg: list[tuple[type[StyleDefBase], Iterable[str]]] = []
+style_class_reg: list[tuple[type[StyleDefBase], Iterable[str]]] = []
 
 
 class StyleMask(AbstractMaskRule):

--- a/datacube_ows/styles/colormap.py
+++ b/datacube_ows/styles/colormap.py
@@ -7,7 +7,8 @@
 import io
 import logging
 from datetime import datetime
-from typing import Callable, MutableMapping, Type, Union, cast
+from typing import Union, cast
+from collections.abc import Callable, MutableMapping
 
 import numpy
 import xarray
@@ -85,7 +86,7 @@ class AbstractValueMapRule(AbstractMaskRule):
         :return: A value map ruleset dictionary.
         """
         if isinstance(style_or_mdh, ColorMapStyleDef):
-            typ: Type[AbstractValueMapRule] = ValueMapRule
+            typ: type[AbstractValueMapRule] = ValueMapRule
         else:
             mdh = cast(ColorMapStyleDef.MultiDateHandler, style_or_mdh)
             if mdh.aggregator:
@@ -96,7 +97,7 @@ class AbstractValueMapRule(AbstractMaskRule):
                     raise ConfigException(
                         "MultiDate value map only supported on multi-date handlers with min_count and max_count equal.")
                 typ = MultiDateValueMapRule
-        vmap: dict[str, list["AbstractValueMapRule"]] = {}
+        vmap: dict[str, list[AbstractValueMapRule]] = {}
         for band_name, rules in cfg.items():
             band_rules = [typ(style_or_mdh, band_name, rule) for rule in cast(list[CFG_DICT], rules)]
             vmap[band_name] = band_rules

--- a/datacube_ows/styles/component.py
+++ b/datacube_ows/styles/component.py
@@ -4,7 +4,8 @@
 # Copyright (c) 2017-2024 OWS Contributors
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Any, Callable, Hashable, cast
+from typing import Any, cast
+from collections.abc import Callable, Hashable
 
 import numpy as np
 from xarray import DataArray, Dataset

--- a/datacube_ows/styles/expression.py
+++ b/datacube_ows/styles/expression.py
@@ -5,7 +5,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import operator
-from typing import Any, Type, cast
+from typing import Any, cast
 
 import lark
 from datacube.virtual.expr import formula_parser
@@ -125,7 +125,7 @@ class Expression:
         Return an appropriate Expression Evaluator for a given Dataset
         """
         if self.style.user_defined:
-            evaluator_cls: Type[ExpressionEvaluator] = UserDefinedExpressionEvaluator
+            evaluator_cls: type[ExpressionEvaluator] = UserDefinedExpressionEvaluator
         else:
             evaluator_cls = ExpressionEvaluator
 

--- a/datacube_ows/styles/ramp.py
+++ b/datacube_ows/styles/ramp.py
@@ -9,7 +9,8 @@ import logging
 from collections import defaultdict
 from decimal import ROUND_HALF_UP, Decimal
 from math import isclose
-from typing import Any, Hashable, Iterable, MutableMapping, Union, cast
+from typing import Any, Union, cast
+from collections.abc import Hashable, Iterable, MutableMapping
 
 import matplotlib
 import numpy

--- a/datacube_ows/tile_matrix_sets.py
+++ b/datacube_ows/tile_matrix_sets.py
@@ -4,7 +4,7 @@
 # Copyright (c) 2017-2024 OWS Contributors
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Type, cast
+from typing import cast
 
 from datacube_ows.config_utils import (CFG_DICT, RAW_CFG, ConfigException,
                                        OWSConfigEntry)
@@ -37,7 +37,7 @@ webmerc_scale_set = [
 ]
 
 
-def validate_2d_array(array: list, ident: str, label: str, typ: Type):
+def validate_2d_array(array: list, ident: str, label: str, typ: type):
     try:
         if len(array) != 2:
             raise ConfigException(f"In tile matrix set {ident}, {label} must have two values: f{array}")
@@ -46,7 +46,7 @@ def validate_2d_array(array: list, ident: str, label: str, typ: Type):
         raise ConfigException(f"In tile matrix set {ident}, {label} must be a list of two values: f{array}")
 
 
-def validate_array_typ(array: list, ident: str, label: str, typ: Type):
+def validate_array_typ(array: list, ident: str, label: str, typ: type):
     for elem in array:
         if not isinstance(elem, typ):
             raise ConfigException(f"In tile matrix set {ident}, {label} has non-{typ.__name__} value of type {elem.__class__.__name__}: {elem}")

--- a/datacube_ows/time_utils.py
+++ b/datacube_ows/time_utils.py
@@ -6,7 +6,6 @@
 
 import datetime
 import logging
-from typing import Optional
 
 from datacube.model import Dataset
 from dateutil.parser import parse
@@ -94,7 +93,7 @@ def tz_for_coord(lon: float | int, lat: float | int) -> datetime.tzinfo:
     :raises: NoTimezoneException
     """
     try:
-        tzn: Optional[str] = tf.timezone_at(lng=lon, lat=lat)
+        tzn: str | None = tf.timezone_at(lng=lon, lat=lat)
     except Exception as e:
         # Generally shouldn't happen - a common symptom of various geographic and timezone related bugs
         _LOG.warning("Timezone detection failed for lat %f, lon %s (%s)", lat, lon, str(e))

--- a/datacube_ows/utils.py
+++ b/datacube_ows/utils.py
@@ -8,7 +8,8 @@ import datetime
 import logging
 from functools import wraps
 from time import monotonic
-from typing import Any, Callable, TypeVar, cast
+from typing import Any, TypeVar, cast
+from collections.abc import Callable
 
 import pytz
 from datacube import Datacube

--- a/datacube_ows/wcs_scaler.py
+++ b/datacube_ows/wcs_scaler.py
@@ -221,7 +221,7 @@ class WCSScaler:
         else:
             res = grid["resolution"][1]
         scaled_size = abs(
-            ((dim_max - dim_min) * factor / res)
+            (dim_max - dim_min) * factor / res
         )
         self.set_size(dimension, scaled_size)
 

--- a/datacube_ows/wms_utils.py
+++ b/datacube_ows/wms_utils.py
@@ -294,7 +294,7 @@ def parse_wms_time_strings(parts, with_tz=False):
     return start, end
 
 
-class GetParameters():
+class GetParameters:
     def __init__(self, args):
         self.cfg = get_config()
         # Version
@@ -391,7 +391,7 @@ def single_style_from_args(layer, args, required=True):
                                valid_keys=list(layer.style_index))
     return style
 
-class GetLegendGraphicParameters():
+class GetLegendGraphicParameters:
     def __init__(self, args):
         self.layer = get_layer_from_arg(args, 'layer')
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 # This file is part of datacube-ows, part of the Open Data Cube project.
 # See https://opendatacube.org for more information.
 #
@@ -46,8 +45,8 @@ source_suffix = {
 master_doc = 'index'
 
 # General information about the project.
-project = u'datacube-ows'
-copyright = u"2017-2024, Open Data Cube Steering Council and contributors (Open Source License)"
+project = 'datacube-ows'
+copyright = "2017-2024, Open Data Cube Steering Council and contributors (Open Source License)"
 
 # The version info for the project you're documenting, acts as replacement
 # for |version| and |release|, also used in various other places throughout
@@ -78,6 +77,6 @@ htmlhelp_basename = 'datacube_owsdoc'
 # (source start file, name, description, authors, manual section).
 man_pages = [
     ('index', 'datacube_ows',
-     u'datacube-ows Documentation',
-     [u'Datacube OWS Team'], 1)
+     'datacube-ows Documentation',
+     ['Datacube OWS Team'], 1)
 ]

--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -23,7 +23,7 @@ def flask_client():
         yield client
 
 
-class generic_obj(object):
+class generic_obj:
     pass
 
 

--- a/integration_tests/metadata/metadata_importer.py
+++ b/integration_tests/metadata/metadata_importer.py
@@ -14,7 +14,7 @@ doc2ds_pgis = Doc2Dataset(dc_pgis.index, products=["s2_l2a", "geodata_coast_100k
 
 for line in fileinput.input():
     filename, uri = line.split()
-    with open(filename, "r") as fp:
+    with open(filename) as fp:
         doc = yaml.safe_load(fp)
     if "grid_spatial" in doc:
         del doc["grid_spatial"]

--- a/integration_tests/test_wmts_server.py
+++ b/integration_tests/test_wmts_server.py
@@ -89,9 +89,7 @@ def test_wmts_getcap_section(ows_server):
     for section in section_options:
         resp = requests.get(
             ows_server.url
-            + "/wmts?request=GetCapabilities&service=WMTS&version=1.0.0&section={}".format(
-                section
-            ),
+            + f"/wmts?request=GetCapabilities&service=WMTS&version=1.0.0&section={section}",
             timeout=10,
         )
 

--- a/licenseheaders.py
+++ b/licenseheaders.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# encoding: utf-8
 # This file is part of datacube-ows, part of the Open Data Cube project.
 # See https://opendatacube.org for more information.
 #
@@ -46,7 +45,7 @@ __version__ = '0.8.8'
 __author__ = 'Johann Petrak'
 __license__ = 'MIT'
 
-LOGGER = logging.getLogger("licenseheaders_{}".format(__version__))
+LOGGER = logging.getLogger(f"licenseheaders_{__version__}")
 
 
 default_dir = "."
@@ -395,13 +394,13 @@ def parse_command_line(argv):
                                      epilog=example,
                                      formatter_class=formatter_class)
     parser.add_argument("-V", "--version", action="version",
-                        version="%(prog)s {}".format(__version__))
+                        version=f"%(prog)s {__version__}")
     parser.add_argument("-v", "--verbose", dest="verbose_count",
                         action="count", default=0,
                         help="increases log verbosity (can be specified "
                              "1 to 3 times, default shows errors only)")
     parser.add_argument("-d", "--dir", dest="dir", default=default_dir,
-                        help="The directory to recursively process (default: {}).".format(default_dir))
+                        help=f"The directory to recursively process (default: {default_dir}).")
     parser.add_argument("-f", "--files", dest="files", nargs='*', type=str,
                         help="The list of files to process. If not empty - will disable '--dir' option")
     parser.add_argument("-b", action="store_true",
@@ -421,7 +420,7 @@ def parse_command_line(argv):
     parser.add_argument("-u", "--projurl", dest="projecturl", default=None,
                         help="Url of project to use.")
     parser.add_argument("--enc", nargs=1, dest="encoding", default=default_encoding,
-                        help="Encoding of program files (default: {})".format(default_encoding))
+                        help=f"Encoding of program files (default: {default_encoding})")
     parser.add_argument("--dry", action="store_true", help="Only show what would get done, do not change any files")
     parser.add_argument("--safesubst", action="store_true",
                         help="Do not raise error if template variables cannot be substituted.")
@@ -526,7 +525,7 @@ def read_template(template_file, vardict, args):
     :param args: the program arguments
     :return: lines of the template, with variables replaced
     """
-    with open(template_file, 'r') as f:
+    with open(template_file) as f:
         lines = f.readlines()
     if args.safesubst:
         lines = [Template(line).safe_substitute(vardict) for line in lines]
@@ -597,7 +596,7 @@ def read_file(file, args, type_settings):
     settings = type_settings.get(ftype)
     if not os.access(file, os.R_OK):
         LOGGER.error("File %s is not readable.", file)
-    with open(file, 'r', encoding=args.encoding) as f:
+    with open(file, encoding=args.encoding) as f:
         lines = f.readlines()
     # now iterate throw the lines and try to determine the various indies
     # first try to find the start of the header: skip over shebang or empty lines
@@ -607,7 +606,7 @@ def read_file(file, args, type_settings):
     block_comment_end_pattern = settings.get("blockCommentEndPattern")
     line_comment_start_pattern = settings.get("lineCommentStartPattern")
     i = 0
-    LOGGER.info("Processing file {} as {}".format(file, ftype))
+    LOGGER.info(f"Processing file {file} as {ftype}")
     for line in lines:
         if (i == 0 or i == skip) and keep_first and keep_first.findall(line):
             skip = i + 1
@@ -638,7 +637,7 @@ def read_file(file, args, type_settings):
                     "haveLicense": have_license
                     }
         i = i + 1
-    LOGGER.debug("Found preliminary start at {}, i={}, lines={}".format(head_start, i, len(lines)))
+    LOGGER.debug(f"Found preliminary start at {head_start}, i={i}, lines={len(lines)}")
     # now we have either reached the end, or we are at a line where a block start or line comment occurred
     # if we have reached the end, return default dictionary without info
     if i == len(lines):
@@ -656,7 +655,7 @@ def read_file(file, args, type_settings):
     if isBlockHeader:
         LOGGER.debug("Found comment start, process until end")
         for j in range(i, len(lines)):
-            LOGGER.debug("Checking line {}".format(j))
+            LOGGER.debug(f"Checking line {j}")
             if licensePattern.findall(lines[j]):
                 have_license = True
             elif block_comment_end_pattern.findall(lines[j]):
@@ -730,7 +729,7 @@ def make_backup(file, arguments):
             copyfile(file, file + ".bak")
 
 
-class OpenAsWriteable(object):
+class OpenAsWriteable:
     """
     This contextmanager wraps standard open(file, 'w', encoding=...) using
     arguments.encoding encoding. If file cannot be written (read-only file),
@@ -769,14 +768,14 @@ class OpenAsWriteable(object):
                     try:
                         os.chmod(filename, file_permissions | stat.S_IWUSR)
                     except PermissionError:
-                        LOGGER.warning("File {} cannot be made writable, it will be skipped.".format(filename))
+                        LOGGER.warning(f"File {filename} cannot be made writable, it will be skipped.")
                 else:
-                    LOGGER.warning("File {} is not writable, it will be skipped.".format(filename))
+                    LOGGER.warning(f"File {filename} is not writable, it will be skipped.")
 
             if os.access(filename, os.W_OK):
                 file_handle = open(filename, 'w', encoding=arguments.encoding)
         else:
-            LOGGER.warning("File {} does not exist, it will be skipped.".format(filename))
+            LOGGER.warning(f"File {filename} does not exist, it will be skipped.")
 
         self._file_handle = file_handle
         self._file_permissions = file_permissions
@@ -795,7 +794,7 @@ class OpenAsWriteable(object):
                 try:
                     os.chmod(self._filename, self._file_permissions)
                 except PermissionError:
-                    LOGGER.error("File {} permissions could not be restored.".format(self._filename))
+                    LOGGER.error(f"File {self._filename} permissions could not be restored.")
 
             self._file_handle = None
             self._file_permissions = None
@@ -881,7 +880,7 @@ def main():
             # first get all the names of our own templates
             # for this get first the path of this file
             templates_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "templates")
-            LOGGER.debug("File path: {}".format(os.path.abspath(__file__)))
+            LOGGER.debug(f"File path: {os.path.abspath(__file__)}")
             # get all the templates in the templates directory
             templates = [f for f in get_paths("*.tmpl", templates_dir)]
             templates = [(os.path.splitext(os.path.basename(t))[0], t) for t in templates]
@@ -894,20 +893,20 @@ def main():
             if len(tmpls) == 1:
                 tmpl_name = tmpls[0][0]
                 tmpl_file = tmpls[0][1]
-                LOGGER.info("Using template file {} for {}".format(tmpl_file, tmpl_name))
+                LOGGER.info(f"Using template file {tmpl_file} for {tmpl_name}")
                 template_lines = read_template(tmpl_file, settings, arguments)
             else:
                 if len(tmpls) == 0:
                     # check if we can interpret the option as file
                     if os.path.isfile(opt_tmpl):
-                        LOGGER.info("Using file {}".format(os.path.abspath(opt_tmpl)))
+                        LOGGER.info(f"Using file {os.path.abspath(opt_tmpl)}")
                         template_lines = read_template(os.path.abspath(opt_tmpl), settings, arguments)
                     else:
-                        LOGGER.error("Not a built-in template and not a file, cannot proceed: {}".format(opt_tmpl))
+                        LOGGER.error(f"Not a built-in template and not a file, cannot proceed: {opt_tmpl}")
                         LOGGER.error("Built in templates: {}".format(", ".join([t[0] for t in templates])))
                         error = True
                 else:
-                    LOGGER.error("There are multiple matching template names: {}".format([t[0] for t in tmpls]))
+                    LOGGER.error(f"There are multiple matching template names: {[t[0] for t in tmpls]}")
                     error = True
         else:
             # no tmpl parameter
@@ -932,13 +931,13 @@ def main():
                 paths = get_paths(patterns, arguments.dir)
 
             for file in paths:
-                LOGGER.debug("Considering file: {}".format(file))
+                LOGGER.debug(f"Considering file: {file}")
                 file = os.path.normpath(file)
                 if limit2exts is not None and not any([file.endswith(ext) for ext in limit2exts]):
-                    LOGGER.info("Skipping file with non-matching extension: {}".format(file))
+                    LOGGER.info(f"Skipping file with non-matching extension: {file}")
                     continue
                 if arguments.exclude and any([fnmatch.fnmatch(file, pat) for pat in arguments.exclude]):
-                    LOGGER.info("Ignoring file {}".format(file))
+                    LOGGER.info(f"Ignoring file {file}")
                     continue
                 finfo = read_file(file, arguments, type_settings)
                 if not finfo:
@@ -954,7 +953,7 @@ def main():
                 if template_lines:
                     make_backup(file, arguments)
                     if arguments.dry:
-                        LOGGER.info("Would be updating changed file: {}".format(file))
+                        LOGGER.info(f"Would be updating changed file: {file}")
                     else:
                         with open_as_writable(file, arguments) as fw:
                             if (fw is not None):
@@ -966,7 +965,7 @@ def main():
                                 ftype = finfo["type"]
                                 skip = finfo["skip"]
                                 if head_start is not None and head_end is not None and have_license:
-                                    LOGGER.debug("Replacing header in file {}".format(file))
+                                    LOGGER.debug(f"Replacing header in file {file}")
                                     # first write the lines before the header
                                     fw.writelines(lines[0:head_start])
                                     #  now write the new header from the template lines
@@ -974,7 +973,7 @@ def main():
                                     #  now write the rest of the lines
                                     fw.writelines(lines[head_end + 1:])
                                 else:
-                                    LOGGER.debug("Adding header to file {}, skip={}".format(file, skip))
+                                    LOGGER.debug(f"Adding header to file {file}, skip={skip}")
                                     fw.writelines(lines[0:skip])
                                     fw.writelines(for_type(template_lines, ftype, type_settings))
                                     if head_start is not None and not have_license:
@@ -988,11 +987,11 @@ def main():
                     if years_line is not None:
                         make_backup(file, arguments)
                         if arguments.dry:
-                            LOGGER.info("Would be updating year line in file {}".format(file))
+                            LOGGER.info(f"Would be updating year line in file {file}")
                         else:
                             with open_as_writable(file, arguments) as fw:
                                 if (fw is not None):
-                                    LOGGER.debug("Updating years in file {} in line {}".format(file, years_line))
+                                    LOGGER.debug(f"Updating years in file {file} in line {years_line}")
                                     fw.writelines(lines[0:years_line])
                                     fw.write(yearsPattern.sub(years, lines[years_line]))
                                     fw.writelines(lines[years_line + 1:])

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 # This file is part of datacube-ows, part of the Open Data Cube project.
 # See https://opendatacube.org for more information.
 #

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # This file is part of datacube-ows, part of the Open Data Cube project.
 # See https://opendatacube.org for more information.
 #

--- a/tests/cfg/__init__.py
+++ b/tests/cfg/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # This file is part of datacube-ows, part of the Open Data Cube project.
 # See https://opendatacube.org for more information.
 #

--- a/tests/test_ows_configuration.py
+++ b/tests/test_ows_configuration.py
@@ -70,10 +70,10 @@ def test_func_naked():
         f = datacube_ows.config_utils.FunctionWrapper(lyr, {
             "function": a_function,
         })
-    assert str("Directly including callable objects in configuration is no longer supported.")
+    assert "Directly including callable objects in configuration is no longer supported."
     with pytest.raises(datacube_ows.config_utils.ConfigException) as e:
         f = datacube_ows.config_utils.FunctionWrapper(lyr, a_function)
-    assert str("Directly including callable objects in configuration is no longer supported.")
+    assert "Directly including callable objects in configuration is no longer supported."
     f = datacube_ows.config_utils.FunctionWrapper(lyr, {
         "function": a_function,
     }, stand_alone=True)

--- a/tests/test_startup.py
+++ b/tests/test_startup.py
@@ -162,7 +162,7 @@ def test_init_babel_off(babel_cfg, flask_app):
 def test_sentry_before_send():
     from datacube_ows.startup_utils import before_send
 
-    class LGEOS380():
+    class LGEOS380:
         def __init__(self, a=5):
             self.a = a
 


### PR DESCRIPTION
Use modern syntax for types,
and import things from collection
instead of typing when possible.

<!-- readthedocs-preview datacube-ows start -->
----
📚 Documentation preview 📚: https://datacube-ows--1116.org.readthedocs.build/en/1116/

<!-- readthedocs-preview datacube-ows end -->