### PR TITLE
Fix GetCaps when some layers are broken

### DIFF
--- a/datacube_ows/templates/wms_capabilities.xml
+++ b/datacube_ows/templates/wms_capabilities.xml
@@ -35,8 +35,8 @@
     {%  endif %}
 {%- endmacro %}
 {% macro render_named_layer(lyr, depth=0) -%}
-    {% set lyr_ranges = lyr.ranges %}
     {% if not lyr.hide %}
+    {% set lyr_ranges = lyr.ranges %}
     <Layer queryable="1">
         <Name>{{ lyr.name }}</Name>
         <Title>{{ lyr.title }}</Title>


### PR DESCRIPTION
It looks like WMS GetCaps is failing when one or more layers is failing due to one or more layers missing from the range table. This should fix, although it is not clear when or how the bug was introduced.

<!-- readthedocs-preview datacube-ows start -->
----
📚 Documentation preview 📚: https://datacube-ows--1185.org.readthedocs.build/en/1185/

<!-- readthedocs-preview datacube-ows end -->