### PR TITLE
docs: unpin docutils version

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,3 @@
 click
 sphinx_click
-docutils==0.16
+docutils


### PR DESCRIPTION
There is a deprecation warning
caused by docutils being ancient
when building the docs, and there
is nothing in the commit log for
why this was pinned, so try to
unpin it.

<!-- readthedocs-preview datacube-ows start -->
----
📚 Documentation preview 📚: https://datacube-ows--1212.org.readthedocs.build/en/1212/

<!-- readthedocs-preview datacube-ows end -->