### PR TITLE
docker-compose: speed up postgis

### DIFF
--- a/docker-compose.cleandb.yaml
+++ b/docker-compose.cleandb.yaml
@@ -11,6 +11,9 @@ services:
     ports:
       - "${POSTGRES_PORT}:5432"
     restart: always
+    volumes:
+      - type: tmpfs
+        target: /var/lib/postgresql
     healthcheck:
       test: ["CMD", "pg_isready", "-h", "postgres", "-q", "-d", "$POSTGRES_DB", "-U", "$POSTGRES_USER"]
       timeout: 45s

--- a/docker-compose.db.yaml
+++ b/docker-compose.db.yaml
@@ -10,6 +10,9 @@ services:
     ports:
       - "${POSTGRES_PORT}:${POSTGRES_PORT}"
     restart: always
+    volumes:
+      - type: tmpfs
+        target: /var/lib/postgresql
     healthcheck:
       test: ["CMD", "pg_isready", "-h", "postgres", "-q", "-d", "$POSTGRES_DB", "-U", "$POSTGRES_USER"]
       timeout: 45s


### PR DESCRIPTION
Speed up postgis by putting the database on tmpfs instead of the slow Docker overlay filesystem.

<!-- readthedocs-preview datacube-ows start -->
----
📚 Documentation preview 📚: https://datacube-ows--1122.org.readthedocs.build/en/1122/

<!-- readthedocs-preview datacube-ows end -->