### PR TITLE
Factor out colours library

### DIFF
--- a/datacube_ows/ows_configuration.py
+++ b/datacube_ows/ows_configuration.py
@@ -214,8 +214,8 @@ class AttributionCfg(OWSConfigEntry):
             self.logo_url: str | None = None
             self.logo_fmt: str | None = None
         else:
-            self.logo_width = cast(int | None, logo.get("width"))
-            self.logo_height = cast(int | None, logo.get("height"))
+            self.logo_width = None if logo.get("width") is None else int(logo["width"])
+            self.logo_height = None if logo.get("height") is None else int(logo["height"])
             self.logo_url = logo.get("url")
             self.logo_fmt = logo.get("format")
             if not self.logo_url or not self.logo_fmt:

--- a/datacube_ows/styles/colormap.py
+++ b/datacube_ows/styles/colormap.py
@@ -16,7 +16,7 @@ import xarray
 from datacube.utils.masking import make_mask
 from matplotlib import patches as mpatches
 from matplotlib import pyplot as plt
-from matplotlib.colors import to_rgb, to_hex
+from matplotlib.colors import to_rgba, to_hex
 from xarray import DataArray, Dataset
 
 from datacube_ows.config_utils import (CFG_DICT, AbstractMaskRule,
@@ -68,12 +68,13 @@ class AbstractValueMapRule(AbstractMaskRule):
 
     def parse_color(self, cfg: CFG_DICT):
         self.color_str = cast(str, cfg["color"])
-        # TODO: switch to native RGBA format
-        self.rgb = to_rgb(self.color_str)
         if cfg.get("mask"):
-            self.alpha = 0.0
+            alpha: float | None = 0.0
+        elif "alpha" in cfg:
+            alpha = float(cast(float | int | str, cfg["alpha"]))
         else:
-            self.alpha = float(cast(float | int | str, cfg.get("alpha", 1.0)))
+            alpha = None
+        self.rgba = to_rgba(self.color_str, alpha=alpha)
 
     @classmethod
     def value_map_from_config(cls,
@@ -259,12 +260,8 @@ def apply_value_map(value_map: MutableMapping[str, list[AbstractValueMapRule]],
         for rule in reversed(rules):
             mask = rule.create_mask(bdata)
             if mask is not None and mask.data.any():
-                # TODO: switch to native RGBA
                 for i, channel in enumerate(("red", "green", "blue", "alpha")):
-                    if channel == "alpha":
-                        val = convert_to_uint8(rule.alpha)
-                    else:
-                        val = convert_to_uint8(rule.rgb[i])
+                    val = convert_to_uint8(rule.rgba[i])
                     imgdata[channel] = xarray.where(mask, val, imgdata[channel])
     return imgdata
 
@@ -272,7 +269,7 @@ def apply_value_map(value_map: MutableMapping[str, list[AbstractValueMapRule]],
 class PatchTemplate:
     def __init__(self, idx: int, rule: AbstractValueMapRule) -> None:
         self.idx = idx
-        self.colour = to_hex(rule.rgb)
+        self.colour = to_hex(rule.rgba, keep_alpha=True)
         self.label = rule.label
 
 
@@ -292,7 +289,7 @@ class ColorMapLegendBase(StyleDefBase.Legend, OWSMetadataConfig):
         for band in value_map.keys():
             for idx, rule in reversed(list(enumerate(value_map[band]))):
                 # only include values that are not transparent (and that have a non-blank title or abstract)
-                if rule.alpha > 0.001 and rule.label:
+                if rule.rgba[-1] > 0.001 and rule.label:
                     self.patches.append(PatchTemplate(idx, rule))
         self.parse_metadata(cast(CFG_DICT, self._raw_cfg))
 
@@ -367,16 +364,15 @@ class ColorMapStyleDef(StyleDefBase):
             inted.attrs = attrs
         return inted
 
-    # TODO: Use native RGBA format
     @staticmethod
-    def create_colordata(data: DataArray, rgb: tuple[float, float, float], alpha: float, mask: DataArray) -> Dataset:
+    def create_colordata(data: DataArray, rgba: tuple[float, float, float, float], mask: DataArray) -> Dataset:
         """Colour a mask with a given colour/alpha"""
         target = Dataset(coords=data.coords)
-        colors = ["red", "green", "blue", "alpha"]
-        for i, color in enumerate(colors):
-            val = alpha if color == "alpha" else rgb[i]
+        channels = ["red", "green", "blue", "alpha"]
+        for i, channel in enumerate(channels):
+            val = rgba[i]
             c = numpy.full(data.shape, val)
-            target[color] = DataArray(c, dims=data.dims, coords=data.coords)
+            target[channel] = DataArray(c, dims=data.dims, coords=data.coords)
         # pyre-ignore[6]
         masked = target.where(mask).where(numpy.isfinite(data))  # remask
         return masked

--- a/datacube_ows/styles/colormap.py
+++ b/datacube_ows/styles/colormap.py
@@ -13,10 +13,10 @@ from collections.abc import Callable, MutableMapping
 
 import numpy
 import xarray
-from colour import Color
 from datacube.utils.masking import make_mask
 from matplotlib import patches as mpatches
 from matplotlib import pyplot as plt
+from matplotlib.colors import to_rgb, to_hex
 from xarray import DataArray, Dataset
 
 from datacube_ows.config_utils import (CFG_DICT, AbstractMaskRule,
@@ -68,7 +68,8 @@ class AbstractValueMapRule(AbstractMaskRule):
 
     def parse_color(self, cfg: CFG_DICT):
         self.color_str = cast(str, cfg["color"])
-        self.rgb = Color(self.color_str)
+        # TODO: switch to native RGBA format
+        self.rgb = to_rgb(self.color_str)
         if cfg.get("mask"):
             self.alpha = 0.0
         else:
@@ -258,11 +259,12 @@ def apply_value_map(value_map: MutableMapping[str, list[AbstractValueMapRule]],
         for rule in reversed(rules):
             mask = rule.create_mask(bdata)
             if mask is not None and mask.data.any():
-                for channel in ("red", "green", "blue", "alpha"):
+                # TODO: switch to native RGBA
+                for i, channel in enumerate(("red", "green", "blue", "alpha")):
                     if channel == "alpha":
                         val = convert_to_uint8(rule.alpha)
                     else:
-                        val = convert_to_uint8(getattr(rule.rgb, channel))
+                        val = convert_to_uint8(rule.rgb[i])
                     imgdata[channel] = xarray.where(mask, val, imgdata[channel])
     return imgdata
 
@@ -270,7 +272,7 @@ def apply_value_map(value_map: MutableMapping[str, list[AbstractValueMapRule]],
 class PatchTemplate:
     def __init__(self, idx: int, rule: AbstractValueMapRule) -> None:
         self.idx = idx
-        self.colour = rule.rgb.hex_l
+        self.colour = to_hex(rule.rgb)
         self.label = rule.label
 
 
@@ -365,13 +367,14 @@ class ColorMapStyleDef(StyleDefBase):
             inted.attrs = attrs
         return inted
 
+    # TODO: Use native RGBA format
     @staticmethod
-    def create_colordata(data: DataArray, rgb: Color, alpha: float, mask: DataArray) -> Dataset:
+    def create_colordata(data: DataArray, rgb: tuple[float, float, float], alpha: float, mask: DataArray) -> Dataset:
         """Colour a mask with a given colour/alpha"""
         target = Dataset(coords=data.coords)
         colors = ["red", "green", "blue", "alpha"]
-        for color in colors:
-            val = alpha if color == "alpha" else getattr(rgb, color)
+        for i, color in enumerate(colors):
+            val = alpha if color == "alpha" else rgb[i]
             c = numpy.full(data.shape, val)
             target[color] = DataArray(c, dims=data.dims, coords=data.coords)
         # pyre-ignore[6]

--- a/datacube_ows/styles/ramp.py
+++ b/datacube_ows/styles/ramp.py
@@ -7,6 +7,7 @@
 import io
 import logging
 from collections import defaultdict
+from dataclasses import dataclass
 from decimal import ROUND_HALF_UP, Decimal
 from math import isclose
 from typing import Any, Union, cast
@@ -15,9 +16,8 @@ from collections.abc import Hashable, Iterable, MutableMapping
 
 import matplotlib
 import numpy
-from colour import Color
 from matplotlib import pyplot as plt
-from matplotlib.colors import LinearSegmentedColormap, to_hex
+from matplotlib.colors import LinearSegmentedColormap, to_hex, to_rgba
 from numpy import ubyte
 from xarray import DataArray, Dataset
 
@@ -32,48 +32,58 @@ if TYPE_CHECKING:
 
 _LOG = logging.getLogger(__name__)
 
+@dataclass
+class RampNode:
+    value: int | float
+    color: str
+    alpha: int | float | None = None
+
+    @property
+    def rgba(self):
+        return to_rgba(self.color, self.alpha)
+
+    def with_value(self, value: int | float) -> "RampNode":
+        return RampNode(value, self.color, self.alpha)
+
+
 RAMP_SPEC = list[CFG_DICT]
-
-UNSCALED_DEFAULT_RAMP = cast(RAMP_SPEC,
-                             [
-                                {
-                                    "value": -1e-24,
-                                    "color": "#000080",
-                                    "alpha": 0.0
-                                },
-                                {
-                                    "value": 0.0,
-                                    "color": "#000080",
-                                },
-                                {
-                                    "value": 0.1,
-                                    "color": "#0000FF",
-                                },
-                                {
-                                    "value": 0.3,
-                                    "color": "#00FFFF",
-                                },
-                                {
-                                    "value": 0.5,
-                                    "color": "#00FF00",
-                                },
-                                {
-                                    "value": 0.7,
-                                    "color": "#FFFF00",
-                                },
-                                {
-                                    "value": 0.9,
-                                    "color": "#FF0000",
-                                },
-                                {
-                                    "value": 1.0,
-                                    "color": "#800000",
-                                },
-                             ]
-)
+RampRepr = list[RampNode]
 
 
-def scale_unscaled_ramp(rmin: int | float | str, rmax: int | float | str, unscaled: RAMP_SPEC) -> RAMP_SPEC:
+def make_ramp_representation(ramp_spec: RAMP_SPEC, style_name: str) -> RampRepr:
+    rep = cast(RampRepr, [])
+    for node in ramp_spec:
+        if "value" not in node:
+            raise ConfigException(f'Color ramp element without a value in style {style_name}')
+        if "color" not in node:
+            raise ConfigException(f'Color ramp element without a color in style {style_name}')
+        if "legend" in node:
+                raise ConfigException(
+                    f"Style {style_name} uses a no-longer supported format for legend configuration.  " +
+                    "Please refer to the documentation and update your config")
+        rep.append(
+            RampNode(
+                float(cast(float | str | int, node["value"])),
+                cast(str, node["color"]),
+                alpha=None if node.get("alpha") is None else float(cast(str | int | float, node["alpha"]))
+            )
+        )
+    return rep
+
+
+UNSCALED_DEFAULT_RAMP = [
+        RampNode(-1e-24, "#000080", alpha=0.0),
+        RampNode(0.0, "#000080"),
+        RampNode(0.1, "#0000FF"),
+        RampNode(0.3, "#00FFFF"),
+        RampNode(0.5, "#00FF00"),
+        RampNode(0.7, "#FFFF00"),
+        RampNode(0.9, "#FF0000"),
+        RampNode(1.0, "#800000"),
+]
+
+
+def scale_unscaled_ramp(rmin: int | float | str, rmax: int | float | str, unscaled: RampRepr) -> RampRepr:
     """
     Take a unscaled (normalised) ramp that covers values from 0.0 to 1.0 and scale it linearly to cover the
     provided range.
@@ -92,16 +102,12 @@ def scale_unscaled_ramp(rmin: int | float | str, rmax: int | float | str, unscal
     else:
         nmax = float(rmax)
     return [
-        {
-            # pyre-ignore[6]
-            "value": (nmax - nmin) * cast(float, u["value"]) + nmin,
-            "color": u["color"],
-            "alpha": u.get("alpha", 1.0)
-        } for u in unscaled
+        u.with_value((nmax - nmin) * float(u.value) + nmin)
+        for u in unscaled
     ]
 
 
-def crack_ramp(ramp: RAMP_SPEC) -> tuple[
+def crack_ramp(ramp: RampRepr) -> tuple[
     list[float],
     list[float], list[float],
     list[float], list[float],
@@ -118,48 +124,35 @@ def crack_ramp(ramp: RAMP_SPEC) -> tuple[
     blue = cast(list[float], [])
     alpha = cast(list[float], [])
     for r in ramp:
-        if isinstance(r["value"], float):
-            value: float = r["value"]
-        else:
-            value = float(cast(int | str, r["value"]))
-        values.append(value)
-        color = Color(r["color"])
-        red.append(color.red)
-        green.append(color.green)
-        blue.append(color.blue)
-        alpha.append(float(cast(float | int | str, r.get("alpha", 1.0))))
+        values.append(float(r.value))
+        cr, cg, cb, ca = r.rgba
+        red.append(cr)
+        green.append(cg)
+        blue.append(cb)
+        alpha.append(ca)
 
     return values, red, green, blue, alpha
 
 
-def read_mpl_ramp(mpl_ramp: str) -> RAMP_SPEC:
+def read_mpl_ramp(mpl_ramp: str) -> RampRepr:
     """
     Extract a named colour ramp from Matplotlib as a normalised OWS-compatible ramp specification
 
     :param mpl_ramp: The name of Matplotlib colour ramp
     :return: A normalised ramp specification.
     """
-    unscaled_cmap = cast(RAMP_SPEC, [])
+    unscaled_cmap = cast(RampRepr, [])
     try:
         cmap = plt.get_cmap(mpl_ramp)
     except:
         raise ConfigException(f"Invalid Matplotlib name: {mpl_ramp}")
     val_range = numpy.arange(0.1, 1.1, 0.1)
     rgba_hex = to_hex(cmap(0.0))
-    unscaled_cmap.append(
-        {
-            "value": 0.0,
-            "color": rgba_hex,
-            "alpha": 1.0
-        }
-    )
+    unscaled_cmap.append(RampNode(0.0, rgba_hex))
     for val in val_range:
         rgba_hex = to_hex(cast(tuple[float, float, float, float], cmap(val)))
         unscaled_cmap.append(
-            {
-                "value": float(val),
-                "color": rgba_hex
-            }
+            RampNode(float(val), rgba_hex)
         )
     return unscaled_cmap
 
@@ -177,7 +170,7 @@ class ColorRamp:
         """
         self.style = style
         if "color_ramp" in ramp_cfg:
-            raw_scaled_ramp = cast(list[CFG_DICT], ramp_cfg["color_ramp"])
+            raw_scaled_ramp = make_ramp_representation(cast(list[CFG_DICT], ramp_cfg["color_ramp"]), self.style.name)
         else:
             rmin, rmax = cast(list[float], ramp_cfg["range"])
             unscaled_ramp = UNSCALED_DEFAULT_RAMP
@@ -202,7 +195,7 @@ class ColorRamp:
             leg_begin_before_idx = None
             leg_end_before_idx = None
             for idx, col_point in enumerate(self.ramp):
-                col_val = cast(int | float, col_point["value"])
+                col_val = col_point.value
                 if not leg_begin_in_ramp and leg_begin_before_idx is None:
                     if isclose(col_val, fleg_begin, abs_tol=1e-9):
                         leg_begin_in_ramp = True
@@ -214,12 +207,8 @@ class ColorRamp:
                     elif col_val > fleg_end:
                         end_before_idx = idx
             if not leg_begin_in_ramp:
-                color, alpha = self.color_alpha_at(fleg_begin)
-                begin_col_point = {
-                    "value": fleg_begin,
-                    "color": color.get_hex(),
-                    "alpha": alpha
-                }
+                rgba = self.rgba_at(fleg_begin)
+                begin_col_point = RampNode(fleg_begin, to_hex(rgba))
                 if leg_begin_before_idx is None:
                     self.ramp.append(begin_col_point)
                 else:
@@ -227,12 +216,8 @@ class ColorRamp:
                 if leg_end_before_idx is not None:
                     leg_end_before_idx += 1
             if not leg_end_in_ramp:
-                color, alpha = self.color_alpha_at(fleg_end)
-                end_col_point = {
-                    "value": fleg_end,
-                    "color": color.get_hex(),
-                    "alpha": alpha
-                }
+                rgba = self.rgba_at(fleg_end)
+                end_col_point = RampNode(fleg_end, to_hex(rgba))
                 if leg_end_before_idx is None:
                     self.ramp.append(end_col_point)
                 else:
@@ -266,16 +251,13 @@ class ColorRamp:
         imgdataset = Dataset(imgdata, coords=data.coords)
         return imgdataset
 
-    def color_alpha_at(self, val: float) -> tuple[Color, float]:
-        color = Color(
-            rgb=(
-                float(self.get_value(val, "red")),
-                float(self.get_value(val, "green")),
-                float(self.get_value(val, "blue")),
-            )
+    def rgba_at(self, val: float) -> tuple[float, float, float, float]:
+        return (
+            float(self.get_value(val, "red")),
+            float(self.get_value(val, "green")),
+            float(self.get_value(val, "blue")),
+            float(self.get_value(val, "alpha"))
         )
-        alpha = float(self.get_value(val, "alpha"))
-        return color, alpha
 
 
 class RampLegendBase(StyleDefBase.Legend, OWSMetadataConfig):
@@ -359,18 +341,18 @@ class RampLegendBase(StyleDefBase.Legend, OWSMetadataConfig):
     def register_ramp(self, ramp: ColorRamp) -> None:
         if self.begin.is_nan():
             for col_def in ramp.ramp:
-                if isclose(cast(float, col_def.get("alpha", 1.0)), 1.0, abs_tol=1e-9):
-                    self.begin = Decimal(cast(int | float, col_def["value"]))
+                if isclose(col_def.rgba[-1], 1.0, abs_tol=1e-9):
+                    self.begin = Decimal(col_def.value)
                     break
             if self.begin.is_nan():
-                self.begin = Decimal(cast(int | float, ramp.ramp[0]["value"]))
+                self.begin = Decimal(ramp.ramp[0].value)
         if self.end.is_nan():
             for col_def in reversed(ramp.ramp):
-                if isclose(cast(int | float, col_def.get("alpha", 1.0)), 1.0, abs_tol=1e-9):
-                    self.end = Decimal(cast(int | float, col_def["value"]))
+                if isclose(col_def.rgba[-1], 1.0, abs_tol=1e-9):
+                    self.end = Decimal(col_def.value)
                     break
             if self.end.is_nan():
-                self.end = Decimal(cast(int | float, ramp.ramp[-1]["value"]))
+                self.end = Decimal(ramp.ramp[-1].value)
         for t in self.ticks:
             if t < self.begin or t > self.end:
                 raise ConfigException("Explicit ticks must all be within legend begin/end range")
@@ -404,12 +386,6 @@ class RampLegendBase(StyleDefBase.Legend, OWSMetadataConfig):
                 )
         self.parse_metadata(cast(CFG_DICT, self._raw_cfg))
 
-        # Check for legacy legend tips in ramp:
-        for r in ramp.ramp:
-            if "legend" in r:
-                raise ConfigException(
-                    f"Style {self.style.name} uses a no-longer supported format for legend configuration.  " +
-                    "Please refer to the documentation and update your config")
 
     def tick_label(self, tick):
         try:
@@ -432,11 +408,11 @@ class RampLegendBase(StyleDefBase.Legend, OWSMetadataConfig):
         bands = cast(MutableMapping[str, list[tuple[float, float, float]]], defaultdict(list))
         started = False
         finished = False
-        for index, ramp_point in enumerate(self.style_or_mdh.color_ramp.ramp):
+        for index, ramp_node in enumerate(self.style_or_mdh.color_ramp.ramp):
             if finished:
                 break
 
-            value = cast(float | int, ramp_point.get("value"))
+            value = ramp_node.value
             normalized = (value - float(self.begin)) / float(normalize_factor)
 
             if not started:

--- a/datacube_ows/styles/ramp.py
+++ b/datacube_ows/styles/ramp.py
@@ -170,7 +170,7 @@ class ColorRamp:
         """
         self.style = style
         if "color_ramp" in ramp_cfg:
-            raw_scaled_ramp = make_ramp_representation(cast(list[CFG_DICT], ramp_cfg["color_ramp"]), self.style.name)
+            raw_scaled_ramp = make_ramp_representation(cast(RAMP_SPEC, ramp_cfg["color_ramp"]), self.style.name)
         else:
             rmin, rmax = cast(list[float], ramp_cfg["range"])
             unscaled_ramp = UNSCALED_DEFAULT_RAMP

--- a/datacube_ows/styles/ramp.py
+++ b/datacube_ows/styles/ramp.py
@@ -51,7 +51,7 @@ RampRepr = list[RampNode]
 
 
 def make_ramp_representation(ramp_spec: RAMP_SPEC, style_name: str) -> RampRepr:
-    rep = cast(RampRepr, [])
+    rep: RampRepr = []
     for node in ramp_spec:
         if "value" not in node:
             raise ConfigException(f'Color ramp element without a value in style {style_name}')

--- a/datacube_ows/styles/ramp.py
+++ b/datacube_ows/styles/ramp.py
@@ -141,7 +141,7 @@ def read_mpl_ramp(mpl_ramp: str) -> RampRepr:
     :param mpl_ramp: The name of Matplotlib colour ramp
     :return: A normalised ramp specification.
     """
-    unscaled_cmap = cast(RampRepr, [])
+    unscaled_cmap: RampRepr = []
     try:
         cmap = plt.get_cmap(mpl_ramp)
     except:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -10,7 +10,7 @@ services:
         - opendatacube/ows:_builder
     image: opendatacube/ows:latest
     # Uncomment for use with non-dockerised postgres (for docker-compose 1.x)
-    # network_mode: host
+    network_mode: host
     environment:
       LOCAL_UID: ${LOCAL_UID:-1000}
       LOCAL_GID: ${LOCAL_GID:-1000}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -10,7 +10,7 @@ services:
         - opendatacube/ows:_builder
     image: opendatacube/ows:latest
     # Uncomment for use with non-dockerised postgres (for docker-compose 1.x)
-    network_mode: host
+    # network_mode: host
     environment:
       LOCAL_UID: ${LOCAL_UID:-1000}
       LOCAL_GID: ${LOCAL_GID:-1000}

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -74,27 +74,27 @@ alternative applies):
 
    Config loaded as **json** from relative file path.
 
-3. Begins with an open brace "{", e.g. ``{...}``
-
-   Config loaded directly from the environment variable as **json** (not recommended)
-
-4. Ends in ".json", e.g. ``cfg_prod.json``
+3. Ends in ".json", e.g. ``cfg_prod.json``
 
    Config loaded from **json** file in working directory.
 
-5. Has a valid ``s3://`` URL and a ``.json`` extension
+4. Has a valid ``s3://`` URL and a ``.json`` extension
 
    The configuration is fetched from AWS S3 in json format.
 
    N.B. Configuration can only be loaded from S3 if the environment variable ``$DATACUBE_OWS_CFG_ALLOW_S3``
    is set to ``yes``, otherwise a ``ConfigurationException`` will be raised.
 
-6. Contains a dot (.), e.g. ``package.sub_package.module.cfg_object_name``
+5. Contains a dot (.), e.g. ``package.sub_package.module.cfg_object_name``
 
    Imported as python object (expected to be a dictionary).
 
    N.B. It is up to you to ensure that the Python file in question is in your Python path and
    that all package directories have a ``__init__.py`` file, etc.
+
+6. Begins with an open brace "{", e.g. ``{...}``
+
+   Config loaded directly from the environment variable as **json** (not recommended)
 
 7. Valid python object name, e.g. ``cfg_prod``
 

--- a/docs/environment_variables.rst
+++ b/docs/environment_variables.rst
@@ -30,8 +30,7 @@ If you want to use a ``postgis`` based ODC index, you should also specify the in
 setting e.g. ``$ODC_MYENV_INDEX_DRIVER`` to ``postgis``.
 
 Other valid methods for configuring an OpenDatacube instance (e.g. a ``.datacube.conf`` file)
-should also work.  Note that OWS currently only works with legacy/postgres index driver.
-Postgis support is hopefully coming soon.
+should also work.  As of the 1.9.0 release, OWS supports both the postgres and postgis drivers.
 
 The old `$DB_HOSTNAME`, `$DB_DATABASE` etc. environment variables are now STRONGLY DEPRECATED as they
 only work in a single-index environment.

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,6 @@ install_requirements = [
     'requests',
     'affine',
     'click',
-    'colour',
     'fsspec',
     'lxml',
     'deepdiff',

--- a/tests/test_mpl_cmaps.py
+++ b/tests/test_mpl_cmaps.py
@@ -17,7 +17,5 @@ def test_get_mpl_cmap():
     ows_ramp_dict = read_mpl_ramp(matplotlib_ramp_name)
     assert len(ows_ramp_dict) == 11
     for cmap in ows_ramp_dict:
-        assert "color" in cmap
-        assert "value" in cmap
-        assert cmap["color"].startswith("#")
-        assert isinstance(cmap["value"], float)
+        assert cmap.color.startswith("#")
+        assert isinstance(cmap.value, float)

--- a/tests/test_styles.py
+++ b/tests/test_styles.py
@@ -732,55 +732,55 @@ def test_reint():
 
 
 def test_createcolordata():
-    from matplotlib.colors import to_rgb
+    from matplotlib.colors import to_rgba
 
     from datacube_ows.styles.colormap import ColorMapStyleDef
 
     band = np.array([0, 0, 1, 1, 2, 2])
     da = DataArray(band, name='foo')
-    rgb = to_rgb("#FFFFFF")
+    rgba = to_rgba("#FFFFFF")
 
-    data = ColorMapStyleDef.create_colordata(da, rgb, 1.0, (band >= 0))
+    data = ColorMapStyleDef.create_colordata(da, rgba, (band >= 0))
     assert (data == 1.0).all()
 
 
 def test_createcolordata_alpha():
-    from matplotlib.colors import to_rgb
+    from matplotlib.colors import to_rgba
 
     from datacube_ows.styles.colormap import ColorMapStyleDef
 
     band = np.array([0, 0, 1, 1, 2, 2])
     da = DataArray(band, name='foo')
-    rgb = to_rgb("#FFFFFF")
+    rgba = to_rgba("#FFFFFF", alpha=0.0)
 
-    data = ColorMapStyleDef.create_colordata(da, rgb, 0.0, (band >= 0))
+    data = ColorMapStyleDef.create_colordata(da, rgba, (band >= 0))
     assert (data["alpha"] == 0).all()
 
 
 def test_createcolordata_mask():
-    from matplotlib.colors import to_rgb
+    from matplotlib.colors import to_rgba
 
     from datacube_ows.styles.colormap import ColorMapStyleDef
 
     band = np.array([0, 0, 1, 1, 2, 2])
     da = DataArray(band, name='foo')
-    rgb = to_rgb("#FFFFFF")
+    rgba = to_rgba("#FFFFFF", alpha=0.0)
 
-    data = ColorMapStyleDef.create_colordata(da, rgb, 0.0, (band > 0))
+    data = ColorMapStyleDef.create_colordata(da, rgba, (band > 0))
     assert (np.isnan(data["red"][0:1:1])).all()
     assert (np.isfinite(data["red"][2:5:1])).all()
 
 
 def test_createcolordata_remask():
-    from matplotlib.colors import to_rgb
+    from matplotlib.colors import to_rgba
 
     from datacube_ows.styles.colormap import ColorMapStyleDef
 
     band = np.array([0, 0, 1, 1, np.nan, np.nan])
     da = DataArray(band, name='foo')
-    rgb = to_rgb("#FFFFFF")
+    rgba = to_rgba("#FFFFFF", alpha=0.0)
 
-    data = ColorMapStyleDef.create_colordata(da, rgb, 0.0, np.array([True, True, True, True, True, True]))
+    data = ColorMapStyleDef.create_colordata(da, rgba, np.array([True, True, True, True, True, True]))
     assert (np.isfinite(data["red"][0:3:1])).all()
     assert (np.isnan(data["red"][4:5:1])).all()
 

--- a/tests/test_styles.py
+++ b/tests/test_styles.py
@@ -732,39 +732,39 @@ def test_reint():
 
 
 def test_createcolordata():
-    from colour import Color
+    from matplotlib.colors import to_rgb
 
     from datacube_ows.styles.colormap import ColorMapStyleDef
 
     band = np.array([0, 0, 1, 1, 2, 2])
     da = DataArray(band, name='foo')
-    rgb = Color("#FFFFFF")
+    rgb = to_rgb("#FFFFFF")
 
     data = ColorMapStyleDef.create_colordata(da, rgb, 1.0, (band >= 0))
     assert (data == 1.0).all()
 
 
 def test_createcolordata_alpha():
-    from colour import Color
+    from matplotlib.colors import to_rgb
 
     from datacube_ows.styles.colormap import ColorMapStyleDef
 
     band = np.array([0, 0, 1, 1, 2, 2])
     da = DataArray(band, name='foo')
-    rgb = Color("#FFFFFF")
+    rgb = to_rgb("#FFFFFF")
 
     data = ColorMapStyleDef.create_colordata(da, rgb, 0.0, (band >= 0))
     assert (data["alpha"] == 0).all()
 
 
 def test_createcolordata_mask():
-    from colour import Color
+    from matplotlib.colors import to_rgb
 
     from datacube_ows.styles.colormap import ColorMapStyleDef
 
     band = np.array([0, 0, 1, 1, 2, 2])
     da = DataArray(band, name='foo')
-    rgb = Color("#FFFFFF")
+    rgb = to_rgb("#FFFFFF")
 
     data = ColorMapStyleDef.create_colordata(da, rgb, 0.0, (band > 0))
     assert (np.isnan(data["red"][0:1:1])).all()
@@ -772,13 +772,13 @@ def test_createcolordata_mask():
 
 
 def test_createcolordata_remask():
-    from colour import Color
+    from matplotlib.colors import to_rgb
 
     from datacube_ows.styles.colormap import ColorMapStyleDef
 
     band = np.array([0, 0, 1, 1, np.nan, np.nan])
     da = DataArray(band, name='foo')
-    rgb = Color("#FFFFFF")
+    rgb = to_rgb("#FFFFFF")
 
     data = ColorMapStyleDef.create_colordata(da, rgb, 0.0, np.array([True, True, True, True, True, True]))
     assert (np.isfinite(data["red"][0:3:1])).all()
@@ -786,23 +786,23 @@ def test_createcolordata_remask():
 
 
 def test_scale_ramp():
-    from datacube_ows.styles.ramp import scale_unscaled_ramp
+    from datacube_ows.styles.ramp import scale_unscaled_ramp, RampNode
 
     input = [
-        {"value": 0.0, "color": "red", "alpha": 0.5},
-        {"value": 0.5, "color": "green"},
-        {"value": 1.0, "color": "blue"},
+        RampNode(0.0, "red", alpha=0.5),
+        RampNode(0.5, "green"),
+        RampNode(1.0, "blue"),
     ]
     output = scale_unscaled_ramp(-100.0, 100.0, input)
-    assert output[0]["color"] == "red"
-    assert output[0]["alpha"] == 0.5
-    assert output[0]["value"] == -100.0
-    assert output[1]["color"] == "green"
-    assert output[1]["alpha"] == 1.0
-    assert output[1]["value"] == 0.0
-    assert output[2]["color"] == "blue"
-    assert output[2]["alpha"] == 1.0
-    assert output[2]["value"] == 100.0
+    assert output[0].color == "red"
+    assert output[0].rgba[-1] == 0.5
+    assert output[0].value == -100.0
+    assert output[1].color == "green"
+    assert output[1].rgba[-1] == 1.0
+    assert output[1].value == 0.0
+    assert output[2].color == "blue"
+    assert output[2].rgba[-1] == 1.0
+    assert output[2].value == 100.0
 
 
 def test_bad_mpl_ramp():


### PR DESCRIPTION
As noted in #1126, the `colour` library has not been updated in nearly 8 years and appears orphaned.  I have ported to the `matplotlib.colors` and switched a more consistent internal RGBA colour+alpha representation in both the color ramp and color map style types, with associated simplification of code and type-checking (and of course removed the dependency on `colour`)

Also included in this PR are fixes to minor documentation issues as identified in #1098, #1108 and #1135.

<!-- readthedocs-preview datacube-ows start -->
----
📚 Documentation preview 📚: https://datacube-ows--1140.org.readthedocs.build/en/1140/

<!-- readthedocs-preview datacube-ows end -->