### PR TITLE
Update pypi action runner to ubuntu 24.04.

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -8,17 +8,17 @@ on:
 jobs:
   build-n-publish:
     name: Build and publish datacube-ows distributions 📦 to PyPI and TestPyPI
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     if: github.event_name == 'release'
 
     steps:
       - uses: actions/checkout@v4
       - name: Fetch all history for all tags and branches
         run: git fetch --prune --unshallow
-      - name: Set up Python 3.7
+      - name: Set up Python 3.10
         uses: actions/setup-python@v5
         with:
-          python-version: 3.7
+          python-version: 3.10
       - name: Install pypa/build
         run: >-
           python -m


### PR DESCRIPTION
The pypi action was using the ubuntu 20.04 action runner, which hasn't been supported for nearly a month now.

As a result the last two OWS releases (1.9.1 and 1.9.2) never actually made it PyPI!! (until this afternoon when I uploaded them both manually.)

This PR moves the action onto the ubuntu-24.04 runner.

<!-- readthedocs-preview datacube-ows start -->
----
📚 Documentation preview 📚: https://datacube-ows--1181.org.readthedocs.build/en/1181/

<!-- readthedocs-preview datacube-ows end -->