### PR TITLE
Remove unused variables

### DIFF
--- a/datacube_ows/data.py
+++ b/datacube_ows/data.py
@@ -250,7 +250,7 @@ def _write_empty(geobox: GeoBox) -> bytes:
                           count=1,
                           transform=None,
                           nodata=0,
-                          dtype='uint8') as thing:
+                          dtype='uint8'):
             pass
         return memfile.read()
 

--- a/datacube_ows/feature_info.py
+++ b/datacube_ows/feature_info.py
@@ -26,7 +26,7 @@ from datacube_ows.http_utils import (FlaskResponse, html_json_response,
 from datacube_ows.loading import DataStacker, ProductBandQuery
 from datacube_ows.ows_configuration import OWSNamedLayer, get_config
 from datacube_ows.styles import StyleDef
-from datacube_ows.time_utils import dataset_center_time, tz_for_geometry
+from datacube_ows.time_utils import dataset_center_time
 from datacube_ows.utils import log_call
 from datacube_ows.wms_utils import (GetFeatureInfoParameters,
                                     img_coords_to_geopoint)
@@ -88,7 +88,7 @@ def _make_band_dict(prod_cfg: OWSNamedLayer, pixel_dataset: xarray.Dataset) -> d
         if flag_def:
             try:
                 flag_dict = mask_to_dict(flag_def, band_val)
-            except TypeError as te:
+            except TypeError:
                 logging.warning('Working around for float bands')
                 flag_dict = mask_to_dict(flag_def, int(band_val))
             ret_val: dict[str, bool | str] = {}
@@ -155,7 +155,6 @@ def feature_info(args: dict[str, str]) -> FlaskResponse:
         # Make a 1x1 pixel geobox
         geo_point_geobox = GeoBox.from_geopolygon(
             geo_point, params.geobox.resolution, crs=params.geobox.crs)
-    tz = tz_for_geometry(geo_point_geobox.geographic_extent)
     stacker = DataStacker(params.layer, geo_point_geobox, params.times)
     # --- Begin code section requiring datacube.
     cfg = get_config()

--- a/datacube_ows/index/postgis/product_ranges.py
+++ b/datacube_ows/index/postgis/product_ranges.py
@@ -254,7 +254,7 @@ def sanitise_bbox(bbox: odc.geo.geom.BoundingBox) -> dict[str, float]:
 
 
 def get_ranges(layer: OWSNamedLayer) -> LayerExtent | None:
-    cfg = layer.global_cfg
+    _ = layer.global_cfg
     conn = get_sqlconn(layer.dc)
     results = conn.execute(text("""
         SELECT *

--- a/datacube_ows/index/postgres/product_ranges.py
+++ b/datacube_ows/index/postgres/product_ranges.py
@@ -218,7 +218,7 @@ def sanitise_bbox(bbox: odc.geo.geom.BoundingBox) -> dict[str, float]:
 
 
 def get_ranges(layer: OWSNamedLayer) -> LayerExtent | None:
-    cfg = layer.global_cfg
+    _ = layer.global_cfg
     conn = get_sqlconn(layer.dc)
     results = conn.execute(text("""
         SELECT *

--- a/datacube_ows/ows_configuration.py
+++ b/datacube_ows/ows_configuration.py
@@ -1317,7 +1317,7 @@ class OWSConfig(OWSMetadataConfig):
                 self.parse_wcs(None)
             try:
                 self.parse_layers(cast(list[CFG_DICT], cfg["layers"]))
-            except KeyError as e:
+            except KeyError:
                 raise ConfigException("Missing required config entry in 'layers' section")
 
             try:

--- a/datacube_ows/protocol_versions.py
+++ b/datacube_ows/protocol_versions.py
@@ -54,11 +54,11 @@ class SupportedSvc:
             try:
                 clean.append(int(part))
                 continue
-            except ValueError as e:
+            except ValueError:
                 pass
             try:
                 clean.append(int(re.split(r"[^\d]", part)[0]))
-            except ValueError as e:
+            except ValueError:
                 pass
             break
         return clean

--- a/datacube_ows/styles/ramp.py
+++ b/datacube_ows/styles/ramp.py
@@ -203,9 +203,9 @@ class ColorRamp:
                         leg_begin_before_idx = idx
                 if not leg_end_in_ramp and leg_end_before_idx is None:
                     if isclose(col_val, fleg_end, abs_tol=1e-9):
-                        end_in_ramp = True
+                        leg_end_in_ramp = True
                     elif col_val > fleg_end:
-                        end_before_idx = idx
+                        leg_end_before_idx = idx
             if not leg_begin_in_ramp:
                 rgba = self.rgba_at(fleg_begin)
                 begin_col_point = RampNode(fleg_begin, to_hex(rgba))

--- a/integration_tests/test_mv_index.py
+++ b/integration_tests/test_mv_index.py
@@ -31,13 +31,13 @@ def test_no_products() -> None:
     cfg = get_config()
     lyr = list(cfg.layer_index.values())[0]
     with pytest.raises(Exception) as e:
-        sel = mv_search(lyr.dc.index, MVSelectOpts.COUNT)
+        _ = mv_search(lyr.dc.index, MVSelectOpts.COUNT)
     assert "Must filter by product/layer" in str(e.value)
 
 
 def test_bad_set_opt() -> None:
     cfg = get_config()
-    lyr = list(cfg.layer_index.values())[0]
+    _ = list(cfg.layer_index.values())[0]
     with pytest.raises(ValueError):
         _ = MVSelectOpts("INVALID")
 

--- a/integration_tests/test_wcs_server.py
+++ b/integration_tests/test_wcs_server.py
@@ -789,7 +789,7 @@ def test_wcs1_getcoverage_bigimage(ows_server) -> None:
     bbox = test_layer.boundingBoxWGS84
 
     with pytest.raises(ServiceException) as e:
-        output = wcs.getCoverage(
+        _ = wcs.getCoverage(
             identifier="s2_l2a_clone",
             format="GeoTIFF",
             bbox=pytest.helpers.representative_bbox(bbox),
@@ -1091,7 +1091,7 @@ def test_wcs20_getcoverage_geotiff_bigimage(ows_server) -> None:
         ODCExtent.CENTRAL_SUBSET_FOR_TIMES, ODCExtent.LAST, "EPSG:4326"
     )
     with pytest.raises(ServiceException) as e:
-        output = wcs.getCoverage(
+        _ = wcs.getCoverage(
             identifier=[layer.name],
             format="image/geotiff",
             subsets=subsets,
@@ -1101,7 +1101,7 @@ def test_wcs20_getcoverage_geotiff_bigimage(ows_server) -> None:
     assert "too much data for a single request" in str(e.value)
     # Test default request
     with pytest.raises(ServiceException) as e:
-        output = wcs.getCoverage(
+        _ = wcs.getCoverage(
             identifier=[layer.name],
             format="application/x-netcdf",
         )

--- a/integration_tests/test_wms_server.py
+++ b/integration_tests/test_wms_server.py
@@ -267,7 +267,6 @@ def test_wms_style_looping_getmap(ows_server) -> None:
     wms = WebMapService(url=ows_server.url + "/wms", version="1.3.0", timeout=120)
 
     # Ensure that we have at least some layers available
-    contents = list(wms.contents)
     test_layer_names = ["s2_l2a", "s2_l2a_clone"]
     test_time = '2021-12-21T02:01:19'
     for test_layer_name in test_layer_names:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,6 @@ select = [
 ]
 ignore = [
     "E501",
-    "F841", # FIXME: disabled to simplify switch to Ruff.
 ]
 
 [tool.ruff.lint.per-file-ignores]

--- a/tests/test_cfg_bandidx.py
+++ b/tests/test_cfg_bandidx.py
@@ -56,26 +56,26 @@ def test_bidx_p_unready(minimal_prod) -> None:
         "foo": ["foo"]
     })
     with pytest.raises(OWSConfigNotReady) as excinfo:
-        x = bidx.measurements
+        _ = bidx.measurements
     assert "measurements" in str(excinfo.value)
     with pytest.raises(OWSConfigNotReady) as excinfo:
-        x = bidx.nodata_val("foo")
+        _ = bidx.nodata_val("foo")
     assert "_nodata_vals" in str(excinfo.value)
     with pytest.raises(OWSConfigNotReady) as excinfo:
-        x = bidx.dtype_val("foo")
+        _ = bidx.dtype_val("foo")
     assert "dtypes" in str(excinfo.value)
 
 
 def test_bidx_p_duplicates(minimal_prod) -> None:
     with pytest.raises(ConfigException) as excinfo:
-        bidx = BandIndex(minimal_prod, {
+        _ = BandIndex(minimal_prod, {
             "foo": ["bar"],
             "bar": ["baz"]
         })
     assert "Duplicate band name/alias" in str(excinfo.value)
     assert "bar" in str(excinfo.value)
     with pytest.raises(ConfigException) as excinfo:
-        bidx = BandIndex(minimal_prod, {
+       _ = BandIndex(minimal_prod, {
             "foo": ["bar"],
             "boo": ["bar"]
         })

--- a/tests/test_cfg_cache_ctrl.py
+++ b/tests/test_cfg_cache_ctrl.py
@@ -54,7 +54,7 @@ def test_complex_case(ccr_min_layer) -> None:
 
 def test_no_min_datasets_element() -> None:
     with pytest.raises(ConfigException) as e:
-        ccr = CacheControlRules([
+        _ = CacheControlRules([
             {"max_age": 20000},
         ], "Layer a_layer", 12)
     assert "Dataset cache rule does not contain" in str(e.value)
@@ -64,7 +64,7 @@ def test_no_min_datasets_element() -> None:
 
 def test_no_max_age_element() -> None:
     with pytest.raises(ConfigException) as e:
-        ccr = CacheControlRules([
+        _ = CacheControlRules([
             {"min_datasets": 2},
         ], "layer a_layer", 12)
     assert "Dataset cache rule does not contain" in str(e.value)
@@ -74,7 +74,7 @@ def test_no_max_age_element() -> None:
 
 def test_nonint_min_ds() -> None:
     with pytest.raises(ConfigException) as e:
-        ccr = CacheControlRules([
+        _ = CacheControlRules([
             {"min_datasets": "2", "max_age": 2000},
         ], "layer a_layer", 12)
     assert "Dataset cache rule" in str(e.value)
@@ -85,7 +85,7 @@ def test_nonint_min_ds() -> None:
 
 def test_nonint_max_age() -> None:
     with pytest.raises(ConfigException) as e:
-        ccr = CacheControlRules([
+        _ = CacheControlRules([
             {"min_datasets": 2, "max_age": 2000.5},
         ], "layer a_layer", 12)
     assert "Dataset cache rule" in str(e.value)
@@ -96,7 +96,7 @@ def test_nonint_max_age() -> None:
 
 def test_negative_min_datasets() -> None:
     with pytest.raises(ConfigException) as e:
-        ccr = CacheControlRules([
+        _ = CacheControlRules([
             {"min_datasets": -2, "max_age": 2000},
         ], "layer a_layer", 12)
     assert "Invalid dataset cache rule" in str(e.value)
@@ -107,7 +107,7 @@ def test_negative_min_datasets() -> None:
 
 def test_unsorted_min_datasets() -> None:
     with pytest.raises(ConfigException) as e:
-        ccr = CacheControlRules([
+        _ = CacheControlRules([
             {"min_datasets": 4, "max_age": 2000},
             {"min_datasets": 2, "max_age": 4000},
         ], "layer a_layer", 12)
@@ -119,7 +119,7 @@ def test_unsorted_min_datasets() -> None:
 
 def test_min_datasets_max_datasets() -> None:
     with pytest.raises(ConfigException) as e:
-        ccr = CacheControlRules([
+        _ = CacheControlRules([
             {"min_datasets": 2, "max_age": 2000},
             {"min_datasets": 4, "max_age": 4000},
         ], "layer a_layer", 2)
@@ -131,7 +131,7 @@ def test_min_datasets_max_datasets() -> None:
 
 def test_non_negative_max_age() -> None:
     with pytest.raises(ConfigException) as e:
-        ccr = CacheControlRules([
+        _ = CacheControlRules([
             {"min_datasets": 2, "max_age": -2},
         ], "layer a_layer", 12)
     assert "Dataset cache rule" in str(e.value)
@@ -142,7 +142,7 @@ def test_non_negative_max_age() -> None:
 
 def test_unsorted_max_age() -> None:
     with pytest.raises(ConfigException) as e:
-        ccr = CacheControlRules([
+        _ = CacheControlRules([
             {"min_datasets": 2, "max_age": 4000},
             {"min_datasets": 4, "max_age": 2000},
         ], "layer a_layer", 12)

--- a/tests/test_cfg_global.py
+++ b/tests/test_cfg_global.py
@@ -27,7 +27,7 @@ def test_global_no_title(minimal_global_raw_cfg) -> None:
     OWSConfig._instance = None
     del minimal_global_raw_cfg["global"]["title"]
     with pytest.raises(ConfigException) as excinfo:
-        cfg = OWSConfig(cfg=minimal_global_raw_cfg)
+        _ = OWSConfig(cfg=minimal_global_raw_cfg)
     assert "Entity global has no title" in str(excinfo.value)
 
 
@@ -109,7 +109,7 @@ def test_wcs_no_native_format(minimal_global_raw_cfg, wcs_global_cfg) -> None:
     del wcs_global_cfg["native_format"]
     minimal_global_raw_cfg["wcs"] = wcs_global_cfg
     with pytest.raises(ConfigException) as excinfo:
-        cfg = OWSConfig(cfg=minimal_global_raw_cfg)
+        _ = OWSConfig(cfg=minimal_global_raw_cfg)
     assert "native_format" in str(excinfo.value)
     assert "Missing required config entry" in str(excinfo.value)
     assert "wcs" in str(excinfo.value)
@@ -122,14 +122,14 @@ def test_no_services(minimal_global_raw_cfg) -> None:
         "wmts": False,
     }
     with pytest.raises(ConfigException) as excinfo:
-        cfg = OWSConfig(cfg=minimal_global_raw_cfg)
+        _ = OWSConfig(cfg=minimal_global_raw_cfg)
     assert "At least one service must be active" in str(excinfo.value)
 
 
 def test_no_published_crss(minimal_global_raw_cfg) -> None:
     del minimal_global_raw_cfg["global"]["published_CRSs"]
     with pytest.raises(ConfigException) as e:
-        cfg = OWSConfig(cfg=minimal_global_raw_cfg)
+        _ = OWSConfig(cfg=minimal_global_raw_cfg)
     assert "Missing required config entry in 'global' section:" in str(e.value)
     assert "published_CRSs" in str(e.value)
 
@@ -141,7 +141,7 @@ def test_bad_geographic_crs(minimal_global_raw_cfg) -> None:
         "horizontal_coord": "x"
     }
     with pytest.raises(ConfigException) as excinfo:
-        cfg = OWSConfig(cfg=minimal_global_raw_cfg)
+        _ = OWSConfig(cfg=minimal_global_raw_cfg)
     assert "is geographic" in str(excinfo.value)
     assert "EPSG:7777" in str(excinfo.value)
     assert "horizontal" in str(excinfo.value)
@@ -152,7 +152,7 @@ def test_bad_geographic_crs(minimal_global_raw_cfg) -> None:
         "vertical_coord": "y"
     }
     with pytest.raises(ConfigException) as excinfo:
-        cfg = OWSConfig(cfg=minimal_global_raw_cfg)
+        _ = OWSConfig(cfg=minimal_global_raw_cfg)
     assert "is geographic" in str(excinfo.value)
     assert "EPSG:7777" in str(excinfo.value)
     assert "latitude" in str(excinfo.value)
@@ -172,7 +172,7 @@ def test_no_wcs(minimal_global_raw_cfg) -> None:
     OWSConfig._instance = None
     minimal_global_raw_cfg["global"]["services"] = {"wcs": True}
     with pytest.raises(ConfigException) as excinfo:
-        cfg = OWSConfig(cfg=minimal_global_raw_cfg)
+        _ = OWSConfig(cfg=minimal_global_raw_cfg)
     assert "WCS section missing" in str(excinfo.value)
     assert "WCS is enabled" in str(excinfo.value)
 
@@ -184,7 +184,7 @@ def test_no_wcs_formats(minimal_global_raw_cfg) -> None:
         "formats": {}
     }
     with pytest.raises(ConfigException) as excinfo:
-        cfg = OWSConfig(cfg=minimal_global_raw_cfg)
+        _ = OWSConfig(cfg=minimal_global_raw_cfg)
     assert "Must configure at least one wcs format" in str(excinfo.value)
 
 
@@ -194,7 +194,7 @@ def test_bad_wcs_format(minimal_global_raw_cfg, wcs_global_cfg) -> None:
     minimal_global_raw_cfg["wcs"] = wcs_global_cfg
     minimal_global_raw_cfg["wcs"]["native_format"] = "jpeg2000"
     with pytest.raises(ConfigException) as excinfo:
-        cfg = OWSConfig(cfg=minimal_global_raw_cfg)
+        _ = OWSConfig(cfg=minimal_global_raw_cfg)
     assert "Configured native WCS format" in str(excinfo.value)
     assert "jpeg2000" in str(excinfo.value)
     assert "not a supported format" in str(excinfo.value)
@@ -215,7 +215,7 @@ def test_crs_lookup_fail(monkeypatch, minimal_global_raw_cfg, minimal_dc) -> Non
     OWSConfig._instance = None
     cfg = OWSConfig(cfg=minimal_global_raw_cfg)
     with pytest.raises(ConfigException) as excinfo:
-        crs = cfg.crs("EPSG:111")
+        _ = cfg.crs("EPSG:111")
     assert "EPSG:111" in str(excinfo.value)
     assert "is not published" in str(excinfo.value)
 
@@ -224,7 +224,7 @@ def test_no_langs(minimal_global_raw_cfg) -> None:
     OWSConfig._instance = None
     minimal_global_raw_cfg["global"]["supported_languages"] = []
     with pytest.raises(ConfigException) as excinfo:
-        cfg = OWSConfig(cfg=minimal_global_raw_cfg)
+        _ = OWSConfig(cfg=minimal_global_raw_cfg)
     assert "at least one language" in str(excinfo.value)
 
 
@@ -252,25 +252,25 @@ def test_bad_integers_in_wms_section(minimal_global_raw_cfg) -> None:
     minimal_global_raw_cfg["wms"]["max_width"] = "very big"
     with pytest.raises(ConfigException) as e:
         OWSConfig._instance = None
-        cfg = OWSConfig(cfg=minimal_global_raw_cfg)
+        _ = OWSConfig(cfg=minimal_global_raw_cfg)
     assert "max_width and max_height in wms section must be integers" in str(e.value)
     assert "very big" in str(e.value)
     minimal_global_raw_cfg["wms"]["max_width"] = 0
     with pytest.raises(ConfigException) as e:
         OWSConfig._instance = None
-        cfg = OWSConfig(cfg=minimal_global_raw_cfg)
+        _ = OWSConfig(cfg=minimal_global_raw_cfg)
     assert "max_width and max_height in wms section must be positive integers" in str(e.value)
     assert "0" in str(e.value)
     minimal_global_raw_cfg["wms"]["max_width"] = 256
     minimal_global_raw_cfg["wms"]["caps_cache_maxage"] = "forever"
     with pytest.raises(ConfigException) as e:
         OWSConfig._instance = None
-        cfg = OWSConfig(cfg=minimal_global_raw_cfg)
+        _ = OWSConfig(cfg=minimal_global_raw_cfg)
     assert "caps_cache_maxage in wms section must be an integer" in str(e.value)
     assert "forever" in str(e.value)
     minimal_global_raw_cfg["wms"]["caps_cache_maxage"] = -100
     with pytest.raises(ConfigException) as e:
         OWSConfig._instance = None
-        cfg = OWSConfig(cfg=minimal_global_raw_cfg)
+        _ = OWSConfig(cfg=minimal_global_raw_cfg)
     assert "caps_cache_maxage in wms section cannot be negative" in str(e.value)
     assert "-100" in str(e.value)

--- a/tests/test_cfg_inclusion.py
+++ b/tests/test_cfg_inclusion.py
@@ -29,23 +29,23 @@ def test_get_file_loc(monkeypatch) -> None:
 
 
 def test_get_file_loc_s3_disable(monkeypatch) -> None:
-    with pytest.raises(ConfigException) as excinfo:
+    with pytest.raises(ConfigException):
         _ = get_file_loc("s3://testbucket/foo.bar")
 
     monkeypatch.setenv("DATACUBE_OWS_CFG_ALLOW_S3", "NO")
-    with pytest.raises(ConfigException) as excinfo:
+    with pytest.raises(ConfigException):
         _ = get_file_loc("s3://testbucket/foo.bar")
 
     monkeypatch.setenv("DATACUBE_OWS_CFG_ALLOW_S3", "FALSE")
-    with pytest.raises(ConfigException) as excinfo:
+    with pytest.raises(ConfigException):
         _ = get_file_loc("s3://testbucket/foo.bar")
 
     monkeypatch.setenv("DATACUBE_OWS_CFG_ALLOW_S3", "0")
-    with pytest.raises(ConfigException) as excinfo:
+    with pytest.raises(ConfigException):
         _ = get_file_loc("s3://testbucket/foo.bar")
 
     monkeypatch.setenv("DATACUBE_OWS_CFG_ALLOW_S3", "N")
-    with pytest.raises(ConfigException) as excinfo:
+    with pytest.raises(ConfigException):
         _ = get_file_loc("s3://testbucket/foo.bar")
 
 
@@ -65,10 +65,10 @@ def test_get_file_loc_s3_enable(monkeypatch) -> None:
 
 def tests_get_file_loc_other_url(monkeypatch) -> None:
     monkeypatch.setenv("DATACUBE_OWS_CFG_ALLOW_S3", "N")
-    with pytest.raises(ConfigException) as excinfo:
+    with pytest.raises(ConfigException):
         _ = get_file_loc("http://testbucket/directory/foo.bar")
     monkeypatch.setenv("DATACUBE_OWS_CFG_ALLOW_S3", "Y")
-    with pytest.raises(ConfigException) as excinfo:
+    with pytest.raises(ConfigException):
         _ = get_file_loc("http://testbucket/another_directory/bar.foo")
 
 
@@ -241,7 +241,7 @@ def test_cfg_json_infinite_2(monkeypatch) -> None:
     monkeypatch.chdir(src_dir)
     monkeypatch.setenv("DATACUBE_OWS_CFG", "tests/cfg/infinite_2.json")
     try:
-        cfg = read_config()
+        _ = read_config()
         assert False
     except ConfigException as e:
         assert str(e).startswith("Cyclic inclusion")

--- a/tests/test_cfg_layer.py
+++ b/tests/test_cfg_layer.py
@@ -18,7 +18,7 @@ from datacube_ows.index import LayerExtent, CoordRange
 
 def test_missing_title(minimal_global_cfg) -> None:
     with pytest.raises(ConfigException) as excinfo:
-        lyr = OWSFolder({
+        _ = OWSFolder({
             "abstract": "The Abstract"
         },
             global_cfg=minimal_global_cfg)
@@ -78,7 +78,7 @@ def test_minimal_folder(minimal_global_cfg) -> None:
 
 def test_folder_nolayers(minimal_global_cfg) -> None:
     with pytest.raises(ConfigException) as excinfo:
-        lyr = OWSFolder({
+        _ = OWSFolder({
             "title": "The Title",
             "abstract": "The Abstract",
         }, global_cfg=minimal_global_cfg)
@@ -130,7 +130,7 @@ def test_catch_folder_as_list(minimal_global_cfg) -> None:
 
 def test_duplicate_folder_label(minimal_global_cfg) -> None:
     with pytest.raises(ConfigException) as e:
-        lyr = OWSFolder({
+        _ = OWSFolder({
             "title": "The Title",
             "abstract": "The Abstract",
             "label": "existing_folder",
@@ -210,7 +210,7 @@ def test_lowres_named_layer(minimal_layer_cfg, minimal_global_cfg) -> None:
 def test_double_underscore_product_name(minimal_layer_cfg, minimal_global_cfg) -> None:
     minimal_layer_cfg["product_name"] = "no__double__underscores"
     with pytest.raises(ConfigException) as excinfo:
-        lyr = parse_ows_layer(minimal_layer_cfg,
+        _ = parse_ows_layer(minimal_layer_cfg,
                               global_cfg=minimal_global_cfg)
     assert "double underscore" in str(excinfo.value)
 
@@ -218,7 +218,7 @@ def test_double_underscore_product_name(minimal_layer_cfg, minimal_global_cfg) -
 def test_no_product_name(minimal_layer_cfg, minimal_global_cfg) -> None:
     del minimal_layer_cfg["product_name"]
     with pytest.raises(ConfigException) as excinfo:
-        lyr = parse_ows_layer(minimal_layer_cfg,
+        _ = parse_ows_layer(minimal_layer_cfg,
                               global_cfg=minimal_global_cfg)
     assert "product names" in str(excinfo.value)
     assert "a_layer" in str(excinfo.value)
@@ -250,7 +250,7 @@ def test_bad_lowres_product_name(minimal_layer_cfg, minimal_global_cfg, minimal_
 def test_plural_in_nonmultiproduct(minimal_layer_cfg, minimal_global_cfg) -> None:
     minimal_layer_cfg["low_res_product_names"] = "smolfoolookupfail"
     with pytest.raises(ConfigException) as excinfo:
-        lyr = parse_ows_layer(minimal_layer_cfg,
+        _ = parse_ows_layer(minimal_layer_cfg,
                               global_cfg=minimal_global_cfg)
     assert "a_layer" in str(excinfo.value)
     assert "'low_res_product_names' entry in non-multi-product layer" in str(excinfo.value)
@@ -258,7 +258,7 @@ def test_plural_in_nonmultiproduct(minimal_layer_cfg, minimal_global_cfg) -> Non
     del minimal_layer_cfg["low_res_product_names"]
     minimal_layer_cfg["product_names"] = ["foo", "bar"]
     with pytest.raises(ConfigException) as excinfo:
-        lyr = parse_ows_layer(minimal_layer_cfg,
+        _ = parse_ows_layer(minimal_layer_cfg,
                               global_cfg=minimal_global_cfg)
     assert "a_layer" in str(excinfo.value)
     assert "'product_names' entry in non-multi-product layer" in str(excinfo.value)
@@ -271,7 +271,7 @@ def test_flag_plural_in_nonmultiproduct(minimal_layer_cfg, minimal_global_cfg) -
         "products": ["prod1", "prod2"],
     }
     with pytest.raises(ConfigException) as excinfo:
-        lyr = parse_ows_layer(minimal_layer_cfg,
+        _ = parse_ows_layer(minimal_layer_cfg,
                               global_cfg=minimal_global_cfg)
     assert "a_layer" in str(excinfo.value)
     assert "'products' entry in flags section of non-multi-product layer" in str(excinfo.value)
@@ -279,7 +279,7 @@ def test_flag_plural_in_nonmultiproduct(minimal_layer_cfg, minimal_global_cfg) -
     del minimal_layer_cfg["flags"]["products"]
     minimal_layer_cfg["flags"]["low_res_products"] = ["smolfoo", "smolbar"]
     with pytest.raises(ConfigException) as excinfo:
-        lyr = parse_ows_layer(minimal_layer_cfg,
+        _ = parse_ows_layer(minimal_layer_cfg,
                               global_cfg=minimal_global_cfg)
     assert "'low_res_products' entry in flags section of non-multi-product layer" in str(excinfo.value)
     assert "use 'low_res_product' only" in str(excinfo.value)
@@ -289,7 +289,7 @@ def test_flag_plural_in_nonmultiproduct(minimal_layer_cfg, minimal_global_cfg) -
 def test_singular_in_multiproduct(minimal_multiprod_cfg, minimal_global_cfg) -> None:
     minimal_multiprod_cfg["low_res_product_name"] = "smolfoolookupfail"
     with pytest.raises(ConfigException) as excinfo:
-        lyr = parse_ows_layer(minimal_multiprod_cfg,
+        _ = parse_ows_layer(minimal_multiprod_cfg,
                               global_cfg=minimal_global_cfg)
     assert "'low_res_product_name' entry in multi-product layer" in str(excinfo.value)
     assert "use 'low_res_product_names' only" in str(excinfo.value)
@@ -297,7 +297,7 @@ def test_singular_in_multiproduct(minimal_multiprod_cfg, minimal_global_cfg) -> 
     del minimal_multiprod_cfg["low_res_product_name"]
     minimal_multiprod_cfg["product_name"] = "foo"
     with pytest.raises(ConfigException) as excinfo:
-        lyr = parse_ows_layer(minimal_multiprod_cfg,
+        _ = parse_ows_layer(minimal_multiprod_cfg,
                               global_cfg=minimal_global_cfg)
     assert "'product_name' entry in multi-product layer" in str(excinfo.value)
     assert "use 'product_names' only" in str(excinfo.value)
@@ -310,7 +310,7 @@ def test_flag_singular_in_multiproduct(minimal_multiprod_cfg, minimal_global_cfg
         "product": "goo",
     }
     with pytest.raises(ConfigException) as excinfo:
-        lyr = parse_ows_layer(minimal_multiprod_cfg,
+        _ = parse_ows_layer(minimal_multiprod_cfg,
                           global_cfg=minimal_global_cfg)
     assert "'product' entry in flags section of multi-product layer" in str(excinfo.value)
     assert "use 'products' only" in str(excinfo.value)
@@ -318,7 +318,7 @@ def test_flag_singular_in_multiproduct(minimal_multiprod_cfg, minimal_global_cfg
     del minimal_multiprod_cfg["flags"]["product"]
     minimal_multiprod_cfg["flags"]["low_res_product"] = "smolfoo"
     with pytest.raises(ConfigException) as excinfo:
-        lyr = parse_ows_layer(minimal_multiprod_cfg,
+        _ = parse_ows_layer(minimal_multiprod_cfg,
                               global_cfg=minimal_global_cfg)
     assert "'low_res_product' entry in flags section of multi-product layer" in str(excinfo.value)
     assert "use 'low_res_products' only" in str(excinfo.value)
@@ -328,7 +328,7 @@ def test_flag_singular_in_multiproduct(minimal_multiprod_cfg, minimal_global_cfg
 def test_noprod_multiproduct(minimal_multiprod_cfg, minimal_global_cfg, minimal_dc) -> None:
     minimal_multiprod_cfg["product_names"] = []
     with pytest.raises(ConfigException) as excinfo:
-        lyr = parse_ows_layer(minimal_multiprod_cfg,
+        _ = parse_ows_layer(minimal_multiprod_cfg,
                           global_cfg=minimal_global_cfg)
 
     assert "a_layer" in str(excinfo.value)
@@ -390,7 +390,7 @@ def test_multi_product_lrpq(minimal_multiprod_cfg, minimal_global_cfg, minimal_d
 def test_multi_product_name_mismatch(minimal_multiprod_cfg, minimal_global_cfg) -> None:
     minimal_multiprod_cfg["low_res_product_names"] = ["smol_foo"]
     with pytest.raises(ConfigException) as excinfo:
-        lyr = parse_ows_layer(minimal_multiprod_cfg,
+        _ = parse_ows_layer(minimal_multiprod_cfg,
                               global_cfg=minimal_global_cfg)
     assert "low_res_product_names" in str(excinfo.value)
     assert "a_layer" in str(excinfo.value)
@@ -406,7 +406,7 @@ def test_resource_limit_zoomfill(minimal_layer_cfg, minimal_global_cfg) -> None:
     assert lyr.resource_limits.zoom_fill[3] == 255
     minimal_layer_cfg["resource_limits"]["wms"]["zoomed_out_fill_colour"] = [13, 254]
     with pytest.raises(ConfigException) as excinfo:
-        lyr = parse_ows_layer(minimal_layer_cfg,
+        _ = parse_ows_layer(minimal_layer_cfg,
                               global_cfg=minimal_global_cfg)
     assert "zoomed_out_fill_colour must have 3 or 4 elements" in str(excinfo.value)
 
@@ -462,7 +462,7 @@ def test_manual_merge(minimal_layer_cfg, minimal_global_cfg) -> None:
 def test_bad_timeres(minimal_layer_cfg, minimal_global_cfg) -> None:
     minimal_layer_cfg["time_resolution"] = "prime_ministers"
     with pytest.raises(ConfigException) as excinfo:
-        lyr = parse_ows_layer(minimal_layer_cfg,
+        _ = parse_ows_layer(minimal_layer_cfg,
                               global_cfg=minimal_global_cfg)
     assert "Invalid time resolution" in str(excinfo.value)
     assert "prime_ministers" in str(excinfo.value)
@@ -476,7 +476,7 @@ def test_flag_no_band(minimal_layer_cfg, minimal_global_cfg) -> None:
     }
 
     with pytest.raises(ConfigException) as excinfo:
-        lyr = parse_ows_layer(minimal_layer_cfg,
+        _ = parse_ows_layer(minimal_layer_cfg,
                               global_cfg=minimal_global_cfg)
     assert "required" in str(excinfo.value)
     assert "a_layer" in str(excinfo.value)
@@ -533,7 +533,7 @@ def test_flag_info_mask(minimal_layer_cfg, minimal_global_cfg, minimal_dc) -> No
 def test_img_proc_no_extent_func(minimal_layer_cfg, minimal_global_cfg) -> None:
     del minimal_layer_cfg["image_processing"]["extent_mask_func"]
     with pytest.raises(ConfigException) as excinfo:
-        lyr = parse_ows_layer(minimal_layer_cfg,
+        _ = parse_ows_layer(minimal_layer_cfg,
                               global_cfg=minimal_global_cfg)
     assert "required" in str(excinfo.value)
     assert "a_layer" in str(excinfo.value)
@@ -546,7 +546,7 @@ def test_id_badauth(minimal_layer_cfg, minimal_global_cfg) -> None:
         "authn": "mnnnmnnh"
     }
     with pytest.raises(ConfigException) as excinfo:
-        lyr = parse_ows_layer(minimal_layer_cfg,
+        _ = parse_ows_layer(minimal_layer_cfg,
                               global_cfg=minimal_global_cfg)
     assert "non-declared authority" in str(excinfo.value)
     assert "authn" in str(excinfo.value)
@@ -556,7 +556,7 @@ def test_id_badauth(minimal_layer_cfg, minimal_global_cfg) -> None:
 def test_no_styles(minimal_layer_cfg, minimal_global_cfg) -> None:
     del minimal_layer_cfg["styling"]["styles"]
     with pytest.raises(ConfigException) as excinfo:
-        lyr = parse_ows_layer(minimal_layer_cfg,
+        _ = parse_ows_layer(minimal_layer_cfg,
                               global_cfg=minimal_global_cfg)
     assert "Missing required" in str(excinfo.value)
     assert "styles" in str(excinfo.value)
@@ -566,7 +566,7 @@ def test_no_styles(minimal_layer_cfg, minimal_global_cfg) -> None:
 def test_bad_default_style(minimal_layer_cfg, minimal_global_cfg) -> None:
     minimal_layer_cfg["styling"]["default_style"] = "nonexistent"
     with pytest.raises(ConfigException) as excinfo:
-        lyr = parse_ows_layer(minimal_layer_cfg,
+        _ = parse_ows_layer(minimal_layer_cfg,
                               global_cfg=minimal_global_cfg)
     assert "not in the 'styles'" in str(excinfo.value)
     assert "nonexistent" in str(excinfo.value)
@@ -586,7 +586,7 @@ def test_invalid_native_format(minimal_layer_cfg, minimal_global_cfg) -> None:
         "native_format": "geosplunge"
     }
     with pytest.raises(ConfigException) as excinfo:
-        lyr = parse_ows_layer(minimal_layer_cfg,
+        _ = parse_ows_layer(minimal_layer_cfg,
                               global_cfg=minimal_global_cfg)
     assert "a_layer" in str(excinfo.value)
     assert "geosplunge" in str(excinfo.value)
@@ -675,15 +675,15 @@ def test_time_axis_representation_reg(minimal_layer_cfg, minimal_global_cfg) -> 
 def test_time_axis_errors(minimal_layer_cfg, minimal_global_cfg) -> None:
     minimal_layer_cfg["time_axis"] = {"start_date": "2010-11-22"}
     with pytest.raises(ConfigException) as e:
-        lyr = parse_ows_layer(minimal_layer_cfg, global_cfg=minimal_global_cfg)
+        _ = parse_ows_layer(minimal_layer_cfg, global_cfg=minimal_global_cfg)
     assert "No time_interval supplied in time_axis" in str(e.value)
     minimal_layer_cfg["time_axis"] = {"time_interval": 0.6}
     with pytest.raises(ConfigException) as e:
-        lyr = parse_ows_layer(minimal_layer_cfg, global_cfg=minimal_global_cfg)
+        _ = parse_ows_layer(minimal_layer_cfg, global_cfg=minimal_global_cfg)
     assert "time_interval must be an integer" in str(e.value)
     minimal_layer_cfg["time_axis"] = {"time_interval": 0}
     with pytest.raises(ConfigException) as e:
-        lyr = parse_ows_layer(minimal_layer_cfg, global_cfg=minimal_global_cfg)
+        _ = parse_ows_layer(minimal_layer_cfg, global_cfg=minimal_global_cfg)
     assert "time_interval must be greater than zero" in str(e.value)
     minimal_layer_cfg["time_axis"] = {
         "time_interval": 7,
@@ -691,7 +691,7 @@ def test_time_axis_errors(minimal_layer_cfg, minimal_global_cfg) -> None:
         "end_date": "2010-11-22",
     }
     with pytest.raises(ConfigException) as e:
-        lyr = parse_ows_layer(minimal_layer_cfg, global_cfg=minimal_global_cfg)
+        _ = parse_ows_layer(minimal_layer_cfg, global_cfg=minimal_global_cfg)
     assert "time_axis start_date is not a valid ISO format date string" in str(e.value)
     minimal_layer_cfg["time_axis"] = {
         "time_interval": 7,
@@ -699,7 +699,7 @@ def test_time_axis_errors(minimal_layer_cfg, minimal_global_cfg) -> None:
         "end_date": "seven fortnights before the last full moon",
     }
     with pytest.raises(ConfigException) as e:
-        lyr = parse_ows_layer(minimal_layer_cfg, global_cfg=minimal_global_cfg)
+        _ = parse_ows_layer(minimal_layer_cfg, global_cfg=minimal_global_cfg)
     assert "time_axis end_date is not a valid ISO format date string" in str(e.value)
     minimal_layer_cfg["time_axis"] = {
         "time_interval": 7,
@@ -707,7 +707,7 @@ def test_time_axis_errors(minimal_layer_cfg, minimal_global_cfg) -> None:
         "end_date": "1999-12-31",
     }
     with pytest.raises(ConfigException) as e:
-        lyr = parse_ows_layer(minimal_layer_cfg, global_cfg=minimal_global_cfg)
+        _ = parse_ows_layer(minimal_layer_cfg, global_cfg=minimal_global_cfg)
     assert "time_axis end_date must be greater than or equal to the start_date if both are provided" in str(e.value)
 
 
@@ -773,7 +773,7 @@ def test_missing_default_time(minimal_layer_cfg, minimal_global_cfg, minimal_dc,
 def test_invalid_default_time(minimal_layer_cfg, minimal_global_cfg, minimal_dc, mock_range) -> None:
     minimal_layer_cfg["default_time"] = "Not-a-date"
     with pytest.raises(ConfigException) as e:
-        lyr = parse_ows_layer(minimal_layer_cfg,
+        _ = parse_ows_layer(minimal_layer_cfg,
                           global_cfg=minimal_global_cfg)
     assert "a_layer" in str(e.value)
     assert "Not-a-date" in str(e.value)

--- a/tests/test_cfg_metadata_types.py
+++ b/tests/test_cfg_metadata_types.py
@@ -30,7 +30,7 @@ def owner_w_attrib_title():
 
 def test_cfg_attrib_emptyfail(minimal_owner) -> None:
     with pytest.raises(ConfigException) as excinfo:
-        attrib = AttributionCfg.parse({"foo": "bar"}, minimal_owner)
+        _ = AttributionCfg.parse({"foo": "bar"}, minimal_owner)
     assert "At least one" in str(excinfo.value)
 
 
@@ -69,14 +69,14 @@ def test_cfg_attrib_minimal_logo_only(minimal_owner) -> None:
 
 def test_cfg_attrib_logo_requirements(minimal_owner) -> None:
     with pytest.raises(ConfigException) as excinfo:
-        attrib = AttributionCfg.parse({
+        _ = AttributionCfg.parse({
             "logo": {
                 "url": "http://test.url/path/img.png",
             }
         }, minimal_owner)
     assert "url and format" in str(excinfo.value)
     with pytest.raises(ConfigException) as excinfo:
-        attrib = AttributionCfg.parse({
+        _ = AttributionCfg.parse({
             "logo": {
                 "format": "image/png"
             }
@@ -137,7 +137,7 @@ def test_surl_empty() -> None:
 
 def test_surl_no_url() -> None:
     with pytest.raises(KeyError):
-        supps = SuppURL.parse_list([
+        _ = SuppURL.parse_list([
             {
                 "format": "text/html"
             }
@@ -146,7 +146,7 @@ def test_surl_no_url() -> None:
 
 def test_surl_no_format() -> None:
     with pytest.raises(KeyError):
-        supps = SuppURL.parse_list([
+        _ = SuppURL.parse_list([
             {
                 "url": "http://test.url/path"
             }

--- a/tests/test_cfg_tile_matrix_set.py
+++ b/tests/test_cfg_tile_matrix_set.py
@@ -51,7 +51,7 @@ def test_tms_unpublished_crs(wwwm_tms_cfg) -> None:
     global_cfg = MagicMock()
     global_cfg.published_CRSs = {}
     with pytest.raises(ConfigException) as excinfo:
-        tms = TileMatrixSet("test", wwwm_tms_cfg, global_cfg)
+        _ = TileMatrixSet("test", wwwm_tms_cfg, global_cfg)
     assert "test" in str(excinfo.value)
     assert "unpublished CRS" in str(excinfo.value)
     assert "EPSG:3857" in str(excinfo.value)
@@ -61,21 +61,21 @@ def test_matrix_origin_float_array(wwwm_tms_cfg, tmsmin_global_cfg) -> None:
     global_cfg = tmsmin_global_cfg
     wwwm_tms_cfg["matrix_origin"] = None
     with pytest.raises(ConfigException) as excinfo:
-        tms = TileMatrixSet("test", wwwm_tms_cfg, global_cfg)
+        _ = TileMatrixSet("test", wwwm_tms_cfg, global_cfg)
     assert "test" in str(excinfo.value)
     assert "Matrix origin" in str(excinfo.value)
     assert "must be a list" in str(excinfo.value)
 
     wwwm_tms_cfg["matrix_origin"] = [3.3, 6.3, 7.8]
     with pytest.raises(ConfigException) as excinfo:
-        tms = TileMatrixSet("test", wwwm_tms_cfg, global_cfg)
+        _ = TileMatrixSet("test", wwwm_tms_cfg, global_cfg)
     assert "test" in str(excinfo.value)
     assert "Matrix origin" in str(excinfo.value)
     assert "must have two values" in str(excinfo.value)
 
     wwwm_tms_cfg["matrix_origin"] = [6.3, "spaghetti bolognaise"]
     with pytest.raises(ConfigException) as excinfo:
-        tms = TileMatrixSet("test", wwwm_tms_cfg, global_cfg)
+        _ = TileMatrixSet("test", wwwm_tms_cfg, global_cfg)
     assert "test" in str(excinfo.value)
     assert "Matrix origin" in str(excinfo.value)
     assert "spaghetti bolognaise" in str(excinfo.value)
@@ -87,21 +87,21 @@ def test_tile_size_int_array(wwwm_tms_cfg, tmsmin_global_cfg) -> None:
     global_cfg = tmsmin_global_cfg
     wwwm_tms_cfg["tile_size"] = None
     with pytest.raises(ConfigException) as excinfo:
-        tms = TileMatrixSet("test", wwwm_tms_cfg, global_cfg)
+        _ = TileMatrixSet("test", wwwm_tms_cfg, global_cfg)
     assert "test" in str(excinfo.value)
     assert "Tile size" in str(excinfo.value)
     assert "must be a list" in str(excinfo.value)
 
     wwwm_tms_cfg["tile_size"] = [256, 512, 1024]
     with pytest.raises(ConfigException) as excinfo:
-        tms = TileMatrixSet("test", wwwm_tms_cfg, global_cfg)
+        _ = TileMatrixSet("test", wwwm_tms_cfg, global_cfg)
     assert "test" in str(excinfo.value)
     assert "Tile size" in str(excinfo.value)
     assert "must have two values" in str(excinfo.value)
 
     wwwm_tms_cfg["tile_size"] = [64, "spaghetti bolognaise"]
     with pytest.raises(ConfigException) as excinfo:
-        tms = TileMatrixSet("test", wwwm_tms_cfg, global_cfg)
+        _ = TileMatrixSet("test", wwwm_tms_cfg, global_cfg)
     assert "test" in str(excinfo.value)
     assert "Tile size" in str(excinfo.value)
     assert "spaghetti bolognaise" in str(excinfo.value)
@@ -113,13 +113,13 @@ def test_scale_set_array(wwwm_tms_cfg, tmsmin_global_cfg) -> None:
     global_cfg = tmsmin_global_cfg
     wwwm_tms_cfg["scale_set"] = None
     with pytest.raises(ConfigException) as excinfo:
-        tms = TileMatrixSet("test", wwwm_tms_cfg, global_cfg)
+        _ = TileMatrixSet("test", wwwm_tms_cfg, global_cfg)
     assert "test" in str(excinfo.value)
     assert "scale_set" in str(excinfo.value)
     assert "is not a list" in str(excinfo.value)
     wwwm_tms_cfg["scale_set"] = []
     with pytest.raises(ConfigException) as excinfo:
-        tms = TileMatrixSet("test", wwwm_tms_cfg, global_cfg)
+        _ = TileMatrixSet("test", wwwm_tms_cfg, global_cfg)
     assert "test" in str(excinfo.value)
     assert "scale_set" in str(excinfo.value)
     assert "no scale denominators" in str(excinfo.value)

--- a/tests/test_legend_generator.py
+++ b/tests/test_legend_generator.py
@@ -52,8 +52,8 @@ def test_image_from_url(image_url) -> None:
 
 
 def test_image_from_bad_image_url(bad_image_url) -> None:
-    with pytest.raises(WMSException) as e:
-        img = get_image_from_url(bad_image_url)
+    with pytest.raises(WMSException):
+        _ = get_image_from_url(bad_image_url)
 
 def test_parse_colorramp_defaults() -> None:
     legend = ColorRampDef.Legend(MagicMock(), {})

--- a/tests/test_multidate_handler.py
+++ b/tests/test_multidate_handler.py
@@ -5,9 +5,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np
-import pandas as pd
 import pytest
-import xarray as xr
 
 from datacube_ows.config_utils import ConfigException
 from datacube_ows.styles.base import StyleDefBase
@@ -35,11 +33,6 @@ def test_multidate_handler() -> None:
             self.index_function = lambda x: FakeData()
             self.stand_alone = True
             self.transform_single_date_data = lambda x: x
-
-    data = np.random.randint(0, 255, size=(4, 3), dtype=np.uint8)
-    locs = ["IA", "IL", "IN"]
-    times = pd.date_range("2000-01-01", periods=4)
-    fake_mask = xr.DataArray(data, coords=[times, locs], dims=["time", "space"])
 
     fake_cfg = {
         "allowed_count_range": [0, 10],

--- a/tests/test_ogc_utils.py
+++ b/tests/test_ogc_utils.py
@@ -69,8 +69,8 @@ def test_tz_for_dataset(dummy_ds) -> None:
 
 
 def test_tz_bad_coords() -> None:
-    with pytest.raises(Exception) as e:
-        tzinf = datacube_ows.time_utils.tz_for_coord(-88.8, 155.2)
+    with pytest.raises(Exception):
+        _ = datacube_ows.time_utils.tz_for_coord(-88.8, 155.2)
 
 
 def test_local_date(dummy_ds) -> None:
@@ -149,7 +149,7 @@ def test_create_geobox() -> None:
         assert geobox.width == 1182
         assert geobox.height == 668
     with pytest.raises(Exception) as excinfo:
-        geobox_no = datacube_ows.ogc_utils.create_geobox("EPSG:4326",
+        _ = datacube_ows.ogc_utils.create_geobox("EPSG:4326",
                                                          140.7184, 145.6924, -16.1144, -13.4938)
     assert "Must supply at least a width or height" in str(excinfo.value)
 

--- a/tests/test_ows_configuration.py
+++ b/tests/test_ows_configuration.py
@@ -66,13 +66,13 @@ def test_function_wrapper_lyr() -> None:
 
 def test_func_naked() -> None:
     lyr = MagicMock()
-    with pytest.raises(datacube_ows.config_utils.ConfigException) as e:
-        f = datacube_ows.config_utils.FunctionWrapper(lyr, {
+    with pytest.raises(datacube_ows.config_utils.ConfigException):
+        _ = datacube_ows.config_utils.FunctionWrapper(lyr, {
             "function": a_function,
         })
     assert "Directly including callable objects in configuration is no longer supported."
-    with pytest.raises(datacube_ows.config_utils.ConfigException) as e:
-        f = datacube_ows.config_utils.FunctionWrapper(lyr, a_function)
+    with pytest.raises(datacube_ows.config_utils.ConfigException):
+        _ = datacube_ows.config_utils.FunctionWrapper(lyr, a_function)
     assert "Directly including callable objects in configuration is no longer supported."
     f = datacube_ows.config_utils.FunctionWrapper(lyr, {
         "function": a_function,

--- a/tests/test_startup.py
+++ b/tests/test_startup.py
@@ -93,7 +93,7 @@ def test_initialise_debugging(monkeypatch) -> None:
     monkeypatch.setenv("PYDEV_DEBUG", "YES")
     from datacube_ows.startup_utils import initialise_debugging
     fake_mod = MagicMock()
-    with patch.dict("sys.modules", pydevd_pycharm=fake_mod) as set_trc:
+    with patch.dict("sys.modules", pydevd_pycharm=fake_mod):
         initialise_debugging()
         fake_mod.settrace.assert_called()
 

--- a/tests/test_style_api.py
+++ b/tests/test_style_api.py
@@ -239,7 +239,7 @@ def test_ramp_legend_parse_errs(simple_ramp_style_cfg) -> None:
         "decimal_places": -1
     }
     with pytest.raises(ConfigException) as e:
-        style = StandaloneStyle(simple_ramp_style_cfg)
+        _ = StandaloneStyle(simple_ramp_style_cfg)
     assert "decimal_places cannot be negative" in str(e.value)
 
 
@@ -251,7 +251,7 @@ def test_ramp_ticks_multimethod(simple_ramp_style_cfg) -> None:
         "tick_count": 5
     }
     with pytest.raises(ConfigException) as e:
-        style = StandaloneStyle(simple_ramp_style_cfg)
+        _ = StandaloneStyle(simple_ramp_style_cfg)
     assert "Cannot use tick count and ticks_every in the same legend" in str(e.value)
     simple_ramp_style_cfg["legend"] = {
         "begin": "0.0",
@@ -260,7 +260,7 @@ def test_ramp_ticks_multimethod(simple_ramp_style_cfg) -> None:
         "ticks": ["0.0", "0.2", "0.4", "0.6", "0.8", "1.0"]
     }
     with pytest.raises(ConfigException) as e:
-        style = StandaloneStyle(simple_ramp_style_cfg)
+        _ = StandaloneStyle(simple_ramp_style_cfg)
     assert "Cannot use ticks and ticks_every in the same legend" in str(e.value)
     simple_ramp_style_cfg["legend"] = {
         "begin": "0.0",
@@ -269,7 +269,7 @@ def test_ramp_ticks_multimethod(simple_ramp_style_cfg) -> None:
         "tick_count": 5
     }
     with pytest.raises(ConfigException) as e:
-        style = StandaloneStyle(simple_ramp_style_cfg)
+        _ = StandaloneStyle(simple_ramp_style_cfg)
     assert "Cannot use tick count and ticks in the same legend" in str(e.value)
 
 
@@ -920,17 +920,17 @@ def test_aggregator_map(enum_colormap_aggregate_multidate, dummy_col_map_time_da
 def test_invalid_multidate_rules(enum_colormap_style_cfg, simple_colormap_style_cfg) -> None:
     simple_colormap_style_cfg["multi_date"][0]["allowed_count_range"] = [2, 4]
     with pytest.raises(ConfigException) as e:
-        style = StandaloneStyle(simple_colormap_style_cfg)
+        _ = StandaloneStyle(simple_colormap_style_cfg)
     assert "min_count and max_count equal" in str(e.value)
     simple_colormap_style_cfg["multi_date"][0]["allowed_count_range"] = [2, 2]
     simple_colormap_style_cfg["multi_date"][0]["animate"] = True
     with pytest.raises(ConfigException) as e:
-        style = StandaloneStyle(simple_colormap_style_cfg)
+        _ = StandaloneStyle(simple_colormap_style_cfg)
     assert "value maps not supported for animation handlers" in str(e.value)
     simple_colormap_style_cfg["multi_date"][0]["animate"] = False
     simple_colormap_style_cfg["multi_date"][0]["value_map"]["pq"][3]["invert"] = [True, False, True]
     with pytest.raises(ConfigException) as e:
-        style = StandaloneStyle(simple_colormap_style_cfg)
+        _ = StandaloneStyle(simple_colormap_style_cfg)
     assert "Invert entry has wrong number of rule sets for date count" in str(e.value)
     del simple_colormap_style_cfg["multi_date"][0]["value_map"]["pq"][3]["invert"]
     orig_flags = simple_colormap_style_cfg["multi_date"][0]["value_map"]["pq"][0]["flags"]
@@ -946,7 +946,7 @@ def test_invalid_multidate_rules(enum_colormap_style_cfg, simple_colormap_style_
         },
     ],
     with pytest.raises(ConfigException) as e:
-        style = StandaloneStyle(simple_colormap_style_cfg)
+        _ = StandaloneStyle(simple_colormap_style_cfg)
     assert "Flags entry has wrong number of rule sets for date count" in str(e.value)
     enum_colormap_style_cfg["multi_date"][0]["value_map"]["pq"][0]["flags"] = [
         {
@@ -958,15 +958,15 @@ def test_invalid_multidate_rules(enum_colormap_style_cfg, simple_colormap_style_
         },
     ]
     with pytest.raises(ConfigException) as e:
-        style = StandaloneStyle(enum_colormap_style_cfg)
+        _ = StandaloneStyle(enum_colormap_style_cfg)
     assert "combines 'and' and 'or' rules" in str(e.value)
     del simple_colormap_style_cfg["multi_date"][0]["value_map"]["pq"][0]["flags"]
     with pytest.raises(ConfigException) as e:
-        style = StandaloneStyle(simple_colormap_style_cfg)
+        _ = StandaloneStyle(simple_colormap_style_cfg)
     assert "must have a non-empty 'flags' or 'values' section" in str(e.value)
     enum_colormap_style_cfg["multi_date"][0]["value_map"]["pq"][0]["flags"] = orig_flags
     with pytest.raises(ConfigException) as e:
-        style = StandaloneStyle(enum_colormap_style_cfg)
+        _ = StandaloneStyle(enum_colormap_style_cfg)
     assert "has both a 'flags' and a 'values' section - choose one" in str(e.value)
 
 

--- a/tests/test_styles.py
+++ b/tests/test_styles.py
@@ -430,7 +430,7 @@ def test_invalid_component_ratio(product_layer, style_cfg_nonlin) -> None:
         }
     }
     with pytest.raises(ConfigException) as e:
-        style_def = datacube_ows.styles.StyleDef(product_layer, style_cfg_nonlin)
+        _ = datacube_ows.styles.StyleDef(product_layer, style_cfg_nonlin)
     assert "Component ratio must be a floating point number between 0 and 1" in str(e.value)
 
 
@@ -442,7 +442,7 @@ def test_correct_style_linear(product_layer, style_cfg_lin, style_cfg_lin_clone)
 
 def test_unresolvable_style(product_layer) -> None:
     with pytest.raises(ConfigException) as e:
-        style_def = datacube_ows.styles.StyleDef(product_layer, {
+        _ = datacube_ows.styles.StyleDef(product_layer, {
             "foo": "This is not real",
             "name": "gotaname",
             "abstract": "gotabstract",
@@ -464,7 +464,7 @@ def test_inherit_exceptions(product_layer, style_cfg_lin, style_cfg_lin_clone) -
     product_layer.style_index[style_def.name] = style_def
     style_cfg_lin_clone["inherits"]["layer"] = "fake_layer"
     try:
-        style_def_clone = datacube_ows.styles.StyleDef(product_layer, style_cfg_lin_clone)
+        _ = datacube_ows.styles.StyleDef(product_layer, style_cfg_lin_clone)
         assert "Expected exception not thrown" == False
     except OWSEntryNotFound:
         pass
@@ -492,8 +492,8 @@ def test_inherit_exceptions(product_layer, style_cfg_lin, style_cfg_lin_clone) -
 def test_style_exceptions(product_layer, style_cfg_map: dict) -> None:
     style_no_name = dict(style_cfg_map)
     style_no_name.pop('name', None)
-    with pytest.raises(KeyError) as excinfo:
-        style_def = datacube_ows.styles.StyleDef(product_layer, style_no_name)
+    with pytest.raises(KeyError):
+        _ = datacube_ows.styles.StyleDef(product_layer, style_no_name)
 
 
 def test_correct_style_map(product_layer, style_cfg_map) -> None:
@@ -527,7 +527,7 @@ def test_alpha_style_map(
     npmap = np.array([True, True, True])
     damap = DataArray(npmap)
 
-    with patch('datacube_ows.config_utils.make_mask', new_callable=lambda: fake_make_mask) as fmm:
+    with patch('datacube_ows.config_utils.make_mask', new_callable=lambda: fake_make_mask):
         style_def = datacube_ows.styles.StyleDef(product_layer_alpha_map, style_cfg_map_alpha_1)
 
         result = style_def.transform_data(ds, damap)
@@ -695,7 +695,7 @@ def test_RGBAMapped_Masking(product_layer_mask_map, style_cfg_map_mask) -> None:
     npmap = np.array([True, True, True, True, True, True])
     damap = DataArray(npmap, coords={"dim": dim}, dims=["dim"])
 
-    with patch('datacube_ows.config_utils.make_mask', new_callable=lambda: fake_make_mask) as fmm:
+    with patch('datacube_ows.config_utils.make_mask', new_callable=lambda: fake_make_mask):
         style_def = datacube_ows.styles.StyleDef(product_layer_mask_map, style_cfg_map_mask)
         data = style_def.transform_data(ds, damap)
         r = data["red"]
@@ -809,7 +809,7 @@ def test_bad_mpl_ramp() -> None:
     from datacube_ows.styles.ramp import read_mpl_ramp
 
     with pytest.raises(ConfigException) as e:
-        ramp = read_mpl_ramp("definitely_not_a_real_matplotlib_ramp_name")
+        _ = read_mpl_ramp("definitely_not_a_real_matplotlib_ramp_name")
     assert "Invalid Matplotlib name: " in str(e.value)
 
 @pytest.fixture
@@ -855,7 +855,7 @@ def test_style_with_pq_masks(product_layer, style_with_pq_masking, minimal_dc) -
     npmap = np.array([True, True, True, True, True, True])
     damap = DataArray(npmap, coords={"dim": dim}, dims=["dim"])
 
-    with patch('datacube_ows.config_utils.make_mask', new_callable=lambda: fake_make_mask) as fmm:
+    with patch('datacube_ows.config_utils.make_mask', new_callable=lambda: fake_make_mask):
         style_def = datacube_ows.styles.StyleDef(product_layer, style_with_pq_masking)
         style_def.make_ready(minimal_dc)
         mask = style_def.to_mask(ds, damap)
@@ -868,10 +868,10 @@ def test_style_with_pq_masks(product_layer, style_with_pq_masking, minimal_dc) -
 def test_styles_with_invalid_pq_masks(product_layer, style_with_pq_masking) -> None:
     style_with_pq_masking["pq_masks"][0]["band"] = "invalid_band"
     with pytest.raises(ConfigException) as e:
-        style_def = datacube_ows.styles.StyleDef(product_layer, style_with_pq_masking)
+        _ = datacube_ows.styles.StyleDef(product_layer, style_with_pq_masking)
     assert "has a mask that references flag band invalid_band which is not defined" in str(e.value)
     product_layer.flag_bands = {}
     product_layer.allflag_productbands = []
     with pytest.raises(ConfigException) as e:
-        style_def = datacube_ows.styles.StyleDef(product_layer, style_with_pq_masking)
+        _ = datacube_ows.styles.StyleDef(product_layer, style_with_pq_masking)
     assert "contains a mask, but the layer has no flag bands" in str(e.value)

--- a/tests/test_wcs2_utils.py
+++ b/tests/test_wcs2_utils.py
@@ -43,6 +43,6 @@ def test_uniform_crs_published(minimal_cfg) -> None:
 
 def test_uniform_crs_published_with_exception(minimal_cfg) -> None:
     with pytest.raises(WCS2Exception) as e:
-        crs = uniform_crs(minimal_cfg, "spam")
+        _ = uniform_crs(minimal_cfg, "spam")
     assert "spam" in str(e.value)
     assert "Not a CRS" in str(e.value)


### PR DESCRIPTION
Fix the variable names in
ramp.py so the end of
the ramp is detected
properly.

Replace variables that are
not accessed after they are
defined with an underscore
to make it clear they are
not used.

This also uncovered some
dead code, so remove that,
and then enable rule F841
so these are not introduced
again.

<!-- readthedocs-preview datacube-ows start -->
----
📚 Documentation preview 📚: https://datacube-ows--1155.org.readthedocs.build/en/1155/

<!-- readthedocs-preview datacube-ows end -->