### PR TITLE
CI: fix attestation permissions

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -28,6 +28,7 @@ jobs:
       id-token: write   # This is required for requesting the JWT
       contents: read    # This is required for actions/checkout
       packages: write  # This is required for pushing to ghcr
+      attestations: write # This is required for pushing the attestation
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
The attestation job requires
write permissions, so add that.

<!-- readthedocs-preview datacube-ows start -->
----
📚 Documentation preview 📚: https://datacube-ows--1214.org.readthedocs.build/en/1214/

<!-- readthedocs-preview datacube-ows end -->