### PR TITLE
Fix PyPI push on release automation

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Python 3.10
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
-          python-version: 3.10
+          python-version: "3.10"
       - name: Install pypa/build
         run: >-
           python -m


### PR DESCRIPTION
The last 3 releases of OWS ended up being done manually.  This should ensure 1.9.4 goes out by itself!

Python "3.10", not 3.1

<!-- readthedocs-preview datacube-ows start -->
----
📚 Documentation preview 📚: https://datacube-ows--1202.org.readthedocs.build/en/1202/

<!-- readthedocs-preview datacube-ows end -->