### PR TITLE
Use Ruff instead of flake8

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -48,8 +48,8 @@ jobs:
           pip install .[test,dev]
           pylint -j 2 --reports no datacube_ows --disable=C,R,W,E1136
 
-  flake8:
-    name: flake8
+  ruff:
+    name: ruff
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -58,13 +58,9 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.10"
-      - run: python -m pip install flake8
-      - name: flake8 cleanup imported but unused
-        uses: liskin/gh-problem-matcher-wrap@v3
-        with:
-          linters: flake8
-          run: |
-            flake8 . --exclude Dockerfile --ignore=E501 --select=F401,E201,E202,E203,E502,E241,E225,E306,E231,E226,E123,F811
+      - run: python -m pip install ruff
+      - name: Ruff check
+        run: ruff check --output-format=github
 
   mypy:
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,11 +5,11 @@ repos:
     -   id: check-yaml
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
--   repo: https://github.com/PyCQA/flake8
-    rev: 7.2.0
+-   repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.11.7
     hooks:
-    -   id: flake8
-        args: ["--ignore=E501", "--select=F401,E201,E202,E203,E502,E241,E225,E306,E231,E226,E123,F811"]
+    -   id: ruff
+        args: [--fix, --show-fixes, --output-format, grouped]
 # -   repo: https://github.com/PyCQA/bandit
 #     rev: 1.7.4
 #     hooks:

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -72,13 +72,13 @@ Get Started!
 
    Now you can make your changes locally.
 
-5. When you're done making changes, check that your changes pass flake8 and the tests, including testing other Python versions with tox::
+5. When you're done making changes, check that your changes pass Ruff and the tests, including testing other Python versions with tox::
 
-    $ flake8 datacube-ows tests
+    $ ruff check
     $ python setup.py test or py.test
     $ tox
 
-   To get flake8 and tox, just pip install them into your virtualenv.
+   To get Ruff and tox, just pip install them into your virtualenv.
 
 6. Commit your changes and push your branch to GitHub::
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -10,13 +10,13 @@ Datacube-ows version 1.9.x indicates that it is designed work with datacube-core
 1.9.1 (2025-04-16)
 ------------------
 
