### PR TITLE
update_ranges_impl: import psycopg2 locally

### DIFF
--- a/datacube_ows/update_ranges_impl.py
+++ b/datacube_ows/update_ranges_impl.py
@@ -9,7 +9,6 @@
 import sys
 
 import click
-import psycopg2
 import sqlalchemy
 from datacube import Datacube
 
@@ -165,6 +164,7 @@ def main(layers: list[str],
         errors = add_ranges(cfg, layers)
         click.echo("Done.")
     except sqlalchemy.exc.ProgrammingError as e:
+        import psycopg2.errors
         if isinstance(e.orig, psycopg2.errors.UndefinedColumn):
             click.echo("ERROR: OWS schema or extent materialised views appear to be missing")
             click.echo("")


### PR DESCRIPTION
The psycopg2 package might not be
installed, so import locally instead.

This fixes the exception raised
in the documentation build.

<!-- readthedocs-preview datacube-ows start -->
----
📚 Documentation preview 📚: https://datacube-ows--1211.org.readthedocs.build/en/1211/

<!-- readthedocs-preview datacube-ows end -->