### PR TITLE
docs: fix some warnings

### DIFF
--- a/docs/cfg_layers.rst
+++ b/docs/cfg_layers.rst
@@ -417,7 +417,7 @@ Regular Time Axis (time_axis)
 
 The time axis is how OWS publishes the dates for which data is available.  The default
 behaviour (``time_axis`` not specified or ``None``) is to use an irregular time axis, where the available dates
-(as cached in :doc:`the OWS range tables <datacube-ows-update <database>`)
+(as cached in :doc:`the OWS range tables <database>`)
 are listed individually.  These long lists of dates lead to unnecessarily large capabilities documents
 for all supported protocols.
 

--- a/docs/cfg_wms.rst
+++ b/docs/cfg_wms.rst
@@ -105,6 +105,8 @@ be kept fairly short (e.g. a few hours at most).
 
 E.g.
 
+::
+
     "wms": {
         "caps_cache_maxage": 3600,   # 3600 seconds = 1 hour
         ...

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -168,8 +168,8 @@ can be supplied in any of the following ways:
 
    The path must be fully qualified.  Relative Python imports are not supported.
 
-   .. note:: It is up to you to ensure that the Python file in question is in your Python path and
-   that all package directories have a ``__init__.py`` file, etc.
+   .. note:: It is up to you to ensure that the Python file in question is in your Python
+      path and that all package directories have a ``__init__.py`` file, etc.
 
 
 3. Include a JSON file (by absolute or relative file path):

--- a/docs/environment_variables.rst
+++ b/docs/environment_variables.rst
@@ -155,10 +155,14 @@ PYTHONPATH:
     PYTHONPATH to ows config file
 
 POSTGRES_DB:
-POSTGRES_USER:
-POSTGRES_PASSWORD:
-    The db superuser name and password for the postgis database container.
+    The database to use.
     If multiple databases are required, use a comma-separated list of database names
+
+POSTGRES_USER:
+    The db superuser name for the postgis database container.
+
+POSTGRES_PASSWORD:
+    The db superuser password for the postgis database container.
 
 POSTGRES_HOSTNAME:
     The name of the database server/container.

--- a/docs/style_howto_color_map.rst
+++ b/docs/style_howto_color_map.rst
@@ -141,7 +141,7 @@ The results look like this:
     :width: 600
 
 `View full size:
-<https://user-images.githubusercontent.com/4548530/121298369-1bb28280-c937-11eb-8f9d-bc3ab55a331e.png>`_
+<https://user-images.githubusercontent.com/4548530/121298369-1bb28280-c937-11eb-8f9d-bc3ab55a331e.png>`__
 
 This all looks a bit of a mess. The problem is that rules are evaluated in order, which can result in
 unexpected behaviour if you are not paying attention.
@@ -215,7 +215,7 @@ Let's construct a better ordering:
     :width: 600
 
 `View full size:
-<https://user-images.githubusercontent.com/4548530/121298626-895eae80-c937-11eb-9d26-32414c8eb7bc.png>`_
+<https://user-images.githubusercontent.com/4548530/121298626-895eae80-c937-11eb-9d26-32414c8eb7bc.png>`__
 
 Note the differences coming from the order in which the rules are evaluated.
 
@@ -328,7 +328,7 @@ optional and defaults to 1.0 (fully opaque).
     :width: 600
 
 `View full size:
-<https://user-images.githubusercontent.com/4548530/121300057-a72d1300-c939-11eb-9b25-add2b2701709.png>`_
+<https://user-images.githubusercontent.com/4548530/121300057-a72d1300-c939-11eb-9b25-add2b2701709.png>`__
 
 The clouds are clearly visible, with only the separately derived terrain data and the noisy water-detection
 bits visible through the cloud, with clearly defined cloud shadows and clear water detection.

--- a/docs/style_howto_color_ramp.rst
+++ b/docs/style_howto_color_ramp.rst
@@ -46,7 +46,7 @@ same as "RdYlGn" except green is the low end of the scale and red the high end.)
     :width: 600
 
 `View full size
-<https://user-images.githubusercontent.com/4548530/112426051-591d6000-8d8b-11eb-9673-c3efd4463353.png>`_
+<https://user-images.githubusercontent.com/4548530/112426051-591d6000-8d8b-11eb-9673-c3efd4463353.png>`__
 
 The green (positive) bits looks pretty good, but the zero/negative (yellow/red) bits aren't that interesting.
 
