### PR TITLE
Make ping multi-db aware.

### DIFF
--- a/datacube_ows/index/api.py
+++ b/datacube_ows/index/api.py
@@ -65,6 +65,11 @@ class LayerExtent:
 class OWSAbstractIndex(ABC):
     name: str = ""
 
+    # method to check database access (for ping op)
+    @abstractmethod
+    def check_db_access(self, dc: Datacube) -> bool:
+        ...
+
     # method to delete obsolete schemas etc.
     @abstractmethod
     def cleanup_schema(self, dc: Datacube):
@@ -177,6 +182,7 @@ class OWSAbstractIndex(ABC):
         else:
             # Return polygons and multipolygons as is.
             return any_geom
+
 
 class OWSAbstractIndexDriver(ABC):
     @classmethod

--- a/datacube_ows/index/postgis/api.py
+++ b/datacube_ows/index/postgis/api.py
@@ -34,7 +34,7 @@ class OWSPostgisIndex(OWSAbstractIndex):
     def check_db_access(self, dc: Datacube) -> bool:
         db_ok = False
         try:
-            with dc.index._db._give_me_a_connection() as conn:
+            with dc.index._db._give_me_a_connection() as conn:  # type: ignore[attr-defined]
                 results = conn.execute(text("""
                     SELECT *
                     FROM ows.layer_ranges

--- a/datacube_ows/index/postgis/api.py
+++ b/datacube_ows/index/postgis/api.py
@@ -12,6 +12,7 @@ from typing import Any
 from typing_extensions import override
 from collections.abc import Iterable
 from uuid import UUID
+from sqlalchemy import text
 
 from odc.geo import Geometry, CRS
 from datacube import Datacube
@@ -27,6 +28,23 @@ from ...utils import default_to_utc
 
 class OWSPostgisIndex(OWSAbstractIndex):
     name: str = "postgis"
+
+    # method to check database access (for ping op)
+    @override
+    def check_db_access(self, dc: Datacube) -> bool:
+        db_ok = False
+        try:
+            with dc.index._db._give_me_a_connection() as conn:
+                results = conn.execute(text("""
+                    SELECT *
+                    FROM ows.layer_ranges
+                    LIMIT 1""")
+                )
+                for r in results:
+                    db_ok = True
+        except:
+            pass
+        return db_ok
 
     # method to delete obsolete schemas etc.
     @override

--- a/datacube_ows/index/postgres/api.py
+++ b/datacube_ows/index/postgres/api.py
@@ -32,7 +32,7 @@ class OWSPostgresIndex(OWSAbstractIndex):
     def check_db_access(self, dc: Datacube) -> bool:
         db_ok = False
         try:
-            with dc.index._db.give_me_a_connection() as conn:
+            with dc.index._db.give_me_a_connection() as conn:  # type: ignore[attr-defined]
                 results = conn.execute(text("""
                     SELECT *
                     FROM ows.layer_ranges

--- a/datacube_ows/index/postgres/api.py
+++ b/datacube_ows/index/postgres/api.py
@@ -11,6 +11,7 @@ from typing import cast
 from typing_extensions import override
 from collections.abc import Iterable
 from uuid import UUID
+from sqlalchemy import text
 
 from odc.geo import Geometry, CRS
 from datacube import Datacube
@@ -25,6 +26,23 @@ from datacube_ows.index.sql import run_sql
 
 class OWSPostgresIndex(OWSAbstractIndex):
     name: str = "postgres"
+
+    # method to check database access (for ping op)
+    @override
+    def check_db_access(self, dc: Datacube) -> bool:
+        db_ok = False
+        try:
+            with dc.index._db.give_me_a_connection() as conn:
+                results = conn.execute(text("""
+                    SELECT *
+                    FROM ows.layer_ranges
+                    LIMIT 1""")
+                )
+                for r in results:
+                    db_ok = True
+        except:
+            pass
+        return db_ok
 
     # method to delete obsolete schemas etc.
     @override

--- a/datacube_ows/ogc.py
+++ b/datacube_ows/ogc.py
@@ -9,7 +9,6 @@ import traceback
 from time import monotonic
 
 from flask import g, render_template, request
-from sqlalchemy import text
 
 from datacube_ows import __version__
 from datacube_ows.http_utils import (

--- a/datacube_ows/ogc.py
+++ b/datacube_ows/ogc.py
@@ -18,6 +18,7 @@ from datacube_ows.http_utils import (
     lower_get_args,
     resp_headers,
 )
+from datacube_ows.index.api import ows_index
 from datacube_ows.legend_generator import create_legend_for_style
 from datacube_ows.ogc_exceptions import OGCException, WMSException
 from datacube_ows.ows_configuration import get_config
@@ -197,23 +198,19 @@ def ogc_wcs_impl():
 @app.route('/ping')
 @metrics.summary('ows_heartbeat_pings', "Ping durations", labels={"status": lambda r: r.status})
 def ping():
-    db_ok = False
-    cfg = get_config()
-    try:
-        with cfg.dc.index._db.give_me_a_connection() as conn:
-            results = conn.execute(text("""
-                    SELECT *
-                    FROM ows.layer_ranges
-                    LIMIT 1""")
-            )
-            for r in results:
-                db_ok = True
-    except Exception:
-        pass
-    if db_ok:
-        return render_template("ping.html", status="Up"), 200, resp_headers({"Content-Type": "text/html"})
+    dbs_ok = {
+        name: ows_index(dc).check_db_access(dc)
+        for name, dc in get_config().all_dcs.items()
+    }
+    all_ok = all(dbs_ok.values())
+    any_ok = any(dbs_ok.values())
+
+    if all_ok:
+        return render_template("ping.html", status="Up", statuses=dbs_ok), 200, resp_headers({"Content-Type": "text/html"})
+    elif any_ok:
+        return render_template("ping.html", status="Partially Up", statuses=dbs_ok), 500, resp_headers({"Content-Type": "text/html"})
     else:
-        return render_template("ping.html", status="Down"), 500, resp_headers({"Content-Type": "text/html"})
+        return render_template("ping.html", status="Down", statuses=dbs_ok), 500, resp_headers({"Content-Type": "text/html"})
 
 
 @app.route("/legend/<string:layer>/<string:style>/legend.png")

--- a/datacube_ows/ogc.py
+++ b/datacube_ows/ogc.py
@@ -201,15 +201,13 @@ def ping():
         name: ows_index(dc).check_db_access(dc)
         for name, dc in get_config().all_dcs.items()
     }
-    all_ok = all(dbs_ok.values())
-    any_ok = any(dbs_ok.values())
 
-    if all_ok:
+    if all(dbs_ok.values()):
         return render_template("ping.html", status="Up", statuses=dbs_ok), 200, resp_headers({"Content-Type": "text/html"})
-    elif any_ok:
-        return render_template("ping.html", status="Partially Up", statuses=dbs_ok), 500, resp_headers({"Content-Type": "text/html"})
+    elif any(dbs_ok.values()):
+        return render_template("ping.html", status="Partially Up", statuses=dbs_ok), 503, resp_headers({"Content-Type": "text/html"})
     else:
-        return render_template("ping.html", status="Down", statuses=dbs_ok), 500, resp_headers({"Content-Type": "text/html"})
+        return render_template("ping.html", status="Down", statuses=dbs_ok), 503, resp_headers({"Content-Type": "text/html"})
 
 
 @app.route("/legend/<string:layer>/<string:style>/legend.png")

--- a/datacube_ows/ows_configuration.py
+++ b/datacube_ows/ows_configuration.py
@@ -1333,6 +1333,7 @@ class OWSConfig(OWSMetadataConfig):
             self.declare_unready("dc")
             self.declare_unready("crses")
             self.declare_unready("native_product_index")
+            self.declare_unready("all_dcs")
 
     #pylint: disable=attribute-defined-outside-init
     @override
@@ -1353,6 +1354,11 @@ class OWSConfig(OWSMetadataConfig):
         self.crses = {s: self.crs(s) for s in self.published_CRSs}
         self.native_product_index: dict[str, OWSNamedLayer] = {}
         self.root_layer_folder.make_ready(*args, **kwargs)
+        self.all_dcs: dict[str, Datacube] = {}
+        for layer in self.active_products:
+            if layer.local_env._name not in self.all_dcs:
+                self.all_dcs[layer.local_env._name] = layer.dc
+
         super().make_ready(*args, **kwargs)
 
     def export_metadata(self) -> Catalog:

--- a/datacube_ows/templates/ping.html
+++ b/datacube_ows/templates/ping.html
@@ -7,5 +7,13 @@
 <body>
     <h1>PONG!!</h1>
     <p>Database: {{ status }}</p>
+    <ul>
+        {% for env, status in statuses.items() %}
+            <li>
+                {{ env }}:
+                {% if status %}UP{% else %}DOWN{% endif %}
+            </li>
+        {% endfor %}
+    </ul>
 </body>
 </html>


### PR DESCRIPTION
Ping was only checking connectivity to the database associated with the default environment. This PR implements a general multi-db ping operation.

- Add db check method to OWS index API
- implement db check method for postgres and postgis drivers.
- keep track of configured environments in global config object
- refactor ping method to check all configured environments, using the OWS index API. 

<!-- readthedocs-preview datacube-ows start -->
----
📚 Documentation preview 📚: https://datacube-ows--1139.org.readthedocs.build/en/1139/

<!-- readthedocs-preview datacube-ows end -->