### PR TITLE
Make psycopg2 an optional dependency.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ dev_requirements = [
 
 operational_requirements = [
     "gunicorn>=22.0.0", "gunicorn[gevent]", "gevent", "prometheus_client", "sentry_sdk",
-    "prometheus_flask_exporter", "blinker", 'psycopg2',
+    "prometheus_flask_exporter", "blinker", "psycopg2",
 ]
 setup_requirements = ['setuptools_scm', 'setuptools']
 

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,6 @@ dev_requirements = [
     'types-pytz',
     'types-python-dateutil',
     'types-requests',
-    'psycopg2',
 ]
 
 operational_requirements = [

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,6 @@ install_requirements = [
     'Pillow>=10.2.0',
     'Babel',
     'Flask-Babel>3.0.0',   # New API in 3.x, bug in 3.0.0
-    'psycopg2',
     'python_dateutil',
     'pytz',
     'rasterio>=1.3.2',
@@ -47,6 +46,7 @@ test_requirements = [
     'pytest_mock',
     'pytest-helpers-namespace', 'flask-cors',
     'fsspec',
+    'psycopg2',
 ]
 
 dev_requirements = [
@@ -59,11 +59,12 @@ dev_requirements = [
     'types-pytz',
     'types-python-dateutil',
     'types-requests',
+    'psycopg2',
 ]
 
 operational_requirements = [
     "gunicorn>=22.0.0", "gunicorn[gevent]", "gevent", "prometheus_client", "sentry_sdk",
-    "prometheus_flask_exporter", "blinker"
+    "prometheus_flask_exporter", "blinker", 'psycopg2',
 ]
 setup_requirements = ['setuptools_scm', 'setuptools']
 
@@ -72,6 +73,7 @@ extras = {
     "test": test_requirements,
     "ops": operational_requirements,
     "setup": setup_requirements,
+    "postgres": ["psycopg2"],
     "all": dev_requirements + test_requirements + operational_requirements,
 }
 


### PR DESCRIPTION
Psycopg2 is needed for operational OWS use, but is not used if OWS is only used for the rendering API.  As psycopg2 is now optional in core, making it optional here means OWS can be installed for non-operational usage without psycopg2.

psycopg2 is included under the optional "extra" dependencies: dev, tests, ops or postgres.  e.g.: `pip install datacube-ows[postgres]` or  `pip install datacube-ows[ops]` WILL install psycopg2, but simply `pip install datacube-ows` will NOT.

I haven't changed the README as we already strongly recommend Docker for operational use and the Docker image installs `[ops]` which includes psycopg2.

- Fixes #1178

<!-- readthedocs-preview datacube-ows start -->
----
📚 Documentation preview 📚: https://datacube-ows--1200.org.readthedocs.build/en/1200/

<!-- readthedocs-preview datacube-ows end -->