### PR TITLE
ruff: add isort rule

### DIFF
--- a/datacube_ows/cfg_parser_impl.py
+++ b/datacube_ows/cfg_parser_impl.py
@@ -18,8 +18,13 @@ from deepdiff import DeepDiff
 
 from datacube_ows import __version__
 from datacube_ows.config_utils import ConfigException
-from datacube_ows.ows_configuration import (OWSConfig, OWSFolder, OWSLayer,
-                                            OWSNamedLayer, read_config)
+from datacube_ows.ows_configuration import (
+    OWSConfig,
+    OWSFolder,
+    OWSLayer,
+    OWSNamedLayer,
+    read_config,
+)
 
 
 @click.group(invoke_without_command=True)

--- a/datacube_ows/config_utils.py
+++ b/datacube_ows/config_utils.py
@@ -8,11 +8,10 @@ import contextlib
 import json
 import logging
 import os
+from collections.abc import Callable, Iterable, Sequence
 from importlib import import_module
 from itertools import chain
 from typing import Any, Optional, cast
-from typing_extensions import override
-from collections.abc import Callable, Iterable, Sequence
 from urllib.parse import urlparse
 
 import fsspec
@@ -20,6 +19,7 @@ from babel.messages import Catalog, Message
 from datacube.model import Product
 from datacube.utils.masking import make_mask
 from flask_babel import gettext as _
+from typing_extensions import override
 from xarray import DataArray
 
 from datacube_ows.config_toolkit import deepinherit

--- a/datacube_ows/feature_info.py
+++ b/datacube_ows/feature_info.py
@@ -6,30 +6,28 @@
 
 import logging
 import re
+from collections.abc import Iterable
 from datetime import datetime
 from itertools import chain
 from typing import cast
-from collections.abc import Iterable
 
 import numpy
 import xarray
 from datacube.model import Dataset
 from datacube.utils.masking import mask_to_dict
-from odc.geo.crs import CRS
 from odc.geo import geom
+from odc.geo.crs import CRS
 from odc.geo.geobox import GeoBox
 from pandas import Timestamp
 
 from datacube_ows.config_utils import CFG_DICT, RAW_CFG, ConfigException
-from datacube_ows.http_utils import (FlaskResponse, html_json_response,
-                                     json_response)
+from datacube_ows.http_utils import FlaskResponse, html_json_response, json_response
 from datacube_ows.loading import DataStacker, ProductBandQuery
 from datacube_ows.ows_configuration import OWSNamedLayer, get_config
 from datacube_ows.styles import StyleDef
 from datacube_ows.time_utils import dataset_center_time
 from datacube_ows.utils import log_call
-from datacube_ows.wms_utils import (GetFeatureInfoParameters,
-                                    img_coords_to_geopoint)
+from datacube_ows.wms_utils import GetFeatureInfoParameters, img_coords_to_geopoint
 
 
 @log_call