@@ -81,7 +81,7 @@ arithmetic operators like `+ - / *` and parentheses for precedence.
     :width: 600
 
 `View full size
-<https://user-images.githubusercontent.com/4548530/112567708-6e4ec900-8e35-11eb-8c75-a6a1f35ef665.png>`_
+<https://user-images.githubusercontent.com/4548530/112567708-6e4ec900-8e35-11eb-8c75-a6a1f35ef665.png>`__
 
 That's a more informative visualisation of NDVI, but the choice of colour ramp doesn't look particularly
 appropriate, in my opinion.
@@ -167,7 +167,7 @@ at the results.
     :width: 600
 
 `View full size
-<https://user-images.githubusercontent.com/4548530/113971225-b6c9a600-987b-11eb-9ba8-c046728aedee.png>`_
+<https://user-images.githubusercontent.com/4548530/113971225-b6c9a600-987b-11eb-9ba8-c046728aedee.png>`__
 
 Oh well, looks like there's nothing much interesting in that close-to-zero region.  In fact, it would be
 nice if we could get rid of those bits all together, just leave those bits transparent, to show the next
@@ -237,12 +237,12 @@ where 0.0 is totally transparent and 1.0 (the default) is opaque.  Note that you
     :width: 600
 
 `View full size
-<https://user-images.githubusercontent.com/4548530/112597171-e1ba0000-8e60-11eb-8dbc-7b983cb71af3.png>`_
+<https://user-images.githubusercontent.com/4548530/112597171-e1ba0000-8e60-11eb-8dbc-7b983cb71af3.png>`__
 
 (The image is displayed here against a white background.  When displayed on a webmap, those white pixels would
 show the next layer down on the map.  The full size view shows the image against a grey background on most
 browsers, which may help to convey the sense of transparency.)
 
 :doc:`Next up, colour-map styles
-<style_howto_color_map`
+<style_howto_color_map>`
 , which are useful for visualising discrete measurement bands.

--- a/docs/style_howto_components.rst
+++ b/docs/style_howto_components.rst
@@ -74,7 +74,7 @@ output image.
     :width: 600
 
 `View full size
-<https://user-images.githubusercontent.com/4548530/112120795-b215b880-8c12-11eb-8bfa-1033961fb1ba.png>`_
+<https://user-images.githubusercontent.com/4548530/112120795-b215b880-8c12-11eb-8bfa-1033961fb1ba.png>`__
 
 Example: Greyscale single band
 ++++++++++++++++++++++++++++++
@@ -144,7 +144,7 @@ bands to make the blue channel:
     :width: 600
 
 `View full size
-<https://user-images.githubusercontent.com/4548530/112124842-e8553700-8c16-11eb-9d60-a5a964d3a9ab.png>`_
+<https://user-images.githubusercontent.com/4548530/112124842-e8553700-8c16-11eb-9d60-a5a964d3a9ab.png>`__
 
 Example: Unused channels
 ++++++++++++++++++++++++
@@ -170,7 +170,7 @@ just leave it empty:
     :width: 600
 
 `View full size
-<https://user-images.githubusercontent.com/4548530/112239767-357aec80-8c9b-11eb-9827-6696a1d03a17.png>`_
+<https://user-images.githubusercontent.com/4548530/112239767-357aec80-8c9b-11eb-9827-6696a1d03a17.png>`__
 
 Scale Ranges: Controlling dynamic range
 ---------------------------------------
