### PR TITLE
Remove pep8 dependency

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -80,7 +80,6 @@ Linting
 
     ruff check
     isort --check --diff **/*.py
-    autopep8  -r  --diff . --select F401,E201,E202,E203,E502,E241,E225,E306,E231,E226,E123,F811
 
 
 Configuration and Environment

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ install_requirements = [
 test_requirements = [
     'pytest', 'pytest_cov', 'pytest_localserver',
     'owslib>0.29.2',
-    'pytest_mock', 'pep8',
+    'pytest_mock',
     'pytest-helpers-namespace', 'flask-cors',
     'fsspec',
 ]


### PR DESCRIPTION
This package has been renamed
to pycodestyle and hasn't had
a release since 2017, so remove
it.

<!-- readthedocs-preview datacube-ows start -->
----
📚 Documentation preview 📚: https://datacube-ows--1166.org.readthedocs.build/en/1166/

<!-- readthedocs-preview datacube-ows end -->