--- a/datacube_ows/gunicorn_config.py
+++ b/datacube_ows/gunicorn_config.py
@@ -8,8 +8,7 @@
 """
 import os
 
-from prometheus_flask_exporter.multiprocess import \
-    GunicornInternalPrometheusMetrics
+from prometheus_flask_exporter.multiprocess import GunicornInternalPrometheusMetrics
 
 
 def child_exit(server, worker) -> None:

--- a/datacube_ows/index/__init__.py
+++ b/datacube_ows/index/__init__.py
@@ -4,7 +4,6 @@
 # Copyright (c) 2017-2024 OWS Contributors
 # SPDX-License-Identifier: Apache-2.0
 
-from .api import ows_index, AbortRun, CoordRange, LayerSignature, LayerExtent
-
+from .api import AbortRun, CoordRange, LayerExtent, LayerSignature, ows_index
 
 __all__ = ["ows_index", "AbortRun", "CoordRange", "LayerSignature", "LayerExtent"]

--- a/datacube_ows/index/api.py
+++ b/datacube_ows/index/api.py
@@ -6,14 +6,14 @@
 
 import dataclasses
 from abc import ABC, abstractmethod
-from datetime import datetime, date
-from typing import NamedTuple
 from collections.abc import Iterable
+from datetime import date, datetime
+from typing import NamedTuple
 from uuid import UUID
 
 from datacube import Datacube
 from datacube.index.abstract import AbstractIndex
-from datacube.model import Product, Dataset
+from datacube.model import Dataset, Product
 from odc.geo.crs import CRS
 from odc.geo.geom import Geometry, polygon
 

--- a/datacube_ows/index/driver.py
+++ b/datacube_ows/index/driver.py
@@ -9,7 +9,6 @@ from typing import Optional
 
 from datacube.drivers.driver_cache import load_drivers
 
-
 TYPE_CHECKING = False
 if TYPE_CHECKING:
     from datacube_ows.index.api import OWSAbstractIndexDriver

--- a/datacube_ows/index/postgis/api.py
+++ b/datacube_ows/index/postgis/api.py
@@ -4,26 +4,33 @@
 # Copyright (c) 2017-2024 OWS Contributors
 # SPDX-License-Identifier: Apache-2.0
 
-import click
 import datetime
-
+from collections.abc import Iterable
 from threading import Lock
 from typing import Any
-from typing_extensions import override
-from collections.abc import Iterable
 from uuid import UUID
-from sqlalchemy import text
 
-from odc.geo import Geometry, CRS
-from datacube import Datacube
-from datacube.model import Product, Dataset, Range
+import click
 from antimeridian import fix_shape
+from datacube import Datacube
+from datacube.model import Dataset, Product, Range
+from odc.geo import CRS, Geometry
+from sqlalchemy import text
+from typing_extensions import override
 
-from datacube_ows.ows_configuration import OWSNamedLayer
-from datacube_ows.index.api import OWSAbstractIndex, OWSAbstractIndexDriver, LayerSignature, LayerExtent, TimeSearchTerm
+from datacube_ows.index.api import (
+    LayerExtent,
+    LayerSignature,
+    OWSAbstractIndex,
+    OWSAbstractIndexDriver,
+    TimeSearchTerm,
+)
 from datacube_ows.index.sql import run_sql
-from .product_ranges import create_range_entry as create_range_entry_impl, get_ranges as get_ranges_impl
+from datacube_ows.ows_configuration import OWSNamedLayer
+
 from ...utils import default_to_utc
+from .product_ranges import create_range_entry as create_range_entry_impl
+from .product_ranges import get_ranges as get_ranges_impl
 
 
 class OWSPostgisIndex(OWSAbstractIndex):

--- a/datacube_ows/index/postgis/product_ranges.py
+++ b/datacube_ows/index/postgis/product_ranges.py
@@ -6,21 +6,20 @@
 
 import logging
 import math
-from datetime import date, datetime, timezone
 from collections.abc import Callable
-import click
+from datetime import date, datetime, timezone
 
+import click
 import datacube
 import odc.geo
 import sqlalchemy.exc
+from odc.geo.crs import CRS
 from psycopg2.extras import Json
 from sqlalchemy import text
 
-from odc.geo.crs import CRS
-
+from datacube_ows.index.api import CoordRange, LayerExtent, LayerSignature
 from datacube_ows.ows_configuration import OWSNamedLayer
 from datacube_ows.utils import get_sqlconn
-from datacube_ows.index.api import CoordRange, LayerSignature, LayerExtent
 
 _LOG: logging.Logger = logging.getLogger(__name__)
 

--- a/datacube_ows/index/postgres/api.py
+++ b/datacube_ows/index/postgres/api.py
@@ -4,24 +4,31 @@
 # Copyright (c) 2017-2024 OWS Contributors
 # SPDX-License-Identifier: Apache-2.0
 
-import click
-
+from collections.abc import Iterable
 from threading import Lock
 from typing import cast
-from typing_extensions import override
-from collections.abc import Iterable
 from uuid import UUID
-from sqlalchemy import text
 
-from odc.geo import Geometry, CRS
+import click
 from datacube import Datacube
-from datacube.model import Product, Dataset
+from datacube.model import Dataset, Product
+from odc.geo import CRS, Geometry
+from sqlalchemy import text
+from typing_extensions import override
 
-from datacube_ows.ows_configuration import OWSNamedLayer
-from datacube_ows.index.api import OWSAbstractIndex, OWSAbstractIndexDriver, LayerSignature, LayerExtent, TimeSearchTerm
-from .product_ranges import create_range_entry as create_range_entry_impl, get_ranges as get_ranges_impl
-from .mv_index import MVSelectOpts, mv_search
+from datacube_ows.index.api import (
+    LayerExtent,
+    LayerSignature,
+    OWSAbstractIndex,
+    OWSAbstractIndexDriver,
+    TimeSearchTerm,
+)
 from datacube_ows.index.sql import run_sql
+from datacube_ows.ows_configuration import OWSNamedLayer
+
+from .mv_index import MVSelectOpts, mv_search
+from .product_ranges import create_range_entry as create_range_entry_impl
+from .product_ranges import get_ranges as get_ranges_impl
 
 
 class OWSPostgresIndex(OWSAbstractIndex):

--- a/datacube_ows/index/postgres/mv_index.py
+++ b/datacube_ows/index/postgres/mv_index.py
@@ -6,10 +6,10 @@
 
 import datetime
 import json
+from collections.abc import Iterable
 from enum import Enum
 from types import UnionType
 from typing import cast
-from collections.abc import Iterable
 from uuid import UUID as UUID_
 
 import pytz
@@ -18,8 +18,7 @@ from datacube.model import Dataset, Product
 from geoalchemy2 import Geometry
 from odc.geo.geom import Geometry as ODCGeom
 from psycopg2.extras import DateTimeTZRange
-from sqlalchemy import (SMALLINT, Column, MetaData, Table, and_, or_, select,
-                        text)
+from sqlalchemy import SMALLINT, Column, MetaData, Table, and_, or_, select, text
 from sqlalchemy.dialects.postgresql import TSTZRANGE, UUID
 from sqlalchemy.engine import Row
 from sqlalchemy.engine.base import Engine

--- a/datacube_ows/index/postgres/product_ranges.py
+++ b/datacube_ows/index/postgres/product_ranges.py
@@ -6,24 +6,23 @@
 
 import logging
 import math
-import click
+from collections.abc import Callable
 from datetime import date, datetime, timezone
 from typing import cast
-from collections.abc import Callable
 
+import click
 import datacube
 import odc.geo
 import sqlalchemy.exc
+from odc.geo.crs import CRS
+from odc.geo.geom import Geometry
 from psycopg2.extras import Json
 from sqlalchemy import text
 
-from odc.geo.crs import CRS
-from odc.geo.geom import Geometry
-
-from datacube_ows.ows_configuration import OWSNamedLayer
+from datacube_ows.index.api import CoordRange, LayerExtent, LayerSignature
 from datacube_ows.index.postgres.mv_index import MVSelectOpts, mv_search
+from datacube_ows.ows_configuration import OWSNamedLayer
 from datacube_ows.utils import get_sqlconn
-from datacube_ows.index.api import CoordRange, LayerSignature, LayerExtent
 
 _LOG: logging.Logger = logging.getLogger(__name__)
 

--- a/datacube_ows/index/sql.py
+++ b/datacube_ows/index/sql.py
@@ -5,13 +5,14 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import importlib
+import re
+
 import click
 import datacube.cfg
 import psycopg2
-import re
 import sqlalchemy
-
 from datacube import Datacube
+
 from datacube_ows.index import AbortRun
 
 

--- a/datacube_ows/legend_generator.py
+++ b/datacube_ows/legend_generator.py
@@ -9,6 +9,7 @@ import logging
 
 import matplotlib
 import numpy as np
+
 # from flask import make_response
 from PIL import Image
 

--- a/datacube_ows/legend_utils.py
+++ b/datacube_ows/legend_utils.py
@@ -6,6 +6,7 @@
 
 import io
 import logging
+
 import requests
 from PIL import Image
 

--- a/datacube_ows/loading.py
+++ b/datacube_ows/loading.py
@@ -7,9 +7,8 @@
 import datetime
 import logging
 from collections import OrderedDict
-from typing import cast
-from typing_extensions import override
 from collections.abc import Iterable, Mapping
+from typing import cast
 from uuid import UUID
 
 import datacube
@@ -21,6 +20,7 @@ from odc.geo.crs import CRS
 from odc.geo.geobox import GeoBox
 from odc.geo.geom import Geometry
 from odc.geo.warp import Resampling
+from typing_extensions import override
 
 from datacube_ows.ogc_exceptions import WMSException
 from datacube_ows.ows_configuration import OWSNamedLayer

--- a/datacube_ows/ogc.py
+++ b/datacube_ows/ogc.py
@@ -6,10 +6,10 @@
 
 import sys
 import traceback
+from logging import Logger
 from time import monotonic
 
 from flask import g, render_template, request
-from logging import Logger
 
 from datacube_ows import __version__
 from datacube_ows.http_utils import (

--- a/datacube_ows/ogc_exceptions.py
+++ b/datacube_ows/ogc_exceptions.py
@@ -5,11 +5,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import traceback as tb
-from typing_extensions import override
 
 from flask import render_template
 from ows.common.types import OWSException, Version
 from ows.common.v20.encoders import xml_encode_exception_report
+from typing_extensions import override
 
 from datacube_ows.http_utils import resp_headers
 

--- a/datacube_ows/ogc_utils.py
+++ b/datacube_ows/ogc_utils.py
@@ -13,8 +13,8 @@ import numpy
 import xarray
 from affine import Affine
 from deprecat import deprecat
-from odc.geo.geobox import GeoBox
 from odc.geo.crs import CRS
+from odc.geo.geobox import GeoBox
 from PIL import Image
 
 TYPE_CHECKING = False

--- a/datacube_ows/ows_configuration.py
+++ b/datacube_ows/ows_configuration.py
@@ -17,41 +17,49 @@ import json
 import logging
 import math
 import os
-from collections.abc import Mapping
+from collections.abc import Iterable, Mapping
 from enum import Enum
 from importlib import import_module
 from typing import Any, Optional, Union, cast
-from typing_extensions import override
-from collections.abc import Iterable
 
 import numpy
 from babel.messages.catalog import Catalog
 from babel.messages.pofile import read_po
 from datacube import Datacube
 from datacube.api.query import GroupBy
-from datacube.model import Measurement, Product
 from datacube.cfg import ODCConfig, ODCEnvironment
+from datacube.model import Measurement, Product
 from odc.geo import CRS
 from odc.geo.geobox import GeoBox
 from ows import Version
 from slugify import slugify
+from typing_extensions import override
 
-from datacube_ows.config_utils import (CFG_DICT, RAW_CFG, ConfigException,
-                                       F, FlagProductBands, FunctionWrapper,
-                                       ODCInitException, OWSConfigEntry,
-                                       OWSEntryNotFound, OWSExtensibleConfigEntry,
-                                       OWSFlagBand, OWSMetadataConfig,
-                                       cfg_expand, get_file_loc,
-                                       import_python_obj, load_json_obj)
+from datacube_ows.config_utils import (
+    CFG_DICT,
+    RAW_CFG,
+    ConfigException,
+    F,
+    FlagProductBands,
+    FunctionWrapper,
+    ODCInitException,
+    OWSConfigEntry,
+    OWSEntryNotFound,
+    OWSExtensibleConfigEntry,
+    OWSFlagBand,
+    OWSMetadataConfig,
+    cfg_expand,
+    get_file_loc,
+    import_python_obj,
+    load_json_obj,
+)
 from datacube_ows.index.api import OWSAbstractIndex, ows_index
 from datacube_ows.ogc_utils import create_geobox
-from datacube_ows.resource_limits import (OWSResourceManagementRules,
-                                          parse_cache_age)
+from datacube_ows.resource_limits import OWSResourceManagementRules, parse_cache_age
 from datacube_ows.styles import StyleDef
 from datacube_ows.tile_matrix_sets import TileMatrixSet
 from datacube_ows.time_utils import local_solar_date_range
-from datacube_ows.utils import (group_by_begin_datetime, group_by_mosaic,
-                                group_by_solar)
+from datacube_ows.utils import group_by_begin_datetime, group_by_mosaic, group_by_solar
 
 TYPE_CHECKING = False
 if TYPE_CHECKING:

--- a/datacube_ows/protocol_versions.py
+++ b/datacube_ows/protocol_versions.py
@@ -9,9 +9,13 @@ import contextlib
 import re
 from collections.abc import Callable, Mapping, Sequence
 
-from datacube_ows.ogc_exceptions import (OGCException, WCS1Exception,
-                                         WCS2Exception, WMSException,
-                                         WMTSException)
+from datacube_ows.ogc_exceptions import (
+    OGCException,
+    WCS1Exception,
+    WCS2Exception,
+    WMSException,
+    WMTSException,
+)
 from datacube_ows.ows_configuration import get_config
 from datacube_ows.wcs1 import handle_wcs1
 from datacube_ows.wcs2 import handle_wcs2

--- a/datacube_ows/resource_limits.py
+++ b/datacube_ows/resource_limits.py
@@ -5,8 +5,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import math
-from typing import Any, cast
 from collections.abc import Iterable, Mapping
+from typing import Any, cast
 
 import affine
 import numpy as np
@@ -14,8 +14,7 @@ from odc.geo.crs import CRS
 from odc.geo.geobox import GeoBox
 from odc.geo.geom import polygon
 
-from datacube_ows.config_utils import (CFG_DICT, RAW_CFG, ConfigException,
-                                       OWSConfigEntry)
+from datacube_ows.config_utils import CFG_DICT, RAW_CFG, ConfigException, OWSConfigEntry
 from datacube_ows.http_utils import cache_control_headers
 from datacube_ows.ogc_utils import create_geobox
 

--- a/datacube_ows/startup_utils.py
+++ b/datacube_ows/startup_utils.py
@@ -204,8 +204,9 @@ class FakeMetrics:
 def initialise_prometheus(app, log: Logger | None = None):
     # Prometheus
     if os.environ.get("PROMETHEUS_MULTIPROC_DIR", False):
-        from prometheus_flask_exporter.multiprocess import \
-            GunicornInternalPrometheusMetrics
+        from prometheus_flask_exporter.multiprocess import (
+            GunicornInternalPrometheusMetrics,
+        )
         metrics = GunicornInternalPrometheusMetrics(app, group_by="endpoint")
         if log:
             log.info("Prometheus metrics enabled")

--- a/datacube_ows/styles/base.py
+++ b/datacube_ows/styles/base.py
@@ -6,25 +6,33 @@
 
 import io
 import logging
-from typing import Any, Optional, Union, cast
-from typing_extensions import override
 from collections.abc import Iterable, Mapping, MutableMapping, Sized
+from typing import Any, Optional, Union, cast
 
 import datacube.model
 import numpy as np
 import xarray as xr
 from flask_babel import get_locale
 from PIL import Image
+from typing_extensions import override
 
 import datacube_ows.band_utils
-from datacube_ows.config_utils import (CFG_DICT, RAW_CFG, AbstractMaskRule,
-                                       ConfigException, FlagBand, F,
-                                       FlagProductBands, FunctionWrapper,
-                                       OWSConfigEntry, OWSEntryNotFound,
-                                       OWSExtensibleConfigEntry,
-                                       OWSFlagBandStandalone,
-                                       OWSIndexedConfigEntry,
-                                       OWSMetadataConfig)
+from datacube_ows.config_utils import (
+    CFG_DICT,
+    RAW_CFG,
+    AbstractMaskRule,
+    ConfigException,
+    F,
+    FlagBand,
+    FlagProductBands,
+    FunctionWrapper,
+    OWSConfigEntry,
+    OWSEntryNotFound,
+    OWSExtensibleConfigEntry,
+    OWSFlagBandStandalone,
+    OWSIndexedConfigEntry,
+    OWSMetadataConfig,
+)
 from datacube_ows.legend_utils import get_image_from_url
 from datacube_ows.ogc_exceptions import WMSException
 

--- a/datacube_ows/styles/colormap.py
+++ b/datacube_ows/styles/colormap.py
@@ -6,22 +6,26 @@
 
 import io
 import logging
+from collections.abc import Callable, MutableMapping
 from datetime import datetime
 from typing import Union, cast
-from typing_extensions import override
-from collections.abc import Callable, MutableMapping
 
 import numpy
 import xarray
 from datacube.utils.masking import make_mask
 from matplotlib import patches as mpatches
 from matplotlib import pyplot as plt
-from matplotlib.colors import to_rgba, to_hex
+from matplotlib.colors import to_hex, to_rgba
+from typing_extensions import override
 from xarray import DataArray, Dataset
 
-from datacube_ows.config_utils import (CFG_DICT, AbstractMaskRule,
-                                       ConfigException, FlagSpec,
-                                       OWSMetadataConfig)
+from datacube_ows.config_utils import (
+    CFG_DICT,
+    AbstractMaskRule,
+    ConfigException,
+    FlagSpec,
+    OWSMetadataConfig,
+)
 from datacube_ows.styles.base import StyleDefBase
 
 TYPE_CHECKING = False

--- a/datacube_ows/styles/component.py
+++ b/datacube_ows/styles/component.py
@@ -4,15 +4,14 @@
 # Copyright (c) 2017-2024 OWS Contributors
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Any, cast
-from typing_extensions import override
 from collections.abc import Callable, Hashable
+from typing import Any, cast
 
 import numpy as np
+from typing_extensions import override
 from xarray import DataArray, Dataset
 
-from datacube_ows.config_utils import (CFG_DICT, ConfigException,
-                                       FunctionWrapper)
+from datacube_ows.config_utils import CFG_DICT, ConfigException, FunctionWrapper
 from datacube_ows.styles.base import StyleDefBase
 
 TYPE_CHECKING = False

--- a/datacube_ows/styles/hybrid.py
+++ b/datacube_ows/styles/hybrid.py
@@ -5,8 +5,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import cast
-from typing_extensions import override
 
+from typing_extensions import override
 from xarray import DataArray, Dataset
 
 from datacube_ows.config_utils import CFG_DICT, ConfigException

--- a/datacube_ows/styles/ramp.py
+++ b/datacube_ows/styles/ramp.py
@@ -7,22 +7,26 @@
 import io
 import logging
 from collections import defaultdict
+from collections.abc import Hashable, Iterable, MutableMapping
 from dataclasses import dataclass
 from decimal import ROUND_HALF_UP, Decimal
 from math import isclose
 from typing import Any, Union, cast
-from typing_extensions import override
-from collections.abc import Hashable, Iterable, MutableMapping
 
 import matplotlib
 import numpy
 from matplotlib import pyplot as plt
 from matplotlib.colors import LinearSegmentedColormap, to_hex, to_rgba
 from numpy import ubyte
+from typing_extensions import override
 from xarray import DataArray, Dataset
 
-from datacube_ows.config_utils import (CFG_DICT, ConfigException,
-                                       FunctionWrapper, OWSMetadataConfig)
+from datacube_ows.config_utils import (
+    CFG_DICT,
+    ConfigException,
+    FunctionWrapper,
+    OWSMetadataConfig,
+)
 from datacube_ows.styles.base import StyleDefBase
 from datacube_ows.styles.expression import Expression
 

--- a/datacube_ows/tile_matrix_sets.py
+++ b/datacube_ows/tile_matrix_sets.py
@@ -6,8 +6,7 @@
 
 from typing import cast
 
-from datacube_ows.config_utils import (CFG_DICT, RAW_CFG, ConfigException,
-                                       OWSConfigEntry)
+from datacube_ows.config_utils import CFG_DICT, RAW_CFG, ConfigException, OWSConfigEntry
 
 TYPE_CHECKING = False
 if TYPE_CHECKING:

--- a/datacube_ows/update_ranges_impl.py
+++ b/datacube_ows/update_ranges_impl.py
@@ -14,9 +14,8 @@ import sqlalchemy
 from datacube import Datacube
 
 from datacube_ows import __version__
-from datacube_ows.ows_configuration import get_config
-from datacube_ows.ows_configuration import OWSConfig
 from datacube_ows.index import AbortRun, LayerSignature, ows_index
+from datacube_ows.ows_configuration import OWSConfig, get_config
 from datacube_ows.startup_utils import initialise_debugging
 
 

--- a/datacube_ows/utils.py
+++ b/datacube_ows/utils.py
@@ -6,10 +6,10 @@
 
 import datetime
 import logging
+from collections.abc import Callable
 from functools import wraps
 from time import monotonic
 from typing import Any, TypeVar, cast
-from collections.abc import Callable
 
 import pytz
 from datacube import Datacube

--- a/datacube_ows/wcs1.py
+++ b/datacube_ows/wcs1.py
@@ -6,8 +6,11 @@
 
 from flask import render_template
 
-from datacube_ows.http_utils import (cache_control_headers,
-                                     get_service_base_url, json_response)
+from datacube_ows.http_utils import (
+    cache_control_headers,
+    get_service_base_url,
+    json_response,
+)
 from datacube_ows.ogc_exceptions import WCS1Exception
 from datacube_ows.ows_configuration import get_config
 from datacube_ows.query_profiler import QueryProfiler

--- a/datacube_ows/wcs2.py
+++ b/datacube_ows/wcs2.py
@@ -13,13 +13,15 @@ from ows.gml import Grid, IrregularAxis, RegularAxis, SpatioTemporalType
 from ows.swe import Field
 from ows.wcs import CoverageDescription, CoverageSummary, ServiceCapabilities
 from ows.wcs.v20 import encoders as encoders_v20
-from ows.wcs.v20.decoders import (kvp_decode_describe_coverage,
-                                  kvp_decode_get_coverage)
+from ows.wcs.v20.decoders import kvp_decode_describe_coverage, kvp_decode_get_coverage
 from ows.wcs.v21 import encoders as encoders_v21
 
-from datacube_ows.http_utils import (cache_control_headers,
-                                     get_service_base_url, json_response,
-                                     resp_headers)
+from datacube_ows.http_utils import (
+    cache_control_headers,
+    get_service_base_url,
+    json_response,
+    resp_headers,
+)
 from datacube_ows.ogc_exceptions import WCS2Exception
 from datacube_ows.ows_configuration import OWSConfig, get_config
 from datacube_ows.query_profiler import QueryProfiler

--- a/datacube_ows/wms_utils.py
+++ b/datacube_ows/wms_utils.py
@@ -6,7 +6,6 @@
 
 import math
 from datetime import datetime, timezone
-from typing_extensions import override
 
 import numpy
 import regex as re
@@ -14,11 +13,12 @@ from affine import Affine
 from dateutil.parser import parse
 from dateutil.relativedelta import relativedelta
 from matplotlib import pyplot as plt
-from odc.geo.crs import CRS
 from odc.geo import geom
+from odc.geo.crs import CRS
 from odc.geo.geobox import GeoBox
 from pytz import utc
 from rasterio.warp import Resampling
+from typing_extensions import override
 
 from datacube_ows.config_utils import ConfigException
 from datacube_ows.ogc_exceptions import WMSException
@@ -28,7 +28,6 @@ from datacube_ows.resource_limits import RequestScale
 from datacube_ows.styles import StyleDef, StyleDefBase
 from datacube_ows.styles.expression import ExpressionException
 from datacube_ows.utils import default_to_utc, find_matching_date
-
 
 RESAMPLING_METHODS = {
     'nearest': Resampling.nearest,

--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -11,10 +11,9 @@ pytest_plugins = ["helpers_namespace"]
 import pytest
 from click.testing import CliRunner
 from datacube.cfg import ODCConfig
-from pytest_localserver.http import WSGIServer
-
 from datacube_ows import ogc
 from datacube_ows.ogc import app
+from pytest_localserver.http import WSGIServer
 
 
 @pytest.fixture

--- a/integration_tests/metadata/metadata_importer.py
+++ b/integration_tests/metadata/metadata_importer.py
@@ -2,6 +2,7 @@
 #
 # TODO: Would ideally use stac-to-dc but it hasn't been migrated to datacube-1.9 yet.
 import fileinput
+
 import yaml
 from datacube import Datacube
 from datacube.index.hl import Doc2Dataset

--- a/integration_tests/test_cfg_parser.py
+++ b/integration_tests/test_cfg_parser.py
@@ -7,7 +7,6 @@
 import os
 
 import pytest
-
 from datacube_ows.cfg_parser_impl import main
 
 

--- a/integration_tests/test_mv_index.py
+++ b/integration_tests/test_mv_index.py
@@ -5,11 +5,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
-from odc.geo.geom import box
-
 from datacube_ows.index.postgres.mv_index import MVSelectOpts, mv_search
 from datacube_ows.ows_configuration import get_config
 from datacube_ows.time_utils import local_solar_date_range
+from odc.geo.geom import box
 
 
 def test_full_layer() -> None:

--- a/integration_tests/test_wcs_server.py
+++ b/integration_tests/test_wcs_server.py
@@ -8,11 +8,11 @@ from urllib import request
 
 import pytest
 import requests
+from datacube_ows.ows_configuration import OWSConfig, get_config
 from lxml import etree
 from owslib.util import ServiceException
 from owslib.wcs import WebCoverageService
 
-from datacube_ows.ows_configuration import OWSConfig, get_config
 from integration_tests.utils import ODCExtent
 
 

--- a/integration_tests/test_wms_server.py
+++ b/integration_tests/test_wms_server.py
@@ -4,11 +4,11 @@
 # Copyright (c) 2017-2024 OWS Contributors
 # SPDX-License-Identifier: Apache-2.0
 
+import math
 from urllib import request
 
 import pytest
 import requests
-import math
 from lxml import etree
 from owslib.wms import WebMapService
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ select = [
     "C4", # flake8-comprehensions
     "E",  # pycodestyle errors
     "EXE", # flake8-executable
+    "I",  # isort
     "RUF", # Ruff-specific rules
     "SIM", # flake8-simplify
     "UP", # pyupgrade
@@ -39,7 +40,7 @@ ignore = [
 # Multiline string, no good place for adding a noqa.
 "integration_tests/cfg/ows_test_cfg.py" = ["RUF001"]
 # Third-party software, keep pristine.
-"licenseheaders.py" = ["B007", "C408", "C416", "C419", "SIM108", "SIM114", "UP031", "UP032", "UP035"]
+"licenseheaders.py" = ["B", "C", "I", "SIM", "UP"]
 
 [tool.ruff.lint.pycodestyle]
 max-line-length = 120

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,11 +6,11 @@
 
 import datetime
 from unittest.mock import MagicMock
-from datacube.cfg import ODCConfig
 
 import numpy as np
 import pytest
 import xarray as xr
+from datacube.cfg import ODCConfig
 
 from tests.utils import coords, dim1_da, dim1_da_time, dummy_da
 
@@ -249,7 +249,7 @@ def minimal_multiprod_cfg():
 
 @pytest.fixture
 def mock_range():
-    from datacube_ows.index import LayerExtent, CoordRange
+    from datacube_ows.index import CoordRange, LayerExtent
     times = [datetime.date(2010, 1, 1), datetime.date(2010, 1, 2), datetime.date(2010, 1, 3)]
     return LayerExtent(
         lat=CoordRange(-0.1, 0.1),

--- a/tests/test_band_utils.py
+++ b/tests/test_band_utils.py
@@ -6,21 +6,31 @@
 
 """Test band math utilities
 """
+from collections.abc import Sequence
+
 import numpy as np
 import pytest
 import xarray as xr
-
-from datacube_ows.band_utils import (band_quotient, band_quotient_sum,
-                                     constant, delta_bands, multi_date_delta,
-                                     norm_diff, pre_scaled_delta_bands,
-                                     pre_scaled_norm_diff,
-                                     pre_scaled_sum_bands,
-                                     radar_vegetation_index, scale_data,
-                                     sentinel2_ndci, single_band,
-                                     single_band_arcsec, single_band_log,
-                                     single_band_offset_log, sum_bands)
+from datacube_ows.band_utils import (
+    band_quotient,
+    band_quotient_sum,
+    constant,
+    delta_bands,
+    multi_date_delta,
+    norm_diff,
+    pre_scaled_delta_bands,
+    pre_scaled_norm_diff,
+    pre_scaled_sum_bands,
+    radar_vegetation_index,
+    scale_data,
+    sentinel2_ndci,
+    single_band,
+    single_band_arcsec,
+    single_band_log,
+    single_band_offset_log,
+    sum_bands,
+)
 from datacube_ows.ows_configuration import BandIndex, OWSProductLayer
-from collections.abc import Sequence
 
 
 class MockArray(xr.DataArray):

--- a/tests/test_cfg_bandidx.py
+++ b/tests/test_cfg_bandidx.py
@@ -7,7 +7,6 @@
 from unittest.mock import MagicMock
 
 import pytest
-
 from datacube_ows.config_utils import ConfigException, OWSConfigNotReady
 from datacube_ows.ows_configuration import BandIndex
 

--- a/tests/test_cfg_cache_ctrl.py
+++ b/tests/test_cfg_cache_ctrl.py
@@ -7,7 +7,6 @@
 from unittest.mock import MagicMock
 
 import pytest
-
 from datacube_ows.config_utils import ConfigException
 from datacube_ows.resource_limits import CacheControlRules
 

--- a/tests/test_cfg_global.py
+++ b/tests/test_cfg_global.py
@@ -5,9 +5,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
-
 from datacube_ows.config_utils import ConfigException
-from datacube_ows.ows_configuration import OWSConfig, ContactInfo
+from datacube_ows.ows_configuration import ContactInfo, OWSConfig
 
 
 def test_minimal_global(monkeypatch, minimal_global_raw_cfg, minimal_dc) -> None:

--- a/tests/test_cfg_inclusion.py
+++ b/tests/test_cfg_inclusion.py
@@ -8,7 +8,6 @@ import os
 import sys
 
 import pytest
-
 from datacube_ows.config_utils import ConfigException, get_file_loc
 from datacube_ows.ows_configuration import read_config
 

--- a/tests/test_cfg_layer.py
+++ b/tests/test_cfg_layer.py
@@ -9,11 +9,10 @@ import math
 from unittest.mock import MagicMock, patch
 
 import pytest
-
 from datacube_ows.config_utils import ConfigException
+from datacube_ows.index import CoordRange, LayerExtent
 from datacube_ows.ows_configuration import OWSFolder, OWSLayer, parse_ows_layer
 from datacube_ows.resource_limits import ResourceLimited
-from datacube_ows.index import LayerExtent, CoordRange
 
 
 def test_missing_title(minimal_global_cfg) -> None:

--- a/tests/test_cfg_metadata_types.py
+++ b/tests/test_cfg_metadata_types.py
@@ -7,7 +7,6 @@
 from unittest.mock import MagicMock
 
 import pytest
-
 from datacube_ows.config_utils import ConfigException
 from datacube_ows.ows_configuration import AttributionCfg, SuppURL
 

--- a/tests/test_cfg_tile_matrix_set.py
+++ b/tests/test_cfg_tile_matrix_set.py
@@ -7,7 +7,6 @@
 from unittest.mock import MagicMock
 
 import pytest
-
 from datacube_ows.config_utils import ConfigException
 from datacube_ows.tile_matrix_sets import TileMatrixSet
 

--- a/tests/test_cfg_wcs.py
+++ b/tests/test_cfg_wcs.py
@@ -7,7 +7,6 @@
 from unittest.mock import patch
 
 import pytest
-
 from datacube_ows.config_utils import ConfigException
 from datacube_ows.ows_configuration import WCSFormat, parse_ows_layer
 

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -5,19 +5,19 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import datetime
-from typing_extensions import override
 from unittest.mock import MagicMock
-
-import numpy as np
-import pytest
-from odc.geo.geom import polygon
-from xarray import Dataset
 
 import datacube_ows.data
 import datacube_ows.feature_info
+import numpy as np
+import pytest
 from datacube_ows.feature_info import get_s3_browser_uris
 from datacube_ows.loading import DataStacker, ProductBandQuery
 from datacube_ows.ogc_exceptions import WMSException
+from odc.geo.geom import polygon
+from typing_extensions import override
+from xarray import Dataset
+
 from tests.test_styles import product_layer  # noqa: F401
 
 

--- a/tests/test_legend_generator.py
+++ b/tests/test_legend_generator.py
@@ -8,11 +8,11 @@ from decimal import Decimal
 from unittest.mock import MagicMock
 
 import pytest
-
 from datacube_ows.legend_utils import get_image_from_url
 from datacube_ows.ogc_exceptions import WMSException
 from datacube_ows.styles.base import StyleDefBase
 from datacube_ows.styles.ramp import ColorRamp, ColorRampDef
+
 from tests.test_band_utils import dummy_layer  # noqa: F401
 
 

--- a/tests/test_multidate_handler.py
+++ b/tests/test_multidate_handler.py
@@ -6,7 +6,6 @@
 
 import numpy as np
 import pytest
-
 from datacube_ows.config_utils import ConfigException
 from datacube_ows.styles.base import StyleDefBase
 

--- a/tests/test_no_db_routes.py
+++ b/tests/test_no_db_routes.py
@@ -8,6 +8,7 @@
 """
 import os
 import sys
