### PR TITLE
Replace dockerhub push with GHCR.

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,11 +1,10 @@
 ---
-name: Build Docker Image
+name: Build Docker Image and push to GHCR
 
 on:
   push:
     branches:
       - develop
-      - develop-1.9
     paths:
       - "**"
       - '!docs/**'
@@ -14,47 +13,44 @@ on:
       - '!datacube_ows/__init__.py'
 
   release:
-    types: [created, edited, published]
+    types: [published]
 
 env:
-  ORG: opendatacube
-  IMAGE: ows
+  REGISTRY: ghcr.io
+  IMAGE_NAME: opendatacube/ows
 
-# When a PR is updated, cancel the jobs from the previous version. Merges
-# do not define head_ref, so use run_id to never cancel those jobs.
-concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
-  cancel-in-progress: true
 
 jobs:
-  docker:
+  build-and-push-image:
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/master' || github.event_name == 'release'
+
+    permissions:
+      id-token: write   # This is required for requesting the JWT
+      contents: read    # This is required for actions/checkout
+      packages: write  # This is required for pushing to ghcr
 
     steps:
-      - name: Login to DockerHub
+      - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
         with:
-          fetch-depth: 0
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Export Secrets to enviroment
-        run: |
-          echo "${{ secrets.DockerPassword }}" | docker login -u "${{ secrets.DockerUser }}" --password-stdin
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
-      # Tag image if this is a tagged build
-      # if not use a pseudo tag based on current tag,
-      # number of commits since last tag and git hash
-      - name: Push to DockerHub (master branch or tagged release only)
-        if: github.ref == 'refs/heads/master' || github.event_name == 'release'
-        run: |
-
-          # build local docker image
-          docker build -t ${ORG}/${IMAGE}:latest .
-
-          # get version tag
-          tag="$(docker run ${ORG}/${IMAGE}:latest datacube-ows-update --version | grep 'version' | sed 's/Open Data Cube Open Web Services (datacube-ows) version //' | sed 's/+/\_/g')"
-
-          # tag and push images
-          docker tag ${ORG}/${IMAGE}:latest ${ORG}/${IMAGE}:${tag}
-          docker push ${ORG}/${IMAGE}:latest
-          docker push ${ORG}/${IMAGE}:${tag}
+      - name: Build and push Docker image
+        id: push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,10 @@
 # Note that this is now pinned to a fixed version.  Remember to check for new versions periodically.
 FROM ghcr.io/osgeo/gdal:ubuntu-small-3.10.3 AS builder
 
+LABEL org.opencontainers.image.soure=https://github.com/opendatacube/datacube-ows
+LABEL org.opencontainers.image.description="Datacube OWS"
+LABEL org.opencontainers.image.licences="Apache-2.0"
+
 # Environment is test or deployment.
 ARG ENVIRONMENT=deployment
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Note that this is now pinned to a fixed version.  Remember to check for new versions periodically.
 FROM ghcr.io/osgeo/gdal:ubuntu-small-3.10.3 AS builder
 
-LABEL org.opencontainers.image.soure=https://github.com/opendatacube/datacube-ows
+LABEL org.opencontainers.image.source=https://github.com/opendatacube/datacube-ows
 LABEL org.opencontainers.image.description="Datacube OWS"
 LABEL org.opencontainers.image.licences="Apache-2.0"
 


### PR DESCRIPTION
The dockerhub push workflow has been broken for quite some time.  I figure if I'm messing with it, I may as well switch over to GHCR.

I've seen a bunch of variant approaches for doing this.  This PR closely follows the example at https://docs.github.com/en/actions/use-cases-and-examples/publishing-packages/publishing-docker-images

Assuming this works, future possible enhancements include:

1) Folding it into the main test workflow so the docker image only gets built once.
2) Adding attestation, as per the github example code above.

<!-- readthedocs-preview datacube-ows start -->
----
📚 Documentation preview 📚: https://datacube-ows--1170.org.readthedocs.build/en/1170/

<!-- readthedocs-preview datacube-ows end -->