### PR TITLE
Permit lxml 6.0

### DIFF
--- a/datacube_ows/ogc_exceptions.py
+++ b/datacube_ows/ogc_exceptions.py
@@ -59,13 +59,13 @@ class WMSException(OGCException):
     OPERATION_NOT_SUPPORTED = "OperationNotSupported"
 
     version = "1.3.0"
-    schema_url = "http://schemas.opengis.net/wms/1.3.0/exceptions_1_3_0.xsd"
+    schema_url = "https://schemas.opengis.net/wms/1.3.0/exceptions_1_3_0.xsd"
 
 
 class WMTSException(WMSException):
     INVALID_PARAMETER_VALUE = "InvalidParameterValue"
     version = "1.0.0"
-    schema_url = "http://schemas.opengis.net/ows/1.1.0/owsExceptionReport.xsd"
+    schema_url = "https://schemas.opengis.net/ows/1.1.0/owsExceptionReport.xsd"
 
 
 class WCS1Exception(OGCException):
@@ -74,7 +74,7 @@ class WCS1Exception(OGCException):
     INVALID_PARAMETER_VALUE = "InvalidParameterValue"
 
     version = "1.2.0"
-    schema_url = "http://schemas.opengis.net/wcs/1.0.0/OGC-exception.xsd"
+    schema_url = "https://schemas.opengis.net/wcs/1.0.0/OGC-exception.xsd"
 
 
 class WCS2Exception(OGCException):
@@ -98,7 +98,7 @@ class WCS2Exception(OGCException):
     INVALID_PARAMETER_VALUE = "InvalidParameterValue"
 
     version = "2.0.1"
-    schema_url = "http://schemas.opengis.net/wcs/2.0/wcsAll.xsd"
+    schema_url = "https://schemas.opengis.net/wcs/2.0/wcsAll.xsd"
 
     # pylint: disable=dangerous-default-value
     @override

--- a/datacube_ows/ows_configuration.py
+++ b/datacube_ows/ows_configuration.py
@@ -1427,7 +1427,7 @@ class OWSConfig(OWSMetadataConfig):
 
         def make_gml_name(name: str) -> str:
             if name.startswith("EPSG:"):
-                return f"http://www.opengis.net/def/crs/EPSG/0/{name[5:]}"
+                return f"https://www.opengis.net/def/crs/EPSG/0/{name[5:]}"
             else:
                 return name
 

--- a/datacube_ows/wcs2_utils.py
+++ b/datacube_ows/wcs2_utils.py
@@ -27,7 +27,7 @@ _LOG: logging.Logger = logging.getLogger(__name__)
 
 def uniform_crs(cfg: OWSConfig, crs: str) -> str:
     """Helper function to transform a URL style EPSG definition to an 'EPSG:nnn' one"""
-    if crs.startswith('http://www.opengis.net/def/crs/EPSG/'):
+    if crs.startswith('https://www.opengis.net/def/crs/EPSG/'):
         code = crs.rpartition('/')[-1]
         crs = f'EPSG:{code}'
     elif crs.startswith('urn:ogc:def:crs:EPSG:'):

--- a/integration_tests/test_wcs_server.py
+++ b/integration_tests/test_wcs_server.py
@@ -18,7 +18,7 @@ from integration_tests.utils import ODCExtent
 
 def get_xsd(name: str) -> etree.XMLSchema:
     # TODO: Get XSD's for different versions
-    xsd_f = request.urlopen("http://schemas.opengis.net/wcs/" + name)
+    xsd_f = request.urlopen("https://schemas.opengis.net/wcs/" + name)
     schema_doc = etree.parse(xsd_f)
 
     return etree.XMLSchema(schema_doc)

--- a/integration_tests/test_wmts_server.py
+++ b/integration_tests/test_wmts_server.py
@@ -15,8 +15,8 @@ from owslib.wmts import WebMapTileService
 
 def get_xsd(name: str) -> etree.XMLSchema:
     # since this function is only being called by getcapabilities set to wmts/1.0.0