+
 import pytest
 
 src_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))

--- a/tests/test_ogc_utils.py
+++ b/tests/test_ogc_utils.py
@@ -7,15 +7,15 @@
 import datetime
 from unittest.mock import MagicMock
 
+import datacube_ows.http_utils
+import datacube_ows.ogc_utils
+import datacube_ows.time_utils
+import datacube_ows.utils
 import pytest
 import xarray
 from odc.geo.geom import polygon
 from pytz import utc
 
-import datacube_ows.http_utils
-import datacube_ows.ogc_utils
-import datacube_ows.time_utils
-import datacube_ows.utils
 from tests.utils import dummy_da
 
 

--- a/tests/test_ows_configuration.py
+++ b/tests/test_ows_configuration.py
@@ -6,11 +6,11 @@
 
 from unittest.mock import MagicMock
 
-import pytest
-
 import datacube_ows.config_utils
 import datacube_ows.ogc_utils
 import datacube_ows.ows_configuration
+import pytest
+
 from tests.utils import a_function
 
 

--- a/tests/test_protocol_versions.py
+++ b/tests/test_protocol_versions.py
@@ -4,9 +4,8 @@
 # Copyright (c) 2017-2024 OWS Contributors
 # SPDX-License-Identifier: Apache-2.0
 
-import pytest
-
 import datacube_ows.protocol_versions
