### PR TITLE
Fix utcnow() warning

### DIFF
--- a/datacube_ows/wms_utils.py
+++ b/datacube_ows/wms_utils.py
@@ -5,7 +5,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import math
-from datetime import datetime, date
+from datetime import datetime, date, timezone
 
 import numpy
 import regex as re
@@ -263,7 +263,7 @@ def parse_time_delta(delta_str):
 
 def parse_wms_time_string(t, start=True):
     if t.upper() == 'PRESENT':
-        return datetime.utcnow()
+        return datetime.now(timezone.utc)
     elif t.startswith('P'):
         return parse_time_delta(t)
     else:

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -106,7 +106,7 @@ def test_s3_browser_uris(s3_url_datasets):
 #
 #     class fake_dataset:
 #         def __init__(self):
-#             self.center_time = datetime.utcnow()
+#             self.center_time = datetime.now(timezone.utc)
 #             self.id = 1
 #             self.metadata = dict()
 #

--- a/tests/test_wms_utils.py
+++ b/tests/test_wms_utils.py
@@ -48,7 +48,7 @@ def test_parse_wms_time_strings_with_present():
     import datetime as dt
     start, end = datacube_ows.wms_utils.parse_wms_time_strings('2018-01-10/PRESENT'.split('/'))
     assert start == dt.datetime(2018, 1, 10, 0, 0)
-    assert (dt.datetime.utcnow() - end).total_seconds() < 60
+    assert (dt.datetime.now(dt.timezone.utc) - end).total_seconds() < 60
 
 
 @pytest.fixture


### PR DESCRIPTION
Use datetime.now(timezone.utc) instead.

<!-- readthedocs-preview datacube-ows start -->
----
📚 Documentation preview 📚: https://datacube-ows--1119.org.readthedocs.build/en/1119/

<!-- readthedocs-preview datacube-ows end -->