### PR TITLE
Use lxml 5.x

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ install_requirements = [
     'affine',
     'click',
     'fsspec',
-    'lxml',
+    'lxml<6.0',
     'deepdiff',
     'importlib_metadata',
     'matplotlib',


### PR DESCRIPTION
Version 6 binary wheels disable direct HTTP and FTP
support for parsing from URLs:

https://github.com/lxml/lxml/releases/tag/lxml-6.0.0

<!-- readthedocs-preview datacube-ows start -->
----
📚 Documentation preview 📚: https://datacube-ows--1190.org.readthedocs.build/en/1190/

<!-- readthedocs-preview datacube-ows end -->