+import pytest
 
 
 class DummyException1(Exception):

--- a/tests/test_resource_limits.py
+++ b/tests/test_resource_limits.py
@@ -4,11 +4,10 @@
 # Copyright (c) 2017-2024 OWS Contributors
 # SPDX-License-Identifier: Apache-2.0
 
-import pytest
-from odc.geo import CRS
-
 import datacube_ows.resource_limits
+import pytest
 from datacube_ows.ogc_utils import create_geobox
+from odc.geo import CRS
 
 
 def test_request_scale() -> None:

--- a/tests/test_startup.py
+++ b/tests/test_startup.py
@@ -14,8 +14,7 @@ import pytest
 
 
 def test_fake_creds(monkeypatch) -> None:
-    from datacube_ows.startup_utils import (CredentialManager,
-                                            initialise_aws_credentials)
+    from datacube_ows.startup_utils import CredentialManager, initialise_aws_credentials
     CredentialManager._instance = None
     log = MagicMock()
     monkeypatch.setenv("AWS_DEFAULT_REGION", "")
@@ -35,9 +34,11 @@ def test_fake_creds(monkeypatch) -> None:
 
 
 def test_renewable_creds(monkeypatch) -> None:
-    from datacube_ows.startup_utils import (CredentialManager,
-                                            RefreshableCredentials,
-                                            initialise_aws_credentials)
+    from datacube_ows.startup_utils import (
+        CredentialManager,
+        RefreshableCredentials,
+        initialise_aws_credentials,
+    )
     CredentialManager._instance = None
     log = MagicMock()
     monkeypatch.setenv("AWS_DEFAULT_REGION", "")
