### PR TITLE
Pin lxml<6 as 6.0.0 seems buggy

### DIFF
--- a/datacube_ows/templates/wms_capabilities.xml
+++ b/datacube_ows/templates/wms_capabilities.xml
@@ -35,8 +35,8 @@
     {%  endif %}
 {%- endmacro %}
 {% macro render_named_layer(lyr, depth=0) -%}
-    {% if not lyr.hide %}
     {% set lyr_ranges = lyr.ranges %}
+    {% if not lyr.hide %}
     <Layer queryable="1">
         <Name>{{ lyr.name }}</Name>
         <Title>{{ lyr.title }}</Title>

--- a/datacube_ows/templates/wms_capabilities.xml
+++ b/datacube_ows/templates/wms_capabilities.xml
@@ -35,8 +35,8 @@
     {%  endif %}
 {%- endmacro %}
 {% macro render_named_layer(lyr, depth=0) -%}
-    {% set lyr_ranges = lyr.ranges %}
     {% if not lyr.hide %}
+    {% set lyr_ranges = lyr.ranges %}
     <Layer queryable="1">
         <Name>{{ lyr.name }}</Name>
         <Title>{{ lyr.title }}</Title>

--- a/integration_tests/cfg/ows_test_cfg.py
+++ b/integration_tests/cfg/ows_test_cfg.py
@@ -946,13 +946,13 @@ ows_cfg = {
                             "flags": [
                                 {
                                     "band": "fmask_alias",
-                                    "products": ["ga_s2am_ard_3", "ga_s2bm_ard_3"],
+                                    "product": "spaghetti_gateaux",
                                     "ignore_time": False,
                                     "ignore_info_flags": []
                                 },
                                 {
                                     "band": "land",
-                                    "products": ["geodata_coast_100k", "geodata_coast_100k"],
+                                    "product": "spaghetti_gateaux",
                                     "ignore_time": True,
                                     "ignore_info_flags": []
                                 },

--- a/integration_tests/cfg/ows_test_cfg.py
+++ b/integration_tests/cfg/ows_test_cfg.py
@@ -928,6 +928,41 @@ ows_cfg = {
                             "styling": {"default_style": "ndci", "styles": styles_s2_ga_list},
                         },
                         {
+                            "title": "A Broken Layer",
+                            "name": "broken_layer",
+                            "abstract": """Deliberately broken layer - should be silently ignored
+                                        """,
+                            "product_name": "spaghetti_gateaux",
+                            "low_res_product_name": "spaghetti_geteaux_mosaic",
+                            "bands": bands_sentinel2_ard_nbart,
+                            "resource_limits": reslim_for_sentinel2,
+                            "native_crs": "EPSG:3577",
+                            "native_resolution": [10.0, -10.0],
+                            "image_processing": {
+                                "extent_mask_func": "datacube_ows.ogc_utils.mask_by_val",
+                                "always_fetch_bands": [],
+                                "manual_merge": False,
+                            },
+                            "flags": [
+                                {
+                                    "band": "fmask_alias",
+                                    "products": ["ga_s2am_ard_3", "ga_s2bm_ard_3"],
+                                    "ignore_time": False,
+                                    "ignore_info_flags": []
+                                },
+                                {
+                                    "band": "land",
+                                    "products": ["geodata_coast_100k", "geodata_coast_100k"],
+                                    "ignore_time": True,
+                                    "ignore_info_flags": []
+                                },
+                            ],
+                            "time_axis": {
+                                "time_interval": 1
+                            },
+                            "styling": {"default_style": "ndci", "styles": styles_s2_ga_list},
+                        },
+                        {
                             "inherits": {
                                 "layer": "s2_ard_granule_nbar_t",
                             },

--- a/integration_tests/test_wms_server.py
+++ b/integration_tests/test_wms_server.py
@@ -5,13 +5,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import math
+from pathlib import Path
 from urllib import request
 
 import pytest
 import requests
 from lxml import etree
 from owslib.wms import WebMapService
-from pathlib import Path
 
 
 def get_xsd(name: str) -> etree.XMLSchema:

--- a/integration_tests/test_wms_server.py
+++ b/integration_tests/test_wms_server.py
@@ -11,10 +11,12 @@ import pytest
 import requests
 from lxml import etree
 from owslib.wms import WebMapService
+from pathlib import Path
 
 
 def get_xsd(name: str) -> etree.XMLSchema:
-    with open("wms_xsds/" + name) as xsd_f:
+    path = Path(__file__).resolve().parent.parent / 'wms_xsds' / name
+    with open(path) as xsd_f:
         schema_doc = etree.parse(xsd_f)
     return etree.XMLSchema(schema_doc)
 

--- a/integration_tests/test_wms_server.py
+++ b/integration_tests/test_wms_server.py
@@ -115,9 +115,10 @@ def test_wms_server(ows_server) -> None:
 
     assert wms.identification.type == "WMS"
 
-    # Ensure that we have at least some layers available
-    contents = list(wms.contents)
-    assert contents
+    # Ensure that we have expected layers
+    assert "s2_ard_granule_nbar_t" in wms.contents
+    # Ensure that bad layers are hidden
+    assert 'spaghetti_gateaux' not in wms.contents
 
 
 def test_wms_getmap(ows_server) -> None:

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ install_requirements = [
     'affine',
     'click',
     'fsspec',
-    'lxml',
+    'lxml<6',
     'deepdiff',
     'importlib_metadata',
     'matplotlib',


### PR DESCRIPTION
Pins lxml<6 as 6.0.0 seems buggy, see #1189

And misc things I cleaned up while trying to figure out where the failure was coming from:

- Determine xsd location with pathlib, relative to integration_tests directory, instead of making assumptions about current working directory.
- Also adds a quick test to ensure that bad layers are being silently hidden.



<!-- readthedocs-preview datacube-ows start -->
----
📚 Documentation preview 📚: https://datacube-ows--1187.org.readthedocs.build/en/1187/

<!-- readthedocs-preview datacube-ows end -->