@@ -196,7 +196,7 @@ Firstly, let's remind ourselves of our original RGB configuration and image:
     :width: 600
 
 `View full size
-<https://user-images.githubusercontent.com/4548530/112110854-96f17b80-8c07-11eb-9f21-ab5ff49b9fda.png>`_
+<https://user-images.githubusercontent.com/4548530/112110854-96f17b80-8c07-11eb-9f21-ab5ff49b9fda.png>`__
 
 In this image, band values between 50 and 3000 get scaled to the image values 0 to 255.  (Values less than zero
 are clipped to 0 and values greater than 3000 are clipped to 255.)
@@ -222,7 +222,7 @@ Let's start by pulling the scale_range down a bit:
     :width: 600
 
 `View full size
-<https://user-images.githubusercontent.com/4548530/112252356-15562800-8cb1-11eb-961a-8c10c38167d7.png>`_
+<https://user-images.githubusercontent.com/4548530/112252356-15562800-8cb1-11eb-961a-8c10c38167d7.png>`__
 
 As you can see, the resulting image looks saturated, washed out and overly bright.  So if your first
 guess at scale_range values produced an image like this, you probably want to increase your
@@ -246,7 +246,7 @@ Example: High Scale Range
     :width: 600
 
 `View full size
-<https://user-images.githubusercontent.com/4548530/112252569-75e56500-8cb1-11eb-89ae-fde23ea3df58.png>`_
+<https://user-images.githubusercontent.com/4548530/112252569-75e56500-8cb1-11eb-89ae-fde23ea3df58.png>`__
 
 Whoops too far!  Now it's almost pure black!  If your image looks like this, you
 need to pull your scale_range down:
@@ -269,7 +269,7 @@ Example: Narrow Scale Range
     :width: 600
 
 `View full size
-<https://user-images.githubusercontent.com/4548530/112252764-c230a500-8cb1-11eb-873a-68527e786f69.png>`_
+<https://user-images.githubusercontent.com/4548530/112252764-c230a500-8cb1-11eb-873a-68527e786f69.png>`__
 
 This is getting better, the brightest parts are nice and bright, but the lower end of the scale range is too high,
 leaving too much image clipped to black. If you keep adjusting back and forth,
@@ -288,7 +288,7 @@ saturated, especially in the red and green channels (red+green makes yellow).
     :width: 600
 
 `View full size
-<https://user-images.githubusercontent.com/4548530/112120795-b215b880-8c12-11eb-8bfa-1033961fb1ba.png>`_
+<https://user-images.githubusercontent.com/4548530/112120795-b215b880-8c12-11eb-8bfa-1033961fb1ba.png>`__
 
 Let's see what we can do with some judicious tweaking of the scale_ranges
 on a per-band basis:
@@ -321,7 +321,7 @@ The "blue" channel does not have a custom scale_range, so it takes the default s
     :width: 600
 
 `View full size
-<https://user-images.githubusercontent.com/4548530/112267141-1f842080-8cc9-11eb-92c8-d66fba3a43ac.png>`_
+<https://user-images.githubusercontent.com/4548530/112267141-1f842080-8cc9-11eb-92c8-d66fba3a43ac.png>`__
 
 Wow! That looks much better!
 

--- a/docs/style_howto_components_nonlinear.rst
+++ b/docs/style_howto_components_nonlinear.rst
@@ -83,7 +83,7 @@ scaling, discussed later in this chapter.
     :width: 600
 
 `View full size
-<https://user-images.githubusercontent.com/4548530/112403696-00d26800-8d63-11eb-9d16-405b7b972e08.png>`_
+<https://user-images.githubusercontent.com/4548530/112403696-00d26800-8d63-11eb-9d16-405b7b972e08.png>`__
 
 Meh, it's *very* green, and kind of saturated.  This is because we are
 scaling (-1, +1) to (0, 255) and negative values of NDVI