@@ -56,8 +57,7 @@ def test_renewable_creds(monkeypatch) -> None:
 
 
 def test_s3_endpoint_default(monkeypatch) -> None:
-    from datacube_ows.startup_utils import (CredentialManager,
-                                            initialise_aws_credentials)
+    from datacube_ows.startup_utils import CredentialManager, initialise_aws_credentials
     CredentialManager._instance = None
     log = MagicMock()
     monkeypatch.setenv("AWS_DEFAULT_REGION", "us-west-1")

--- a/tests/test_style_api.py
+++ b/tests/test_style_api.py
@@ -7,16 +7,19 @@
 from decimal import Decimal
 
 import pytest
-
 from datacube_ows.config_utils import ConfigException
-
 from datacube_ows.styles.api import (
-                                     StandaloneStyle, apply_ows_style,
-                                     apply_ows_style_cfg, create_geobox,
-                                     generate_ows_legend_style,
-                                     generate_ows_legend_style_cfg,
-                                     plot_image, plot_image_with_style, plot_image_with_style_cfg,
-                                     xarray_image_as_png)
+    StandaloneStyle,
+    apply_ows_style,
+    apply_ows_style_cfg,
+    create_geobox,
+    generate_ows_legend_style,
+    generate_ows_legend_style_cfg,
+    plot_image,
+    plot_image_with_style,
+    plot_image_with_style_cfg,
+    xarray_image_as_png,
+)
 
 
 def test_indirect_imports() -> None:

--- a/tests/test_styles.py
+++ b/tests/test_styles.py
@@ -7,13 +7,12 @@
 import datetime
 from unittest.mock import MagicMock, patch
 
+import datacube_ows.styles
 import numpy as np
 import pytest
-from xarray import DataArray, Dataset, concat
-
-import datacube_ows.styles
 from datacube_ows.config_utils import ConfigException, OWSEntryNotFound
 from datacube_ows.ows_configuration import BandIndex, OWSProductLayer
+from xarray import DataArray, Dataset, concat
 
 
 @pytest.fixture
@@ -732,9 +731,8 @@ def test_reint() -> None:
 
 
 def test_createcolordata() -> None:
-    from matplotlib.colors import to_rgba
-
     from datacube_ows.styles.colormap import ColorMapStyleDef
+    from matplotlib.colors import to_rgba
 
     band = np.array([0, 0, 1, 1, 2, 2])
     da = DataArray(band, name='foo')
@@ -745,9 +743,8 @@ def test_createcolordata() -> None:
 
 
 def test_createcolordata_alpha() -> None:
-    from matplotlib.colors import to_rgba
-
     from datacube_ows.styles.colormap import ColorMapStyleDef
+    from matplotlib.colors import to_rgba
 
     band = np.array([0, 0, 1, 1, 2, 2])
     da = DataArray(band, name='foo')
