### PR TITLE
Avoid timezonefinder 6.6.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ install_requirements = [
     'pytz',
     'rasterio>=1.3.2',
     'regex',
-    'timezonefinder',
+    'timezonefinder!=6.6.0',
     'python_slugify',
     'geoalchemy2',
     'lark',


### PR DESCRIPTION
This version of the package
is broken.

<!-- readthedocs-preview datacube-ows start -->
----
📚 Documentation preview 📚: https://datacube-ows--1213.org.readthedocs.build/en/1213/

<!-- readthedocs-preview datacube-ows end -->