@@ -138,7 +138,7 @@ clipped to the minimum or maximum "scale_to" value.
     :width: 600
 
 `View full size
-<https://user-images.githubusercontent.com/4548530/112408715-67a84f00-8d6c-11eb-82de-8c19b086cde2.png>`_
+<https://user-images.githubusercontent.com/4548530/112408715-67a84f00-8d6c-11eb-82de-8c19b086cde2.png>`__
 
 Non-Linear Components: OWS Function Syntax and Scalable
 -------------------------------------------------------
@@ -189,7 +189,7 @@ Note that utility functions are referenced by name, rather than importing the na
     :width: 600
 
 `View full size
-<https://user-images.githubusercontent.com/4548530/112410722-c6bb9300-8d6f-11eb-944f-ce283e922075.png>`_
+<https://user-images.githubusercontent.com/4548530/112410722-c6bb9300-8d6f-11eb-944f-ce283e922075.png>`__
 
-:doc:`Next up <style_howto_colour_ramp>`
+:doc:`Next up <style_howto_color_ramp>`
 we will look at colour ramp styles.

--- a/docs/style_howto_transparency.rst
+++ b/docs/style_howto_transparency.rst
@@ -100,7 +100,7 @@ vegetation (npv)" band mapped to blue.
     :width: 600
 
 `View full size
-<https://user-images.githubusercontent.com/4548530/113671209-66c2d600-96f9-11eb-8354-43a64ec1d134.png>`_
+<https://user-images.githubusercontent.com/4548530/113671209-66c2d600-96f9-11eb-8354-43a64ec1d134.png>`__
 
 As you can clearly see from comparing this image to the colour map examples in the last chapter,
 areas of cloud and water give false positives as npv.
@@ -142,7 +142,7 @@ keep in the image - pixels that fail any of the pq_mask rules will be transparen
     :width: 600
 
 `View full size
-<https://user-images.githubusercontent.com/4548530/113673585-89a2b980-96fc-11eb-9b73-cfb222c7c621.png>`_
+<https://user-images.githubusercontent.com/4548530/113673585-89a2b980-96fc-11eb-9b73-cfb222c7c621.png>`__
 
 Example: Enumeration masking
 &&&&&&&&&&&&&&&&&&&&&&&&&&&&
@@ -171,7 +171,7 @@ can be done using ``enum`` masking rules:
     :width: 600
 
 `View full size
-<https://user-images.githubusercontent.com/4548530/113792315-f95e8600-9788-11eb-939b-6099fe2ec5d7.png>`_
+<https://user-images.githubusercontent.com/4548530/113792315-f95e8600-9788-11eb-939b-6099fe2ec5d7.png>`__
 
 What happened here?  Remember pq_masking rules specify the values to keep, so setting enum to 1 means that we
 only keep pixels which are marked nodata in WOFS - everything else becomes transparent.
@@ -204,7 +204,7 @@ match the rule and make pixels that do transparent:
     :width: 600
 
 `View full size
-<https://user-images.githubusercontent.com/4548530/113792888-59096100-978a-11eb-9781-b266dc8f40ee.png>`_
+<https://user-images.githubusercontent.com/4548530/113792888-59096100-978a-11eb-9781-b266dc8f40ee.png>`__
 
 Example: Complex logic
 &&&&&&&&&&&&&&&&&&&&&&
@@ -256,7 +256,7 @@ when building up mask logic.
     :width: 600
 
 `View full size
-<https://user-images.githubusercontent.com/4548530/113793657-29f3ef00-978c-11eb-951a-c9c7488631de.png>`_
+<https://user-images.githubusercontent.com/4548530/113793657-29f3ef00-978c-11eb-951a-c9c7488631de.png>`__
 
 Alpha Masking in Component Styles
 +++++++++++++++++++++++++++++++++


### PR DESCRIPTION
Stop defining the same target
multiple times and add some
newlines and indentation.

<!-- readthedocs-preview datacube-ows start -->
----
📚 Documentation preview 📚: https://datacube-ows--1208.org.readthedocs.build/en/1208/

<!-- readthedocs-preview datacube-ows end -->