@@ -758,9 +755,8 @@ def test_createcolordata_alpha() -> None:
 
 
 def test_createcolordata_mask() -> None:
-    from matplotlib.colors import to_rgba
-
     from datacube_ows.styles.colormap import ColorMapStyleDef
+    from matplotlib.colors import to_rgba
 
     band = np.array([0, 0, 1, 1, 2, 2])
     da = DataArray(band, name='foo')
@@ -772,9 +768,8 @@ def test_createcolordata_mask() -> None:
 
 
 def test_createcolordata_remask() -> None:
-    from matplotlib.colors import to_rgba
-
     from datacube_ows.styles.colormap import ColorMapStyleDef
+    from matplotlib.colors import to_rgba
 
     band = np.array([0, 0, 1, 1, np.nan, np.nan])
     da = DataArray(band, name='foo')
@@ -786,7 +781,7 @@ def test_createcolordata_remask() -> None:
 
 
 def test_scale_ramp() -> None:
-    from datacube_ows.styles.ramp import scale_unscaled_ramp, RampNode
+    from datacube_ows.styles.ramp import RampNode, scale_unscaled_ramp
 
     input_ = [
         RampNode(0.0, "red", alpha=0.5),

--- a/tests/test_time_res_method.py
+++ b/tests/test_time_res_method.py
@@ -8,7 +8,6 @@ from datetime import datetime
 
 import pytest
 import pytz
-
 from datacube_ows.ows_configuration import TimeRes
 
 

--- a/tests/test_update_ranges.py
+++ b/tests/test_update_ranges.py
@@ -9,8 +9,8 @@ https://click.palletsprojects.com/en/7.x/testing/
 """
 import pytest
 from click.testing import CliRunner
-from datacube_ows.update_ranges_impl import main
 from datacube_ows.index.sql import run_sql
+from datacube_ows.update_ranges_impl import main
 
 
 @pytest.fixture

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -46,7 +46,6 @@ def datasets_for_sorting():
 
 def test_group_by_stat(datasets_for_sorting) -> None:
     from datacube import Datacube
-
     from datacube_ows.utils import group_by_begin_datetime
 
     gby = group_by_begin_datetime()
@@ -66,7 +65,6 @@ def test_group_by_stat(datasets_for_sorting) -> None:
 
 def test_group_by_solar(datasets_for_sorting) -> None:
     from datacube import Datacube
-
     from datacube_ows.utils import group_by_solar
 
     gby = group_by_solar()
@@ -87,7 +85,6 @@ def test_group_by_solar(datasets_for_sorting) -> None:
 
 def test_group_by_mosaic(datasets_for_sorting) -> None:
     from datacube import Datacube
-
     from datacube_ows.utils import group_by_mosaic
 
     gby = group_by_mosaic()

--- a/tests/test_wcs2_utils.py
+++ b/tests/test_wcs2_utils.py
@@ -7,7 +7,6 @@
 from unittest.mock import MagicMock
 
 import pytest
-
 from datacube_ows.ogc_exceptions import WCS2Exception
 from datacube_ows.wcs2_utils import uniform_crs
 

--- a/tests/test_wcs_scaler.py
+++ b/tests/test_wcs_scaler.py
@@ -8,11 +8,13 @@ import datetime
 
 import pytest
 from affine import Affine
-
-from datacube_ows.ows_configuration import OWSConfig, OWSProductLayer
 from datacube_ows.index.api import CoordRange, LayerExtent
-from datacube_ows.wcs_scaler import (SpatialParameter, WCSScaler,
-                                     WCSScalerUnknownDimension)
+from datacube_ows.ows_configuration import OWSConfig, OWSProductLayer
+from datacube_ows.wcs_scaler import (
+    SpatialParameter,
+    WCSScaler,
+    WCSScalerUnknownDimension,
+)
 
 
 @pytest.fixture

--- a/tests/test_wms_utils.py
+++ b/tests/test_wms_utils.py
@@ -7,13 +7,12 @@
 import datetime
 from unittest.mock import MagicMock
 
-import pytest
-from odc.geo import CRS
-
 import datacube_ows.wms_utils
+import pytest
+from datacube_ows.index import CoordRange, LayerExtent
 from datacube_ows.ogc_exceptions import WMSException
 from datacube_ows.ows_configuration import TimeRes
-from datacube_ows.index import LayerExtent, CoordRange
+from odc.geo import CRS
 
 
 def test_parse_time_delta() -> None:


### PR DESCRIPTION
This is basically a drop-in
replacement for isort, except
that it's much faster.

This will reduce merge conflicts
since the fields within imports
are always kept in the same
order.

<!-- readthedocs-preview datacube-ows start -->
----
📚 Documentation preview 📚: https://datacube-ows--1167.org.readthedocs.build/en/1167/

<!-- readthedocs-preview datacube-ows end -->