### PR TITLE
pylintrc: fix config warning

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -192,4 +192,4 @@ max-public-methods=20
 
 # Exceptions that will emit a warning when being caught. Defaults to
 # "Exception"
-overgeneral-exceptions=Exception
+overgeneral-exceptions=builtins.Exception


### PR DESCRIPTION
Use the fully qualified name like
Pylint suggests in the warning.

<!-- readthedocs-preview datacube-ows start -->
----
📚 Documentation preview 📚: https://datacube-ows--1117.org.readthedocs.build/en/1117/

<!-- readthedocs-preview datacube-ows end -->