### PR TITLE
Stop building Python 2 wheels

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,0 @@
-[bdist_wheel]
-universal = 1


### PR DESCRIPTION
This package requires Python 3.10
and building Python 2 wheels will
stop working Aug 30, so stop
building them.

This corresponds to
https://github.com/opendatacube/datacube-core/pull/1752 in datacube-core.

<!-- readthedocs-preview datacube-ows start -->
----
📚 Documentation preview 📚: https://datacube-ows--1123.org.readthedocs.build/en/1123/

<!-- readthedocs-preview datacube-ows end -->