### PR TITLE
feature_info: fix deprecation warning

### DIFF
--- a/datacube_ows/feature_info.py
+++ b/datacube_ows/feature_info.py
@@ -46,8 +46,8 @@ def get_s3_browser_uris(datasets: dict[ProductBandQuery, xarray.DataArray],
                             last_crs = ds.crs
                         else:
                             pt_native = pt
-                        if ds.extent.contains(pt_native):
-                            uris.append(ds.uris)
+                        if ds.uri is not None and ds.extent.contains(pt_native):
+                            uris.append(ds.uris if ds.has_multiple_uris() else [ds.uri])
                     else:
                         uris.append(ds.uris)
             break


### PR DESCRIPTION
Only use the deprecated uris method
when there are multiple uris.

<!-- readthedocs-preview datacube-ows start -->
----
📚 Documentation preview 📚: https://datacube-ows--1194.org.readthedocs.build/en/1194/

<!-- readthedocs-preview datacube-ows end -->