### PR TITLE
wms_utils: fix relativedelta param type

### DIFF
--- a/datacube_ows/wms_utils.py
+++ b/datacube_ows/wms_utils.py
@@ -259,7 +259,7 @@ def parse_time_delta(delta_str):
     pattern = (r'P((?P<years>\d+)Y)?((?P<months>\d+)M)?((?P<days>\d+)D)?'
                r'(T(((?P<hours>\d+)H)?((?P<minutes>\d+)M)?((?P<seconds>\d+)S)?)?)?')
     parts = re.search(pattern, delta_str).groupdict()
-    return relativedelta(**{k: float(v) for k, v in parts.items() if v is not None})
+    return relativedelta(**{k: int(v) for k, v in parts.items() if v is not None})
 
 
 def parse_wms_time_string(t, start=True):


### PR DESCRIPTION
The regexp matches digits, so the result
is an int, just like relativedelta expects,
so convert to int instead of float.

<!-- readthedocs-preview datacube-ows start -->
----
📚 Documentation preview 📚: https://datacube-ows--1145.org.readthedocs.build/en/1145/

<!-- readthedocs-preview datacube-ows end -->