-    # the exception schema is available from http://schemas.opengis.net/ows/1.1.0/
-    xsd_f = request.urlopen("http://schemas.opengis.net/wmts/1.0/" + name)
+    # the exception schema is available from https://schemas.opengis.net/ows/1.1.0/
+    xsd_f = request.urlopen("https://schemas.opengis.net/wmts/1.0/" + name)
     schema_doc = etree.parse(xsd_f)
     return etree.XMLSchema(schema_doc)
 

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ install_requirements = [
     'affine',
     'click',
     'fsspec',
-    'lxml<6',
+    'lxml',
     'deepdiff',
     'importlib_metadata',
     'matplotlib',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -130,7 +130,7 @@ def minimal_global_cfg(minimal_dc):
             "horizontal_coord": "x",
             "vertical_coord": "y",
             "vertical_coord_first": False,
-            "gml_name": "http://www.opengis.net/def/crs/EPSG/0/3857",
+            "gml_name": "https://www.opengis.net/def/crs/EPSG/0/3857",
             "alias_of": None,
         },
         "EPSG:4326": {  # WGS-84
@@ -138,7 +138,7 @@ def minimal_global_cfg(minimal_dc):
             "vertical_coord_first": True,
             "horizontal_coord": "longitude",
             "vertical_coord": "latitude",
-            "gml_name": "http://www.opengis.net/def/crs/EPSG/0/4326",
+            "gml_name": "https://www.opengis.net/def/crs/EPSG/0/4326",
             "alias_of": None,
         },
         "EPSG:3577": {
@@ -146,7 +146,7 @@ def minimal_global_cfg(minimal_dc):
             "horizontal_coord": "x",
             "vertical_coord": "y",
             "vertical_coord_first": False,
-            "gml_name": "http://www.opengis.net/def/crs/EPSG/0/3577",
+            "gml_name": "https://www.opengis.net/def/crs/EPSG/0/3577",
             "alias_of": None,
         },
         "TEST:CRS": {

--- a/tests/test_wcs2_utils.py
+++ b/tests/test_wcs2_utils.py
@@ -21,7 +21,7 @@ def minimal_cfg():
 
 
 def test_uniform_crs_url(minimal_cfg) -> None:
-    crs = uniform_crs(minimal_cfg, "http://www.opengis.net/def/crs/EPSG/666")
+    crs = uniform_crs(minimal_cfg, "https://www.opengis.net/def/crs/EPSG/666")
     assert crs == "EPSG:666"
 
 

--- a/tests/test_wcs_scaler.py
+++ b/tests/test_wcs_scaler.py
@@ -28,7 +28,7 @@ def layer_crs_nongeom():
             "horizontal_coord": "x",
             "vertical_coord": "y",
             "vertical_coord_first": False,
-            "gml_name": "http://www.opengis.net/def/crs/EPSG/0/3857",
+            "gml_name": "https://www.opengis.net/def/crs/EPSG/0/3857",
             "alias_of": None,
         },
         "EPSG:4326": {  # WGS-84
@@ -36,7 +36,7 @@ def layer_crs_nongeom():
             "vertical_coord_first": True,
             "horizontal_coord": "longitude",
             "vertical_coord": "latitude",
-            "gml_name": "http://www.opengis.net/def/crs/EPSG/0/4326",
+            "gml_name": "https://www.opengis.net/def/crs/EPSG/0/4326",
             "alias_of": None,
         },
         "EPSG:3577": {
@@ -44,7 +44,7 @@ def layer_crs_nongeom():
             "horizontal_coord": "x",
             "vertical_coord": "y",
             "vertical_coord_first": False,
-            "gml_name": "http://www.opengis.net/def/crs/EPSG/0/3577",
+            "gml_name": "https://www.opengis.net/def/crs/EPSG/0/3577",
             "alias_of": None,
         },
         "TEST:CRS": {
@@ -84,7 +84,7 @@ def layer_crs_geom():
             "horizontal_coord": "x",
             "vertical_coord": "y",
             "vertical_coord_first": False,
-            "gml_name": "http://www.opengis.net/def/crs/EPSG/0/3857",
+            "gml_name": "https://www.opengis.net/def/crs/EPSG/0/3857",
             "alias_of": False
         },
         "EPSG:4326": {  # WGS-84
@@ -92,7 +92,7 @@ def layer_crs_geom():
             "vertical_coord_first": True,
             "horizontal_coord": "longitude",
             "vertical_coord": "latitude",
-            "gml_name": "http://www.opengis.net/def/crs/EPSG/0/4326",
+            "gml_name": "https://www.opengis.net/def/crs/EPSG/0/4326",
             "alias_of": False
         },
         "EPSG:3577": {
@@ -100,7 +100,7 @@ def layer_crs_geom():
             "horizontal_coord": "x",
             "vertical_coord": "y",
             "vertical_coord_first": False,
-            "gml_name": "http://www.opengis.net/def/crs/EPSG/0/3577",
+            "gml_name": "https://www.opengis.net/def/crs/EPSG/0/3577",
             "alias_of": False
         },
     }


### PR DESCRIPTION
The binary wheels of lxml 6.0 do not
support HTTP, so use HTTPS instead.

<!-- readthedocs-preview datacube-ows start -->
----
📚 Documentation preview 📚: https://datacube-ows--1193.org.readthedocs.build/en/1193/

<!-- readthedocs-preview datacube-ows end -->