### PR TITLE
pytest: output test runtimes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,9 @@ ignore_missing_imports = true
 warn_redundant_casts = true
 warn_unused_ignores = true
 
+[tool.pytest.ini_options]
+console_output_style = "times"
+
 [tool.ruff]
 src = ["datacube_ows", "docs", "tests", "integration_tests"]
 


### PR DESCRIPTION
Enable the pytest 8.4 feature to display
test times in the output.

Beyond finding the slow tests easily,
this can also be used as an indication
of CI machines suffering from some kind
temporary hickup when failing.

<!-- readthedocs-preview datacube-ows start -->
----
📚 Documentation preview 📚: https://datacube-ows--1186.org.readthedocs.build/en/1186/

<!-- readthedocs-preview datacube-ows end -->