### PR TITLE
CI: pin actions by hash

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
 - package-ecosystem: github-actions
   directory: "/"
   schedule:
-    interval: "daily"
+    interval: "weekly"
   target-branch: "develop"
 - package-ecosystem: docker
   directory: "/"

--- a/.github/workflows/complementary-config-test.yaml
+++ b/.github/workflows/complementary-config-test.yaml
@@ -44,13 +44,13 @@ jobs:
 
     steps:
       - name: git checkout ows
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
           path: datacube-ows
 
       - name: git checkout dea-config
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: GeoscienceAustralia/dea-config
           path: dea-config

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -31,10 +31,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Log in to the Container registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -42,13 +42,13 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
       - name: Build and push Docker image
         id: push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         with:
           context: .
           push: true

--- a/.github/workflows/dockerfile-lint.yml
+++ b/.github/workflows/dockerfile-lint.yml
@@ -30,12 +30,12 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
 
       - name: lint Dockerfile
-        uses: hadolint/hadolint-action@v3.1.0
+        uses: hadolint/hadolint-action@54c9adbab1582c2ef04b2016b760714a4bfde3cf # v3.1.0
         with:
           dockerfile: Dockerfile
           ignore: DL3008,DL3002,DL3013,DL3059,SC2102

--- a/.github/workflows/docpreview.yaml
+++ b/.github/workflows/docpreview.yaml
@@ -20,6 +20,6 @@ jobs:
   documentation-preview:
     runs-on: ubuntu-latest
     steps:
-      - uses: readthedocs/actions/preview@v1
+      - uses: readthedocs/actions/preview@b8bba1484329bda1a3abe986df7ebc80a8950333 # v1.5
         with:
           project-slug: "datacube-ows"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -40,7 +40,7 @@ jobs:
     name: Pylint
     steps:
       - name: checkout git
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
       - name: Install dependencies and run pylint
@@ -53,9 +53,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.10"
       - run: python -m pip install ruff
@@ -70,11 +70,11 @@ jobs:
     name: MyPy
     steps:
       - name: checkout git
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
       - name: Setup conda
-        uses: s-weigand/setup-conda@v1
+        uses: s-weigand/setup-conda@7e8fd4c763d3ccb2296fe2a06814d45b3e447dc7 # v1.2.4
         with:
           update-conda: true
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -12,11 +12,11 @@ jobs:
     if: github.event_name == 'release'
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Fetch all history for all tags and branches
         run: git fetch --prune --unshallow
       - name: Set up Python 3.10
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: 3.10
       - name: Install pypa/build

--- a/.github/workflows/pyspy-profiling.yaml
+++ b/.github/workflows/pyspy-profiling.yaml
@@ -40,7 +40,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
         fetch-depth: 0
 
@@ -51,11 +51,7 @@ jobs:
         export LOCAL_GID=$(id -g $USER)
         export $(grep -v '^#' .env_simple | xargs)
         docker compose -f docker-compose.yaml -f docker-compose.db.yaml -f docker-compose.pyspy.yaml up --quiet-pull -d
-
-    - name: Sleep for 10 seconds (stage 1 - wait for services to be ready)
-      uses: whatnick/wait-action@master
-      with:
-        time: '10s'
+        sleep 10
 
     - name: set output container pid (stage 1 - get ows container pid)
       id: set-output-container-id
@@ -86,7 +82,7 @@ jobs:
         docker compose -f docker-compose.yaml -f docker-compose.db.yaml -f docker-compose.pyspy.yaml down
 
     - name: Upload profile to artifact (stage 1 - Upload profiling svg to artifacts)
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
         name: profile.json
         path: ./artifacts/profile.json

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout git
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
 
@@ -48,7 +48,7 @@ jobs:
 
       - name: Build unstable + latest Docker image tag
         if: github.event_name != 'release'
-        uses: whoan/docker-build-with-cache-action@v8
+        uses: whoan/docker-build-with-cache-action@d8d3ad518e7ac382b880720d0751815e656fe032 # v8.1.0
         with:
           image_name: ${{ env.IMAGE_NAME }}
           image_tag: ${{ env.UNSTABLE_TAG }},latest
@@ -57,7 +57,7 @@ jobs:
 
       - name: Run vulnerability scanner
         if: github.event_name != 'release'
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@76071ef0d7ec797419534a183b498b4d6366cf37 # master
         with:
           image-ref: "${{ env.IMAGE_NAME }}:${{ env.UNSTABLE_TAG }}"
           format: "sarif"
@@ -66,7 +66,7 @@ jobs:
           severity: "CRITICAL,HIGH"
 
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@181d5eefc20863364f96762470ba6f862bdef56b # v3.29.2
         with:
           sarif_file: 'trivy-results.sarif'
 

--- a/.github/workflows/spellcheck.yaml
+++ b/.github/workflows/spellcheck.yaml
@@ -34,6 +34,6 @@ jobs:
   pyspellcheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: igsekor/pyspelling-any@v1.0.5
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: igsekor/pyspelling-any@44278deea34ea69d8f0d5179ac409c140b0a2f5a # v1.0.5
         name: Spellcheck

--- a/.github/workflows/test-prod.yaml
+++ b/.github/workflows/test-prod.yaml
@@ -43,7 +43,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
 
@@ -75,7 +75,7 @@ jobs:
           docker compose -f docker-compose.yaml -f docker-compose.db.yaml down
 
       - name: Upload All coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24 # v5.4.3
         with:
           directory: ./artifacts/
           fail_ci_if_error: false


### PR DESCRIPTION
Pin the actions by hash so
a compromised release of
an action is not automatically
used and leaks our secrets.
This is not bulletproof, but
better than nothing.

Conversion done by stepsecurity
website:

https://app.stepsecurity.io/secureworkflow/opendatacube/datacube-ows/docpreview.yaml/develop?enable=pin&oldview=true

Also reduce the frequency of Dependabot
updates for actions to improve the chances
that someone discovers a compromised
release, and replace the sleep action
by just calling sleep in the shell.

<!-- readthedocs-preview datacube-ows start -->
----
📚 Documentation preview 📚: https://datacube-ows--1197.org.readthedocs.build/en/1197/

<!-- readthedocs-preview datacube-ows end -->