### PR TITLE
docs: fix docker compose name

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -109,7 +109,7 @@ setting a NEW db dump
 .. code-block:: console
 
     # bring up indexing and db container
-    docker-compose -f docker-compose.index.yaml -f docker-compose.cleandb.yaml up
+    docker compose -f docker-compose.index.yaml -f docker-compose.cleandb.yaml up
 
 
 building on top of existing db dump
@@ -117,7 +117,7 @@ building on top of existing db dump
 
 .. code-block:: console
 
-  docker-compose -f docker-compose.yaml -f docker-compose.index.yaml -f docker-compose.db.yaml up
+  docker compose -f docker-compose.yaml -f docker-compose.index.yaml -f docker-compose.db.yaml up
 
 checkpoint
 ~~~~~~~~~~
@@ -150,7 +150,7 @@ indexing and create db dump
   exit
 
   # return to index container
-  docker exec -it index_index_1 bash # if using chained docker-compose the container name is datacube-ows_index_1
+  docker exec -it index_index_1 bash # if using chained docker compose the container name is datacube-ows_index_1
   pg_dump -U localhost -p 5432 -h localhost odc > dump.sql
   # enter password on prompt: mysecretpassword or check .env file
   exit

--- a/README.rst
+++ b/README.rst
@@ -107,25 +107,25 @@ Docker-Compose
 setup env by export
 ^^^^^^^^^^^^^^^^^^^
 
-We use docker-compose to make development and testing of the containerised ows images easier.
+We use docker compose to make development and testing of the containerised ows images easier.
 
 Set up your environment by creating a `.env` file (see below).
 
 To start OWS with flask connected to a pre-existing database on your local machine::
 
-  docker-compose up
+  docker compose up
 
 The first time you run docker-compose, you will need to add the `--build` option::
 
-  docker-compose up --build
+  docker compose up --build
 
 To start ows with a pre-indexed database::
 
-  docker-compose -f docker-compose.yaml -f docker-compose.db.yaml up
+  docker compose -f docker-compose.yaml -f docker-compose.db.yaml up
 
 To start ows with db and gunicorn instead of flask (production)::
 
-  docker-compose -f docker-compose.yaml -f docker-compose.db.yaml -f docker-compose.prod.yaml up
+  docker compose -f docker-compose.yaml -f docker-compose.db.yaml -f docker-compose.prod.yaml up
 
 The default environment variables (in .env file) can be overriden by setting local environment variables::
 
@@ -133,7 +133,7 @@ The default environment variables (in .env file) can be overriden by setting loc
   # hot reload is not supported, so we need to set FLASK_DEV to production
   export PYDEV_DEBUG=yes
   export FLASK_DEV=production
-  docker-compose -f docker-compose.yaml -f docker-compose.db.yaml up --build
+  docker compose -f docker-compose.yaml -f docker-compose.db.yaml up --build
 
 setup env with .env file
 ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -142,7 +142,7 @@ setup env with .env file
 
     cp .env_simple .env # for a single ows config file setup
     cp .env_ows_root .env # for multi-file ows config with ows_root_cfg.py
-    docker-compose up
+    docker compose up
 
 Docker
 ------

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -115,7 +115,7 @@ parameters noted previously are forwarded to the docker image entrypoint.
 
 .. code-block:: console
 
-    $ docker-compose up
+    $ docker compose up
 
 Update_range via docker
 -----------------------

--- a/docs/performance.rst
+++ b/docs/performance.rst
@@ -33,13 +33,13 @@ Run pyspy
 
 Docker-Compose
 --------------
-To make the chained docker-compose with pre-indexed database: ::
+To make the chained docker compose with pre-indexed database: ::
 
-    COMPOSE_CHAIN='docker-compose -f docker-compose.yaml -f docker-compose.db.yaml -f docker-compose.pyspy.yaml'
+    COMPOSE_CHAIN='docker compose -f docker-compose.yaml -f docker-compose.db.yaml -f docker-compose.pyspy.yaml'
 
-To make the chained docker-compose with local database: ::
+To make the chained docker compose with local database: ::
 
-    COMPOSE_CHAIN='docker-compose -f docker-compose.yaml -f docker-compose.pyspy.yaml'
+    COMPOSE_CHAIN='docker compose -f docker-compose.yaml -f docker-compose.pyspy.yaml'
 
 To start ows with pre-indexed db and pyspy on the side: ::
 


### PR DESCRIPTION
The docker-compose binary is long
gone, so update references to use
the subcommand.

<!-- readthedocs-preview datacube-ows start -->
----
📚 Documentation preview 📚: https://datacube-ows--1205.org.readthedocs.build/en/1205/

<!-- readthedocs-preview datacube-ows end -->