### PR TITLE
readthedocs: briefly sleep before checkout

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,7 +9,9 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.10"
-
+  jobs:
+    pre_checkout:
+      - sleep 2
 # Build documentation in the "docs/" directory with Sphinx
 sphinx:
   configuration: docs/conf.py


### PR DESCRIPTION
This hopefully avoids the dreaded
"reference is not a tree" that
causes the readthedocs jobs
to fail.

<!-- readthedocs-preview datacube-ows start -->
----
📚 Documentation preview 📚: https://datacube-ows--1127.org.readthedocs.build/en/1127/

<!-- readthedocs-preview datacube-ows end -->