-* CI fixes and autoupdates (#1101, #1102, #1107, #1106, #1097, #1105, #1117, #1124, #1114, #1121, #1125, #1129, #1136)
+* CI fixes and automatic updates (#1101, #1102, #1107, #1106, #1097, #1105, #1117, #1124, #1114, #1121, #1125, #1129, #1136)
 * wsgi: use 1.9 config variable name (#1110)
 * Misc code cleanup and updates (#1118, #1119, #1111, #1115, #1120, #1123, #1128, #1116, #1130, #1131, #1134, #1141,
   #1142, #1143, #1144, #1145, #1146)
 * Docker cleanups and improvements (#1122)
 * Documentation cleanup (#1113)
-* Properly close db connections in schema mgmt ops (#1133)
+* Properly close db connections in schema management ops (#1133)
 * Refactor styling engine to remove dependency on orphaned colour library (#1140)
 * Make ping multi-db aware (#1139)
 * Update HISTORY.rst and default version number ready for release (#1147)

--- a/README.rst
+++ b/README.rst
@@ -78,7 +78,7 @@ Linting
 
 .. code-block::
 
-    flake8 . --exclude Dockerfile --ignore=E501 --select=F401,E201,E202,E203,E502,E241,E225,E306,E231,E226,E123,F811
+    ruff check
     isort --check --diff **/*.py
     autopep8  -r  --diff . --select F401,E201,E202,E203,E502,E241,E225,E306,E231,E226,E123,F811
 

--- a/datacube_ows/config_utils.py
+++ b/datacube_ows/config_utils.py
@@ -109,7 +109,7 @@ def get_file_loc(x: str) -> str:
     xp = urlparse(x)
     if xp.scheme in ("s3",): # NOTE: could add http/s, ...
         enable_s3 = os.environ.get("DATACUBE_OWS_CFG_ALLOW_S3", "no")
-        if not enable_s3.lower() in ("yes", "true", "1", "y"):
+        if enable_s3.lower() not in ("yes", "true", "1", "y"):
             raise ConfigException("Please set environment variable 'DATACUBE_OWS_CFG_ALLOW_S3=YES' "
                               + "to enable OWS config from AWS S3")
         cwd = xp.scheme + "://" + xp.netloc +  xp.path.rsplit("/", 1)[0]

--- a/datacube_ows/feature_info.py
+++ b/datacube_ows/feature_info.py
@@ -94,10 +94,7 @@ def _make_band_dict(prod_cfg: OWSNamedLayer, pixel_dataset: xarray.Dataset) -> d
             for flag, val in flag_dict.items():
                 if not val:
                     continue
-                if val == True:
-                    ret_val[flag_def[flag].get('description', flag)] = True
-                else:
-                    ret_val[flag_def[flag].get('description', flag)] = val
+                ret_val[flag_def[flag].get('description', flag)] = val
             band_dict[k] = ret_val
         else:
             try:

--- a/datacube_ows/index/postgis/api.py
+++ b/datacube_ows/index/postgis/api.py
@@ -42,7 +42,7 @@ class OWSPostgisIndex(OWSAbstractIndex):
                 )
                 for r in results:
                     db_ok = True
-        except:
+        except Exception:
             pass
         return db_ok
 

--- a/datacube_ows/index/postgis/product_ranges.py
+++ b/datacube_ows/index/postgis/product_ranges.py
@@ -137,9 +137,9 @@ def create_range_entry(layer: OWSNamedLayer, cache: dict[LayerSignature, list[st
                   dates.add(dat_ran.lower)
 
         if layer.time_resolution.is_subday():
-          date_formatter = lambda d: d.isoformat()
+          date_formatter = lambda d: d.isoformat()  # noqa: E731
         else:
-          date_formatter = lambda d: d.strftime("%Y-%m-%d")
+          date_formatter = lambda d: d.strftime("%Y-%m-%d")  # noqa: E731
 
         dates = sorted(dates)
         conn.execute(text("""
@@ -266,9 +266,9 @@ def get_ranges(layer: OWSNamedLayer) -> LayerExtent | None:
     for result in results:
         conn.close()
         if layer.time_resolution.is_subday():
-            dt_parser: Callable[[str], datetime | date] = lambda dts: datetime.fromisoformat(dts)
+            dt_parser: Callable[[str], datetime | date] = lambda dts: datetime.fromisoformat(dts)  # noqa: E731
         else:
-            dt_parser = lambda dts: datetime.strptime(dts, "%Y-%m-%d").date()
+            dt_parser = lambda dts: datetime.strptime(dts, "%Y-%m-%d").date()  # noqa: E731
         times = [dt_parser(d) for d in result.dates if d is not None]
         if not times:
             return None

--- a/datacube_ows/index/postgres/api.py
+++ b/datacube_ows/index/postgres/api.py
@@ -40,7 +40,7 @@ class OWSPostgresIndex(OWSAbstractIndex):
                 )
                 for r in results:
                     db_ok = True
-        except:
+        except Exception:
             pass
         return db_ok
 

--- a/datacube_ows/index/postgres/product_ranges.py
+++ b/datacube_ows/index/postgres/product_ranges.py
@@ -151,9 +151,9 @@ def create_range_entry(layer: OWSNamedLayer, cache: dict[LayerSignature, list[st
                   dates.add(dat_ran.lower)
 
         if layer.time_resolution.is_subday():
-          date_formatter = lambda d: d.isoformat()
+          date_formatter = lambda d: d.isoformat()  # noqa: E731
         else:
-          date_formatter = lambda d: d.strftime("%Y-%m-%d")
+          date_formatter = lambda d: d.strftime("%Y-%m-%d")  # noqa: E731
 
         dates = sorted(dates)
         conn.execute(text("""
@@ -229,9 +229,9 @@ def get_ranges(layer: OWSNamedLayer) -> LayerExtent | None:
     for result in results:
         conn.close()
         if layer.time_resolution.is_subday():
-            dt_parser: Callable[[str], datetime | date] = lambda dts: datetime.fromisoformat(dts)
+            dt_parser: Callable[[str], datetime | date] = lambda dts: datetime.fromisoformat(dts)  # noqa: E731
         else:
-            dt_parser = lambda dts: datetime.strptime(dts, "%Y-%m-%d").date()
+            dt_parser = lambda dts: datetime.strptime(dts, "%Y-%m-%d").date()  # noqa: E731
         times = [dt_parser(d) for d in result.dates if d is not None]
         if not times:
             return None

--- a/datacube_ows/ows_configuration.py
+++ b/datacube_ows/ows_configuration.py
@@ -774,7 +774,7 @@ class OWSNamedLayer(OWSExtensibleConfigEntry, OWSLayer):
 
     # pylint: disable=attribute-defined-outside-init
     def parse_wcs(self, cfg: CFG_DICT | bool) -> None:
-        if cfg == False or not self.global_cfg.wcs:
+        if cfg is False or not self.global_cfg.wcs:
             self.wcs = False
         else:
             self.wcs = not cast(CFG_DICT, cfg).get("disable", False)

--- a/datacube_ows/ows_configuration.py
+++ b/datacube_ows/ows_configuration.py
@@ -389,11 +389,11 @@ class OWSFolder(OWSLayer):
 
     @override
     def unready_layer_count(self) -> int:
-        return sum([l.layer_count() for l in self.unready_layers])
+        return sum([l.layer_count() for l in self.unready_layers])  # noqa: E741
 
     @override
     def layer_count(self) -> int:
-        return sum([l.layer_count() for l in self.child_layers])
+        return sum([l.layer_count() for l in self.child_layers])  # noqa: E741
 
     @override
     def make_ready(self, *args, **kwargs) -> None:

--- a/datacube_ows/styles/expression.py
+++ b/datacube_ows/styles/expression.py
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
 
 # Lark stuff.
 
-identity = lambda ev, x: x
+identity = lambda ev, x: x  # noqa: E731
 
 
 def empty_gen(ev, a) -> set:

--- a/datacube_ows/styles/ramp.py
+++ b/datacube_ows/styles/ramp.py
@@ -144,7 +144,7 @@ def read_mpl_ramp(mpl_ramp: str) -> RampRepr:
     unscaled_cmap: RampRepr = []
     try:
         cmap = plt.get_cmap(mpl_ramp)
-    except:
+    except Exception:
         raise ConfigException(f"Invalid Matplotlib name: {mpl_ramp}")
     val_range = numpy.arange(0.1, 1.1, 0.1)
     rgba_hex = to_hex(cmap(0.0))

--- a/datacube_ows/update_ranges_impl.py
+++ b/datacube_ows/update_ranges_impl.py
@@ -132,7 +132,7 @@ def main(layers: list[str],
                 dc = Datacube(env=cfg.default_env, app=app)
             else:
                 dc = Datacube(env=env, app=app)
-        except:
+        except Exception:
             click.echo(f"Unable to connect to the {env or cfg.default_env} database.")
             sys.exit(1)
 

--- a/datacube_ows/utils.py
+++ b/datacube_ows/utils.py
@@ -61,22 +61,22 @@ def group_by_begin_datetime(pnames: list[str] | None = None,
     Returns an ODC GroupBy object, suitable for daily/monthly/yearly/etc statistical/summary data.
     (Or for sub-day time resolution data)
     """
-    base_sort_key = lambda ds: ds.time.begin
+    base_sort_key = lambda ds: ds.time.begin  # noqa: E731
     if pnames:
         index = {
             pn: i
             for i, pn in enumerate(pnames)
         }
-        sort_key = lambda ds: (index.get(ds.type.name), base_sort_key(ds))
+        sort_key = lambda ds: (index.get(ds.type.name), base_sort_key(ds))  # noqa: E731
     else:
         sort_key = base_sort_key
     if truncate_dates:
-        grp_by = lambda ds: npdt64(datetime.datetime(
+        grp_by = lambda ds: npdt64(datetime.datetime(  # noqa: E731
             ds.time.begin.year,
             ds.time.begin.month,
             ds.time.begin.day), "ns")
     else:
-        grp_by = lambda ds: npdt64(datetime.datetime(
+        grp_by = lambda ds: npdt64(datetime.datetime(  # noqa: E731
             ds.time.begin.year,
             ds.time.begin.month,
             ds.time.begin.day,
@@ -92,33 +92,33 @@ def group_by_begin_datetime(pnames: list[str] | None = None,
 
 
 def group_by_solar(pnames: list[str] | None = None) -> GroupBy:
-    base_sort_key = lambda ds: ds.time.begin
+    base_sort_key = lambda ds: ds.time.begin  # noqa: E731
     if pnames:
         index = {
             pn: i
             for i, pn in enumerate(pnames)
         }
-        sort_key = lambda ds: (index.get(ds.type.name), base_sort_key(ds))
+        sort_key = lambda ds: (index.get(ds.type.name), base_sort_key(ds))  # noqa: E731
     else:
         sort_key = base_sort_key
     return GroupBy(
         dimension='time',
-        group_by_func=lambda x: npdt64(solar_day(x), "ns"),  # type: ignore[call-overload]
+        group_by_func=lambda x: npdt64(solar_day(x), "ns"),  # type: ignore[call-overload]  # noqa: E731
         units='seconds since 1970-01-01 00:00:00',
         sort_key=sort_key
     )
 
 
 def group_by_mosaic(pnames: list[str] | None = None) -> GroupBy:
-    base_sort_key = lambda ds: ds.time.begin
+    base_sort_key = lambda ds: ds.time.begin  # noqa: E731
     if pnames:
         index = {
             pn: i
             for i, pn in enumerate(pnames)
         }
-        sort_key: Callable[[Dataset], tuple] = lambda ds: (solar_day(ds), index.get(ds.type.name), base_sort_key(ds))
+        sort_key: Callable[[Dataset], tuple] = lambda ds: (solar_day(ds), index.get(ds.type.name), base_sort_key(ds))  # noqa: E731
     else:
-        sort_key = lambda ds: (solar_day(ds), base_sort_key(ds))
+        sort_key = lambda ds: (solar_day(ds), base_sort_key(ds))  # noqa: E731
     return GroupBy(
         dimension='time',
         group_by_func=lambda n: npdt64(datetime.datetime(1970, 1, 1), "ns"),

--- a/datacube_ows/wcs1_utils.py
+++ b/datacube_ows/wcs1_utils.py
@@ -99,7 +99,7 @@ class WCS1GetCoverageRequest:
                                 locator="BBOX or TIME parameter")
         try:
             self.minx, self.miny, self.maxx, self.maxy = map(float, args['bbox'].split(','))
-        except:
+        except Exception:
             raise WCS1Exception("Invalid BBOX parameter",
                                 WCS1Exception.INVALID_PARAMETER_VALUE,
                                 locator="BBOX parameter")

--- a/datacube_ows/wms_utils.py
+++ b/datacube_ows/wms_utils.py
@@ -341,7 +341,7 @@ def single_style_from_args(layer: OWSNamedLayer, args, required: bool = True):
         mpl_ramp = args["colorscheme"]
         try:
             plt.get_cmap(mpl_ramp)
-        except:
+        except Exception:
             raise WMSException(f"Invalid Matplotlib ramp name: {mpl_ramp}",
                                locator="Colorscalerange parameter")
         colorscalerange = args.get("colorscalerange", "0,1").split(",")

--- a/integration_tests/test_wcs_server.py
+++ b/integration_tests/test_wcs_server.py
@@ -1254,14 +1254,14 @@ def test_wcs21_describecoverage(ows_server) -> None:
         ows_server.url + "/wcs",
         params={
             "request": "DescribeCoverage",
-            "coverageid": ",".join(l.name for l in layers[0:-2]),
+            "coverageid": ",".join(l.name for l in layers[0:-2]),  # noqa: E741
             "version": "2.1.0",
             "service": "WCS",
         },
     )
     assert r.status_code == 200
     assert "max-age" in r.headers["Cache-Control"]
-    for l in layers[0:-2]:
+    for l in layers[0:-2]:  # noqa: E741
         assert l.name in r.text
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,31 @@ ignore_missing_imports = true
 warn_redundant_casts = true
 warn_unused_ignores = true
 
+[tool.ruff]
+src = ["datacube_ows", "docs", "tests", "integration_tests"]
+
+[tool.ruff.lint]
+select = [
+    "A",  # Don't shadow built-ins
+    "E",  # pycodestyle errors
+    "W",  # pycodestyle warnings
+    "F",  # pyflakes
+    "T10", # flake8-debugger
+]
+ignore = [
+    "E501",
+    "F841", # FIXME: disabled to simplify switch to Ruff.
+]
+
+[tool.ruff.lint.per-file-ignores]
+# Stay close to the generated file for readthedocs, so ignore some rules.
+"docs/conf.py" = ["A001", "E402"]
+# Using pytest_namespace requires assignment before importing pytest.
+"integration_tests/conftest.py" = ["E402"]
+
+[tool.ruff.lint.pycodestyle]
+max-line-length = 120
+
 [build-system]
 requires = ["setuptools>=65.5.1", "wheel>=0.38.1", "setuptools_scm[toml]>3.4"]
 

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ dev_requirements = [
     'sphinx_click',
     'pre-commit',
     'mypy',
-    'flake8',
+    'ruff',
     'types-pytz',
     'types-python-dateutil',
     'types-requests',

--- a/tests/test_band_utils.py
+++ b/tests/test_band_utils.py
@@ -71,15 +71,15 @@ def band_mapper():
 
 
 def test_scale_data() -> None:
-    assert not scale_data(TEST_ARR_1, [0.0, 1.0], [0.0, 1.0]) is None
+    assert scale_data(TEST_ARR_1, [0.0, 1.0], [0.0, 1.0]) is not None
 
 
 def test_sum_bands() -> None:
-    assert not sum_bands(TEST_XARR, "b1", "b2") is None
+    assert sum_bands(TEST_XARR, "b1", "b2") is not None
 
 
 def test_pre_scaled_sum_bands() -> None:
-    assert not pre_scaled_sum_bands(TEST_XARR, "b1", "b2", 1.0, 0.0, 1.0, 0.0) is None
+    assert pre_scaled_sum_bands(TEST_XARR, "b1", "b2", 1.0, 0.0, 1.0, 0.0) is not None
     unscaled = sum_bands(TEST_XARR, "b1", "b2")
     assert pre_scaled_sum_bands(TEST_XARR, "b1", "b2").equals(unscaled)
     assert pre_scaled_sum_bands(TEST_XARR, "b1", "b2", 1.0, 0.0, 1.0, 0.0).equals(
@@ -92,7 +92,7 @@ def test_pre_scaled_sum_bands() -> None:
 
 def test_pre_scaled_delta_bands() -> None:
     assert (
-        not pre_scaled_delta_bands(TEST_XARR2, "b3", "b2", 1.0, 0.0, 1.0, 0.0) is None
+        pre_scaled_delta_bands(TEST_XARR2, "b3", "b2", 1.0, 0.0, 1.0, 0.0) is not None
     )
     unscaled = delta_bands(TEST_XARR2, "b3", "b2")
     assert pre_scaled_delta_bands(TEST_XARR2, "b3", "b2").equals(unscaled)
@@ -105,17 +105,16 @@ def test_pre_scaled_delta_bands() -> None:
 
 
 def test_norm_diff(band_mapper) -> None:
-    assert not norm_diff(TEST_XARR, "b1", "b2") is None
-    assert not norm_diff(TEST_XARR, "b1a", "b2", band_mapper, scale_from=[0, 1]) is None
+    assert norm_diff(TEST_XARR, "b1", "b2") is not None
+    assert norm_diff(TEST_XARR, "b1a", "b2", band_mapper, scale_from=[0, 1]) is not None
 
 
 def test_pre_scaled_norm_diff(band_mapper) -> None:
-    assert not pre_scaled_norm_diff(TEST_XARR, "b1", "b2") is None
+    assert pre_scaled_norm_diff(TEST_XARR, "b1", "b2") is not None
     assert (
-        not pre_scaled_norm_diff(
+        pre_scaled_norm_diff(
             TEST_XARR, "b1a", "b2", band_mapper=band_mapper, scale_from=[0, 1]
-        )
-        is None
+        ) is not None
     )
     assert np.array_equal(
         pre_scaled_norm_diff(TEST_XARR2, "b3", "b2", 2.0, 0.0, 6.0, 0.0).values,
@@ -128,55 +127,55 @@ def test_pre_scaled_norm_diff(band_mapper) -> None:
 
 
 def test_constant(band_mapper) -> None:
-    assert not constant(TEST_XARR, "b1", 10) is None
-    assert not constant(TEST_XARR, "b1a", 10, band_mapper) is None
+    assert constant(TEST_XARR, "b1", 10) is not None
+    assert constant(TEST_XARR, "b1a", 10, band_mapper) is not None
 
 
 def test_band_quotient(band_mapper) -> None:
-    assert not band_quotient(TEST_XARR, "b1", "b2") is None
-    assert not band_quotient(TEST_XARR, "b1", "b2", band_mapper) is None
+    assert band_quotient(TEST_XARR, "b1", "b2") is not None
+    assert band_quotient(TEST_XARR, "b1", "b2", band_mapper) is not None
 
 
 def test_band_quotient_sum() -> None:
-    assert not band_quotient_sum(TEST_XARR, "b1", "b2", "b1", "b2") is None
+    assert band_quotient_sum(TEST_XARR, "b1", "b2", "b1", "b2") is not None
 
 
 def test_single_band_log(band_mapper) -> None:
-    assert not single_band_log(TEST_XARR, "b1", 1.0, 1.0) is None
-    assert not single_band_log(TEST_XARR, "b1", 1.0, 1.0, band_mapper) is None
+    assert single_band_log(TEST_XARR, "b1", 1.0, 1.0) is not None
+    assert single_band_log(TEST_XARR, "b1", 1.0, 1.0, band_mapper) is not None
 
 
 def test_single_band(band_mapper) -> None:
-    assert not single_band(TEST_XARR, "b1") is None
-    assert not single_band(TEST_XARR, "b1", band_mapper) is None
+    assert single_band(TEST_XARR, "b1") is not None
+    assert single_band(TEST_XARR, "b1", band_mapper) is not None
 
 
 def test_multidate() -> None:
-    assert not multi_date_delta(TEST_XARR_T) is None
-    assert not multi_date_delta(TEST_XARR_T, time_direction=1) is None
+    assert multi_date_delta(TEST_XARR_T) is not None
+    assert multi_date_delta(TEST_XARR_T, time_direction=1) is not None
 
 
 def test_ndci() -> None:
-    assert not sentinel2_ndci(TEST_XARR, "b1", "b2", "b1", "b2") is None
+    assert sentinel2_ndci(TEST_XARR, "b1", "b2", "b1", "b2") is not None
 
 
 def test_single_band_offset_log(band_mapper) -> None:
-    assert not single_band_offset_log(TEST_XARR, "b1") is None
-    assert not single_band_offset_log(TEST_XARR, "b1", offset=0.5) is None
-    assert not single_band_offset_log(TEST_XARR, "b1", scale=100) is None
-    assert not single_band_offset_log(TEST_XARR, "b1", scale_from=[0.0, 4.0]) is None
-    assert not single_band_offset_log(TEST_XARR, "b1", scale_from=[0.0, 4.0], scale_to=[0, 1024]) is None
-    assert not single_band_offset_log(TEST_XARR, "b1", band_mapper=band_mapper) is None
-    assert not single_band_offset_log(TEST_XARR, "b1", mult_band="b2", band_mapper=band_mapper) is None
+    assert single_band_offset_log(TEST_XARR, "b1") is not None
+    assert single_band_offset_log(TEST_XARR, "b1", offset=0.5) is not None
+    assert single_band_offset_log(TEST_XARR, "b1", scale=100) is not None
+    assert single_band_offset_log(TEST_XARR, "b1", scale_from=[0.0, 4.0]) is not None
+    assert single_band_offset_log(TEST_XARR, "b1", scale_from=[0.0, 4.0], scale_to=[0, 1024]) is not None
+    assert single_band_offset_log(TEST_XARR, "b1", band_mapper=band_mapper) is not None
+    assert single_band_offset_log(TEST_XARR, "b1", mult_band="b2", band_mapper=band_mapper) is not None
 
 
 def test_single_band_arcsec(band_mapper) -> None:
-    assert not single_band_arcsec(TEST_XARR, "b1") is None
-    assert not single_band_arcsec(TEST_XARR, "b1", scale_from=[0.0, 0.8]) is None
-    assert not single_band_arcsec(TEST_XARR, "b1", scale_from=[0.0, 0.8], scale_to=[0, 1024]) is None
-    assert not single_band_arcsec(TEST_XARR, "b1", band_mapper=band_mapper) is None
+    assert single_band_arcsec(TEST_XARR, "b1") is not None
+    assert single_band_arcsec(TEST_XARR, "b1", scale_from=[0.0, 0.8]) is not None
+    assert single_band_arcsec(TEST_XARR, "b1", scale_from=[0.0, 0.8], scale_to=[0, 1024]) is not None
+    assert single_band_arcsec(TEST_XARR, "b1", band_mapper=band_mapper) is not None
 
 
 def test_rvi(band_mapper) -> None:
-    assert not radar_vegetation_index(TEST_XARR, "b1", "b2") is None
-    assert not radar_vegetation_index(TEST_XARR, "b1", "b2", band_mapper=band_mapper) is None
+    assert radar_vegetation_index(TEST_XARR, "b1", "b2") is not None
+    assert radar_vegetation_index(TEST_XARR, "b1", "b2", band_mapper=band_mapper) is not None

--- a/tests/test_mv_selopts.py
+++ b/tests/test_mv_selopts.py
@@ -12,15 +12,15 @@ def test_all() -> None:
 
 
 class MockSTV:
-    def __init__(self, id) -> None:
-        self.id = id
+    def __init__(self, id_) -> None:
+        self.id = id_
         self.c = self
 
 
 def test_ids_datasets() -> None:
     class MockSTV:
-        def __init__(self, id) -> None:
-            self.id = id
+        def __init__(self, id_) -> None:
+            self.id = id_
             self.c = self
     stv = MockSTV(42)
     assert MVSelectOpts.IDS.sel(stv) == [42]
@@ -35,7 +35,7 @@ def test_extent() -> None:
 
 def test_count() -> None:
     from sqlalchemy import text
-    stv = MockSTV(id=text("foo"))
+    stv = MockSTV(id_=text("foo"))
     sel = MVSelectOpts.COUNT.sel(stv)
     assert len(sel) == 1
     assert str(sel[0]) == "count(foo)"

--- a/tests/test_pyproj.py
+++ b/tests/test_pyproj.py
@@ -23,5 +23,5 @@ def test_pyproj_crs() -> None:
       try:
          crs = CRS(crs_string)
          assert crs is not None
-      except:
+      except Exception:
          assert False

--- a/tests/test_style_api.py
+++ b/tests/test_style_api.py
@@ -80,7 +80,7 @@ def test_external_legends(simple_rgb_style_cfg) -> None:
         "url": "http://fake.com/not/a/real/image_url.png"
     }
     style = StandaloneStyle(simple_rgb_style_cfg)
-    for l in style.legend_cfg.legend_urls:
+    for l in style.legend_cfg.legend_urls:  # noqa: E741
         assert style.legend_cfg.legend_urls[l] == "http://fake.com/not/a/real/image_url.png"
     simple_rgb_style_cfg["legend"] = {
         "url": {
@@ -235,7 +235,7 @@ def test_ramp_legend_ranges(simple_ramp_style_cfg) -> None:
 def test_ramp_legend_parse_errs(simple_ramp_style_cfg) -> None:
     simple_ramp_style_cfg["legend"] = {
         "begin": "0.15",
-        "begin": "0.95",
+        "begin": "0.95",  # noqa: F601
         "decimal_places": -1
     }
     with pytest.raises(ConfigException) as e:

--- a/tests/test_styles.py
+++ b/tests/test_styles.py
@@ -788,12 +788,12 @@ def test_createcolordata_remask() -> None:
 def test_scale_ramp() -> None:
     from datacube_ows.styles.ramp import scale_unscaled_ramp, RampNode
 
-    input = [
+    input_ = [
         RampNode(0.0, "red", alpha=0.5),
         RampNode(0.5, "green"),
         RampNode(1.0, "blue"),
     ]
-    output = scale_unscaled_ramp(-100.0, 100.0, input)
+    output = scale_unscaled_ramp(-100.0, 100.0, input_)
     assert output[0].color == "red"
     assert output[0].rgba[-1] == 0.5
     assert output[0].value == -100.0


### PR DESCRIPTION
Ruff is a fast linter that can check the rules of flake8 and a number of flake8 plugins. Ruff is made by the same people that make uv, and my experience from making a few functional bug reports on Ruff in Q2 2024 is that the bugs were fixed within hours/days, and a new release of Ruff was available within a week.

There are Ruff lint failures on the current develop branch, so this PR consists of a number of individual commits that fixes these problems in the code and gives a reasonable commit message for each one of them so git blame can be followed, and then a commit that adds Ruff to pyproject.toml, switches from flake8 to Ruff in the pre-commit config, and adds a couple of suppressions in the source code.

This PR mirrors https://github.com/opendatacube/datacube-core/pull/1789.

Here's a screenshot of a deliberate failure in this PR:

![image](https://github.com/user-attachments/assets/ac4e6876-4fd6-40ec-97fc-2ed9c5c44855)


<!-- readthedocs-preview datacube-ows start -->
----
📚 Documentation preview 📚: https://datacube-ows--1152.org.readthedocs.build/en/1152/

<!-- readthedocs-preview datacube-ows end -->