### PR TITLE
Enable some more Ruff rules

### DIFF
--- a/datacube_ows/band_utils.py
+++ b/datacube_ows/band_utils.py
@@ -181,8 +181,7 @@ def multi_date_delta(data, time_direction: int = -1):
 #    data1, data2 = data.values.item(0), data.values.item(1)
     if time_direction >= 0:
         return data1 - data2
-    else:
-        return data2 - data1
+    return data2 - data1
 
 def multi_date_pass(data):
     return data

--- a/datacube_ows/cfg_parser_impl.py
+++ b/datacube_ows/cfg_parser_impl.py
@@ -88,8 +88,7 @@ def check(parse_only: bool, folders: bool, styles: bool, input_file: str, output
     if not paths:
         if parse_path(None, parse_only, folders, styles, input_file, output_file):
             return 0
-        else:
-            sys.exit(1)
+        sys.exit(1)
     for path in paths:
         if not parse_path(path, parse_only, folders, styles, input_file, output_file):
             all_ok = False

--- a/datacube_ows/config_utils.py
+++ b/datacube_ows/config_utils.py
@@ -437,7 +437,7 @@ class OWSMetadataConfig(OWSConfigEntry):
         :param fld: Metadata type label
         :return: Displayable metadata.
         """
-        lookup = ".".join([lbl, fld])
+        lookup = f"{lbl}.{fld}"
         if self.global_config().internationalised:
             trans = _(lookup)
             if trans != lookup:
@@ -458,7 +458,7 @@ class OWSMetadataConfig(OWSConfigEntry):
         :param fld: Metadata type label
         :return: True if the metadata is inherited from a parent object, False otherwise.
         """
-        lookup = ".".join([lbl, fld])
+        lookup = f"{lbl}.{fld}"
         return self._inheritance_registry.get(lookup, False)
 
     def register_metadata(self, lbl: str, fld: str, val: str, inherited: bool = False) -> None:
@@ -470,7 +470,7 @@ class OWSMetadataConfig(OWSConfigEntry):
         :param val: The default value, as recorded in the raw config.
         :param inherited: If true, metadata is considered inherited and is not handled independently.
         """
-        lookup = ".".join([lbl, fld])
+        lookup = f"{lbl}.{fld}"
         self._metadata_registry[lookup] = val
         self._inheritance_registry[lookup] = inherited
 

--- a/datacube_ows/config_utils.py
+++ b/datacube_ows/config_utils.py
@@ -86,20 +86,17 @@ def cfg_expand(cfg_unexpanded: CFG_DICT,
                 if json_obj is None:
                     raise ConfigException(f"Could not find json file {raw_path}")
                 return cfg_expand(json_obj, cwd=cwd, inclusions=ninclusions)
-            elif cfg_unexpanded["type"] == "python":
+            if cfg_unexpanded["type"] == "python":
                 # Python Expansion
                 return cfg_expand(import_python_obj(raw_path), cwd=cwd, inclusions=ninclusions)
-            else:
-                raise ConfigException(f"Unsupported inclusion type: {cfg_unexpanded['type']!s}")
-        else:
-            return {
-                k: cfg_expand(cast(CFG_DICT, v), cwd=cwd, inclusions=inclusions)
-                for k, v in cfg_unexpanded.items()
-            }
-    elif isinstance(cfg_unexpanded, Sequence) and not isinstance(cfg_unexpanded, str):
+            raise ConfigException(f"Unsupported inclusion type: {cfg_unexpanded['type']!s}")
+        return {
+            k: cfg_expand(cast(CFG_DICT, v), cwd=cwd, inclusions=inclusions)
+            for k, v in cfg_unexpanded.items()
+        }
+    if isinstance(cfg_unexpanded, Sequence) and not isinstance(cfg_unexpanded, str):
         return [cfg_expand(elem, cwd=cwd, inclusions=inclusions) for elem in cfg_unexpanded]
-    else:
-        return cfg_unexpanded
+    return cfg_unexpanded
 
 
 def get_file_loc(x: str) -> str:
@@ -515,16 +512,14 @@ class OWSMetadataConfig(OWSConfigEntry):
                     FLD_ACCESS_CONSTRAINTS, FLD_CONTACT_POSITION, FLD_CONTACT_ORGANISATION,
                     FLD_UNITS):
             return self.read_local_metadata(name)
-        elif name == FLD_KEYWORDS:
+        if name == FLD_KEYWORDS:
             kw = self.read_local_metadata(FLD_KEYWORDS)
             if kw:
                 return set(kw.split(","))
-            else:
-                return set()
-        elif name == FLD_ATTRIBUTION:
+            return set()
+        if name == FLD_ATTRIBUTION:
             return self.read_local_metadata(FLD_ATTRIBUTION)
-        else:
-            return super().__getattribute__(name)
+        return super().__getattribute__(name)
 
 ###########################
 # Inheritable configuration
@@ -790,7 +785,7 @@ class FlagProductBands(OWSConfigEntry):
             raise ConfigException(f"Fuse functions for flag bands in product set {self.product_names} do not match")
         if fb.pq_ignore_time != self.ignore_time:
             raise ConfigException(f"ignore_time option for flag bands in product set {self.product_names} do not match")
-        elif fb.pq_fuse_func and not self.fuse_func:
+        if fb.pq_fuse_func and not self.fuse_func:
             self.fuse_func = fb.pq_fuse_func
         self.declare_unready("products")
         self.declare_unready("low_res_products")
@@ -887,7 +882,7 @@ class AbstractMaskRule(OWSConfigEntry):
             if "or" in flags and "and" in flags:
                 raise ConfigException(
                     f"ValueMap rule in {self.context} combines 'and' and 'or' rules")
-            elif "or" in flags:
+            if "or" in flags:
                 self.or_flags = True
                 flags = cast(FlagSpec, flags["or"])
             elif "and" in flags:

--- a/datacube_ows/data.py
+++ b/datacube_ows/data.py
@@ -66,13 +66,12 @@ def user_date_sorter(layer: OWSNamedLayer, odc_dates: list[datetime],
                 result.append(idx)
                 break
     npresult = numpy.array(result, dtype="uint8")
-    xrresult = xarray.DataArray(
+    return xarray.DataArray(
         npresult,
         coords={"time": odc_dates},
         dims=["time"],
         name="user_date_sorter"
     )
-    return xrresult
 
 
 class EmptyResponse(Exception):

--- a/datacube_ows/data.py
+++ b/datacube_ows/data.py
@@ -44,21 +44,20 @@ def user_date_sorter(layer: OWSNamedLayer, odc_dates: list[datetime],
             assert tz is not None
             norm_date = solar_date(ts, tz)
             return norm_date == user_date
-        elif time_res.is_summary():
+        if time_res.is_summary():
             norm_date = date(ts.year,
                              ts.month,
                              ts.day)
             return norm_date == user_date
-        else:
-            norm_date = datetime(ts.year,
-                                 ts.month,
-                                 ts.day,
-                                 ts.hour,
-                                 ts.minute,
-                                 ts.second,
-                                 tzinfo=ts.tzinfo)
-            user_date = default_to_utc(user_date)
-            return user_date >= norm_date and user_date < norm_date + timedelta(hours=23, minutes=59, seconds=59)
+        norm_date = datetime(ts.year,
+                             ts.month,
+                             ts.day,
+                             ts.hour,
+                             ts.minute,
+                             ts.second,
+                             tzinfo=ts.tzinfo)
+        user_date = default_to_utc(user_date)
+        return user_date >= norm_date and user_date < norm_date + timedelta(hours=23, minutes=59, seconds=59)
 
     for odc_date in odc_dates:
         for idx, user_date in enumerate(user_dates):
@@ -128,15 +127,14 @@ def get_map(args: dict[str, str]) -> FlaskResponse:
             if extent is None:
                 qprof["write_action"] = "No extent: Write Empty"
                 raise EmptyResponse()
-            else:
-                qprof["write_action"] = "Polygon"
-                qprof.start_event("write")
-                body = _write_polygon(
-                    params.geobox,
-                    extent,
-                    params.layer.resource_limits.zoom_fill,
-                    params.layer)
-                qprof.end_event("write")
+            qprof["write_action"] = "Polygon"
+            qprof.start_event("write")
+            body = _write_polygon(
+                params.geobox,
+                extent,
+                params.layer.resource_limits.zoom_fill,
+                params.layer)
+            qprof.end_event("write")
         elif n_datasets == 0:
             qprof["write_action"] = "No datasets: Write Empty"
             raise EmptyResponse()
@@ -213,8 +211,7 @@ def get_map(args: dict[str, str]) -> FlaskResponse:
 
     if params.ows_stats:
         return json_response(qprof.profile())
-    else:
-        return png_response(body, extra_headers=params.layer.resource_limits.wms_cache_rules.cache_headers(n_datasets))
+    return png_response(body, extra_headers=params.layer.resource_limits.wms_cache_rules.cache_headers(n_datasets))
 
 
 @log_call

--- a/datacube_ows/feature_info.py
+++ b/datacube_ows/feature_info.py
@@ -72,9 +72,8 @@ def get_s3_browser_uris(datasets: dict[ProductBandQuery, xarray.DataArray],
             new_uri = uri
         return new_uri
 
-    formatted = {convert(uri) for uri in unique_uris}
+    return {convert(uri) for uri in unique_uris}
 
-    return formatted
 
 
 @log_call

--- a/datacube_ows/feature_info.py
+++ b/datacube_ows/feature_info.py
@@ -313,5 +313,4 @@ def feature_info(args: dict[str, str]) -> FlaskResponse:
     }
     if params.format == "text/html":
         return html_json_response(result, cfg)
-    else:
-        return json_response(result, cfg)
+    return json_response(result, cfg)

--- a/datacube_ows/http_utils.py
+++ b/datacube_ows/http_utils.py
@@ -40,8 +40,7 @@ def parse_for_base_url(url: str) -> str:
     :return: The base URL (path and parameters stripped)
     """
     parsed = urlparse(url)
-    parsed = (parsed.netloc + parsed.path).rstrip("/")
-    return parsed
+    return (parsed.netloc + parsed.path).rstrip("/")
 
 
 def get_service_base_url(allowed_urls: list[str] | str, request_url: str) -> str:
@@ -62,8 +61,7 @@ def get_service_base_url(allowed_urls: list[str] | str, request_url: str) -> str
         idx = None
     url = allowed_urls[idx] if idx is not None else allowed_urls[0]
     # template includes tailing /, strip any trail slash here to avoid duplicates
-    url = url.rstrip("/")
-    return url
+    return url.rstrip("/")
 
 
 def capture_headers(req: Request,

--- a/datacube_ows/http_utils.py
+++ b/datacube_ows/http_utils.py
@@ -85,8 +85,7 @@ def capture_headers(req: Request,
 def cache_control_headers(max_age: int) -> dict[str, str]:
     if max_age <= 0:
         return {"cache-control": "no-cache"}
-    else:
-        return {"cache-control": f"max-age={max_age}"}
+    return {"cache-control": f"max-age={max_age}"}
 
 
 def lower_get_args() -> dict[str, str]:

--- a/datacube_ows/index/api.py
+++ b/datacube_ows/index/api.py
@@ -174,12 +174,11 @@ class OWSAbstractIndex(ABC):
                 ),
                 crs=layer.native_CRS
             )
-        elif any_geom.geom_type in ("MultiPoint", "LineString", "MultiLineString"):
+        if any_geom.geom_type in ("MultiPoint", "LineString", "MultiLineString"):
             # Not a point, but not a polygon or multipolygon?  Expand to polygon by taking convex hull
             return any_geom.convex_hull
-        else:
-            # Return polygons and multipolygons as is.
-            return any_geom
+        # Return polygons and multipolygons as is.
+        return any_geom
 
 
 class OWSAbstractIndexDriver(ABC):

--- a/datacube_ows/index/postgis/product_ranges.py
+++ b/datacube_ows/index/postgis/product_ranges.py
@@ -227,8 +227,7 @@ def sanitise_bbox(bbox: odc.geo.geom.BoundingBox) -> dict[str, float]:
     def sanitise_coordinate(coord: float, fallback: float, upper: bool) -> float:
         if not math.isfinite(coord) or (upper and coord > fallback) or (not upper and coord < fallback):
             return fallback
-        else:
-            return coord
+        return coord
     if bbox.crs == CRS("epsg:4326"):
         return {
             "top": sanitise_coordinate(bbox.top, float("90.0"), True),
@@ -236,13 +235,12 @@ def sanitise_bbox(bbox: odc.geo.geom.BoundingBox) -> dict[str, float]:
             "left": sanitise_coordinate(bbox.left, float("-180"), False),
             "right": sanitise_coordinate(bbox.right, float("9.999999999e99"), True),
         }
-    else:
-        return {
-            "top": sanitise_coordinate(bbox.top, float("9.999999999e99"), True),
-            "bottom": sanitise_coordinate(bbox.bottom, float("-9.999999999e99"), False),
-            "left": sanitise_coordinate(bbox.left, float("-9.999999999e99"), False),
-            "right": sanitise_coordinate(bbox.right, float("9.999999999e99"), True),
-        }
+    return {
+        "top": sanitise_coordinate(bbox.top, float("9.999999999e99"), True),
+        "bottom": sanitise_coordinate(bbox.bottom, float("-9.999999999e99"), False),
+        "left": sanitise_coordinate(bbox.left, float("-9.999999999e99"), False),
+        "right": sanitise_coordinate(bbox.right, float("9.999999999e99"), True),
+    }
 
 
 def get_ranges(layer: OWSNamedLayer) -> LayerExtent | None:

--- a/datacube_ows/index/postgres/api.py
+++ b/datacube_ows/index/postgres/api.py
@@ -131,8 +131,7 @@ class OWSPostgresIndex(OWSAbstractIndex):
                                                  times=times, geom=geom, products=products))
         if extent is None or crs is None or crs == extent.crs:
             return extent
-        else:
-            return extent.to_crs(crs)
+        return extent.to_crs(crs)
 
     def _run_sql(self, dc: Datacube, path: str, **params: str) -> bool:
         return run_sql(dc, self.name, path, **params)

--- a/datacube_ows/index/postgres/mv_index.py
+++ b/datacube_ows/index/postgres/mv_index.py
@@ -152,26 +152,26 @@ def mv_search(index: Index,
     with engine.connect() as conn:
         if sel == MVSelectOpts.ALL:
             return conn.execute(s)
-        elif sel == MVSelectOpts.IDS:
+        if sel == MVSelectOpts.IDS:
             return [r[0] for r in conn.execute(s)]
-        elif sel in (MVSelectOpts.COUNT, MVSelectOpts.EXTENT):
+        if sel in (MVSelectOpts.COUNT, MVSelectOpts.EXTENT):
             for r in conn.execute(s):
                 if sel == MVSelectOpts.COUNT:
                     return cast(int, r[0])
-                else:  # MVSelectOpts.EXTENT
-                    geojson = r[0]
-                    if geojson is None:
+                # MVSelectOpts.EXTENT
+                geojson = r[0]
+                if geojson is None:
+                    return None
+                uniongeom = ODCGeom(json.loads(geojson), crs="EPSG:4326")
+                if geom:
+                    intersect = uniongeom.intersection(geom)
+                    if intersect.wkt == 'POLYGON EMPTY':
                         return None
-                    uniongeom = ODCGeom(json.loads(geojson), crs="EPSG:4326")
-                    if geom:
-                        intersect = uniongeom.intersection(geom)
-                        if intersect.wkt == 'POLYGON EMPTY':
-                            return None
-                        if orig_crs and orig_crs != "EPSG:4326":
-                            intersect = intersect.to_crs(orig_crs)
-                    else:
-                        intersect = uniongeom
-                    return intersect
+                    if orig_crs and orig_crs != "EPSG:4326":
+                        intersect = intersect.to_crs(orig_crs)
+                else:
+                    intersect = uniongeom
+                return intersect
         elif sel == MVSelectOpts.DATASETS:
             ids = [r[0] for r in conn.execute(s)]
             return index.datasets.bulk_get(ids)

--- a/datacube_ows/index/postgres/product_ranges.py
+++ b/datacube_ows/index/postgres/product_ranges.py
@@ -30,13 +30,12 @@ _LOG: logging.Logger = logging.getLogger(__name__)
 def jsonise_bbox(bbox: odc.geo.geom.BoundingBox) -> dict[str, float]:
     if isinstance(bbox, dict):
         return bbox
-    else:
-        return {
-            "top": bbox.top,
-            "bottom": bbox.bottom,
-            "left": bbox.left,
-            "right": bbox.right,
-        }
+    return {
+        "top": bbox.top,
+        "bottom": bbox.bottom,
+        "left": bbox.left,
+        "right": bbox.right,
+    }
 
 
 def create_range_entry(layer: OWSNamedLayer, cache: dict[LayerSignature, list[str]]) -> None:

--- a/datacube_ows/index/sql.py
+++ b/datacube_ows/index/sql.py
@@ -98,7 +98,7 @@ def run_sql_statement(sql: str, fname: str, conn: sqlalchemy.Connection, env: da
                 f"Insufficient Privileges (user {env.db_username}). Schema altering actions should be run by a role with admin privileges"
             )
             raise AbortRun() from None
-        elif isinstance(e.orig, psycopg2.errors.DuplicateObject):
+        if isinstance(e.orig, psycopg2.errors.DuplicateObject):
             if fname.endswith('_ignore_duplicates.sql'):
                 click.echo("Ignoring 'already exists' error")
             else:

--- a/datacube_ows/loading.py
+++ b/datacube_ows/loading.py
@@ -208,8 +208,7 @@ class DataStacker:
             layer=self._layer,
             geom=geom,
             products=query.products)
-        grpd_result = datacube.Datacube.group_datasets(result, self.group_by)
-        return grpd_result
+        return datacube.Datacube.group_datasets(result, self.group_by)
 
     def datasets(self,
                  all_flag_bands: bool = False,
@@ -357,8 +356,7 @@ class DataStacker:
 
         if not time_slices:
             return None
-        result = xarray.concat(time_slices, datasets.time)
-        return result
+        return xarray.concat(time_slices, datasets.time)
 
     # Read data for given datasets and measurements per the output_geobox
     # TODO: Make skip_broken passed in via config

--- a/datacube_ows/loading.py
+++ b/datacube_ows/loading.py
@@ -284,22 +284,21 @@ class DataStacker:
                 # regularise time dimension:
                 if len(qry_result.time) > 1:
                     raise WMSException("Cannot ignore time on PQ (flag) bands from a time-aware product")
-                elif len(qry_result.time) == len(data.time):
+                if len(qry_result.time) == len(data.time):
                     qry_result["time"] = data.time
                 else:
                     if len(qry_result.time) == 0:
                         data = self.create_nodata_filled_flag_bands(data, pbq)
                         continue
-                    else:
-                        data_new_bands = {}
-                        for band in pbq.bands:
-                            band_data = qry_result[band]
-                            timeless_band_data = band_data.sel(time=qry_result.time.values[0])
-                            band_time_slices = []
-                            for _ in data.time.values:
-                                band_time_slices.append(timeless_band_data)
-                            timed_band_data = xarray.concat(band_time_slices, data.time)
-                            data_new_bands[band] = timed_band_data
+                    data_new_bands = {}
+                    for band in pbq.bands:
+                        band_data = qry_result[band]
+                        timeless_band_data = band_data.sel(time=qry_result.time.values[0])
+                        band_time_slices = []
+                        for _ in data.time.values:
+                            band_time_slices.append(timeless_band_data)
+                        timed_band_data = xarray.concat(band_time_slices, data.time)
+                        data_new_bands[band] = timed_band_data
                     data = data.assign(data_new_bands)
                     continue
             elif len(qry_result.time) == 0:

--- a/datacube_ows/ogc.py
+++ b/datacube_ows/ogc.py
@@ -109,27 +109,26 @@ def ogc_impl():
         op = nocase_args.get("request", "").upper()
         if op in WMS_REQUESTS:
             return ogc_svc_impl("wms")
-        elif op in WCS_REQUESTS:
+        if op in WCS_REQUESTS:
             return ogc_svc_impl("wcs")
-        elif op:
+        if op:
             # Should we return a WMS or WCS exception if there is no service specified?
             # Defaulting to WMS because that's what we already have.
             raise WMSException(
                 "Invalid service and/or request",
                 locator="Service and request parameters")
-        else:
-            cfg = get_config()   # pylint: disable=redefined-outer-name
-            url = nocase_args.get('Host', nocase_args['url_root'])
-            base_url = get_service_base_url(cfg.allowed_urls, url)
-            return (render_template(
-                            "index.html",
-                            cfg=cfg,
-                            supported=OWS_SUPPORTED,
-                            base_url=base_url,
-                            version=__version__,
-                    ),
-                    200,
-                    resp_headers({"Content-Type": "text/html"}))
+        cfg = get_config()   # pylint: disable=redefined-outer-name
+        url = nocase_args.get('Host', nocase_args['url_root'])
+        base_url = get_service_base_url(cfg.allowed_urls, url)
+        return (render_template(
+                        "index.html",
+                        cfg=cfg,
+                        supported=OWS_SUPPORTED,
+                        base_url=base_url,
+                        version=__version__,
+                ),
+                200,
+                resp_headers({"Content-Type": "text/html"}))
     except OGCException as e:
         _LOG.error("Handled Error: %s", repr(e.errors))
         return e.exception_response()
@@ -205,10 +204,9 @@ def ping() -> tuple[str, int, dict[str, str]]:
 
     if all(dbs_ok.values()):
         return render_template("ping.html", status="Up", statuses=dbs_ok), 200, resp_headers({"Content-Type": "text/html"})
-    elif any(dbs_ok.values()):
+    if any(dbs_ok.values()):
         return render_template("ping.html", status="Partially Up", statuses=dbs_ok), 503, resp_headers({"Content-Type": "text/html"})
-    else:
-        return render_template("ping.html", status="Down", statuses=dbs_ok), 503, resp_headers({"Content-Type": "text/html"})
+    return render_template("ping.html", status="Down", statuses=dbs_ok), 503, resp_headers({"Content-Type": "text/html"})
 
 
 @app.route("/legend/<string:layer>/<string:style>/legend.png")

--- a/datacube_ows/ogc_utils.py
+++ b/datacube_ows/ogc_utils.py
@@ -49,8 +49,7 @@ def mask_by_val(data: xarray.Dataset, band: str, val: Any = None) -> xarray.Data
     """
     if val is None:
         return data[band] != data[band].attrs['nodata']
-    else:
-        return data[band] != val
+    return data[band] != val
 
 
 def mask_by_val2(data: xarray.Dataset, band: str) -> xarray.DataArray:

--- a/datacube_ows/ows_configuration.py
+++ b/datacube_ows/ows_configuration.py
@@ -133,10 +133,9 @@ class BandIndex(OWSMetadataConfig):
         def floatify_nans(inp: float | int | str) -> float | int:
             if isinstance(inp, str) and inp == "nan":
                 return float(inp)
-            elif isinstance(inp, str):
+            if isinstance(inp, str):
                 raise ValueError("Invalid nodata value: {inp}")
-            else:
-                return inp
+            return inp
         default_to_all = not bool(self._raw_cfg)
         # pylint: disable=attribute-defined-outside-init
         self.measurements: dict[str, Measurement] = {}
@@ -240,8 +239,7 @@ class AttributionCfg(OWSConfigEntry):
     def parse(cls, cfg: CFG_DICT | None, owner: Union["OWSConfig", "OWSLayer"]) -> Optional["AttributionCfg"]:
         if not cfg:
             return None
-        else:
-            return cls(cfg, owner)
+        return cls(cfg, owner)
 
 
 class SuppURL(OWSConfigEntry):
@@ -347,8 +345,7 @@ class OWSLayer(OWSMetadataConfig):
     def can_inherit_from(self) -> Union["OWSConfig", "OWSLayer"]:
         if self.parent_layer:
             return self.parent_layer
-        else:
-            return self.global_cfg
+        return self.global_cfg
 
     @override
     def get_obj_label(self) -> str:
@@ -479,12 +476,11 @@ class TimeRes(Enum):
     def dataset_groupby(self, product_names: list[str] | None = None, is_mosaic: bool = False) -> GroupBy:
         if self.is_subday():
             return group_by_begin_datetime(product_names, truncate_dates=False)
-        elif is_mosaic:
+        if is_mosaic:
             return group_by_mosaic(product_names)
-        elif self.is_solar():
+        if self.is_solar():
             return group_by_solar(product_names)
-        else:
-            return group_by_begin_datetime(product_names)
+        return group_by_begin_datetime(product_names)
 
 DEF_TIME_LATEST = "latest"
 DEF_TIME_EARLIEST = "earliest"
@@ -527,8 +523,7 @@ class OWSNamedLayer(OWSExtensibleConfigEntry, OWSLayer):
         tr = TimeRes.parse(cast(str | None, cfg.get("time_resolution")))
         if not tr:
             raise ConfigException(f"Invalid time resolution value {cfg['time_resolution']} in named layer {self.name}")
-        else:
-            self.time_resolution: TimeRes = tr
+        self.time_resolution: TimeRes = tr
         self.mosaic_date_func: FunctionWrapper | None = None
         if "mosaic_date_func" in cfg:
             self.mosaic_date_func = FunctionWrapper(self, cast(CFG_DICT, cfg["mosaic_date_func"]))
@@ -1167,10 +1162,8 @@ def parse_ows_layer(cfg: CFG_DICT,
     if cfg.get("name", None):
         if cfg.get("multi_product", False):
             return OWSMultiProductLayer(cfg, global_cfg, parent_layer)
-        else:
-            return OWSProductLayer(cfg, global_cfg, parent_layer)
-    else:
-        return OWSFolder(cfg, global_cfg, parent_layer=parent_layer, sibling=sibling)
+        return OWSProductLayer(cfg, global_cfg, parent_layer)
+    return OWSFolder(cfg, global_cfg, parent_layer=parent_layer, sibling=sibling)
 
 
 class WCSFormat:
@@ -1232,8 +1225,7 @@ class ContactInfo(OWSConfigEntry):
             def parse(cls, cfg: dict[str, str] | None) -> Optional["Address"]:
                 if not cfg:
                     return None
-                else:
-                    return cls(cfg)
+                return cls(cfg)
 
         self.address = Address.parse(cast(dict[str, str] | None, cfg.get("address")))
         self.telephone = cast(str | None, cfg.get("telephone"))
@@ -1252,8 +1244,7 @@ class ContactInfo(OWSConfigEntry):
     def parse(cls, cfg, global_cfg) -> Optional["ContactInfo"]:
         if cfg:
             return cls(cfg, global_cfg)
-        else:
-            return None
+        return None
 
 
 class OWSConfig(OWSMetadataConfig):
@@ -1428,8 +1419,7 @@ class OWSConfig(OWSMetadataConfig):
         def make_gml_name(name: str) -> str:
             if name.startswith("EPSG:"):
                 return f"http://www.opengis.net/def/crs/EPSG/0/{name[5:]}"
-            else:
-                return name
+            return name
 
         self.published_CRSs: dict[str, CFG_DICT] = {}
         self.internal_CRSs: dict[str, CFG_DICT] = {}

--- a/datacube_ows/resource_limits.py
+++ b/datacube_ows/resource_limits.py
@@ -118,8 +118,7 @@ class RequestScale:
         for i in range(2):
             ratio = ratio * self.pixel_size[i] / other.pixel_size[i]
         ratio = ratio * self.total_band_size / other.total_band_size
-        ratio = ratio * other.res_xy() / self.res_xy()
-        return ratio
+        return ratio * other.res_xy() / self.res_xy()
 
     @property
     def load_factor(self) -> float:

--- a/datacube_ows/resource_limits.py
+++ b/datacube_ows/resource_limits.py
@@ -199,8 +199,7 @@ class CacheControlRules(OWSConfigEntry):
             rule = r
         if rule:
             return cache_control_headers(cast(int, rule['max_age']))
-        else:
-            return cache_control_headers(0)
+        return cache_control_headers(0)
 
 
 class ResourceLimited(Exception):

--- a/datacube_ows/resource_limits.py
+++ b/datacube_ows/resource_limits.py
@@ -103,7 +103,7 @@ class RequestScale:
 
     @property
     def base_zoom_level(self) -> float:
-        return math.log(559082264.0287178 / self.scale_denominator, 2)
+        return math.log2(559082264.0287178 / self.scale_denominator)
 
     @property
     def load_adjusted_zoom_level(self) -> float:

--- a/datacube_ows/startup_utils.py
+++ b/datacube_ows/startup_utils.py
@@ -179,8 +179,7 @@ def parse_config_file(log: Logger | None = None) -> OWSConfig | None:
 
 def initialise_flask(name: str) -> Flask:
     app_path = os.path.dirname(os.path.abspath(__file__))
-    app = Flask(name.split('.')[0], template_folder=os.path.join(app_path, 'templates'))
-    return app
+    return Flask(name.split('.')[0], template_folder=os.path.join(app_path, 'templates'))
 
 def pass_through(undecorated):
     def decorator(*args, **kwargs):
@@ -223,8 +222,7 @@ def proxy_fix(app, log=None):
     return app
 
 def request_extractor() -> str | None:
-    qreq = request.args.get('request')
-    return qreq
+    return request.args.get('request')
 
 def initialise_babel(cfg, app) -> object | None:
     if cfg and cfg.internationalised:
@@ -234,11 +232,10 @@ def initialise_babel(cfg, app) -> object | None:
         def get_locale():
             return request.accept_languages.best_match(cfg.locales, default=cfg.locales[0])
 
-        babel = Babel(app,
+        return Babel(app,
                       locale_selector=get_locale,
                       default_domain=cfg.message_domain,
                       configure_jinja=False
                       )
-        return babel
     else:
         return None

--- a/datacube_ows/startup_utils.py
+++ b/datacube_ows/startup_utils.py
@@ -237,5 +237,4 @@ def initialise_babel(cfg, app) -> object | None:
                       default_domain=cfg.message_domain,
                       configure_jinja=False
                       )
-    else:
-        return None
+    return None

--- a/datacube_ows/styles/base.py
+++ b/datacube_ows/styles/base.py
@@ -434,14 +434,12 @@ class StyleDefBase(OWSExtensibleConfigEntry, OWSMetadataConfig):
     def count_dates(count_or_sized_or_ds: int | Sized | xr.Dataset) -> int:
         if isinstance(count_or_sized_or_ds, int):
             return count_or_sized_or_ds
-        elif isinstance(count_or_sized_or_ds, xr.Dataset):
+        if isinstance(count_or_sized_or_ds, xr.Dataset):
             data = count_or_sized_or_ds
             if not data.time.shape:
                 return 1
-            else:
-                return len(data.coords["time"])
-        else:
-            return len(count_or_sized_or_ds)
+            return len(data.coords["time"])
+        return len(count_or_sized_or_ds)
 
     def get_legend_cfg(self, count_or_sized_or_ds: int | Sized | xr.Dataset) -> LegendBase:
         mdh = self.get_multi_date_handler(count_or_sized_or_ds)

--- a/datacube_ows/styles/base.py
+++ b/datacube_ows/styles/base.py
@@ -330,8 +330,7 @@ class StyleDefBase(OWSExtensibleConfigEntry, OWSMetadataConfig):
             :return: A DataArray boolean mask with no time dimension
             """
             pq_data = getattr(data, mask.band)
-            odc_mask = mask.create_mask(pq_data)
-            return odc_mask
+            return mask.create_mask(pq_data)
 
         result: xr.DataArray | None = extra_mask
         for mask in self.masks:
@@ -375,8 +374,7 @@ class StyleDefBase(OWSExtensibleConfigEntry, OWSMetadataConfig):
                         flat_mask &= mask_slice
                 mask = cast(xr.DataArray, flat_mask)
             alpha = alpha.where(mask, other=0)
-        img_data = img_data.assign({"alpha": alpha})
-        return img_data
+        return img_data.assign({"alpha": alpha})
 
     def transform_data(self, data: xr.Dataset, mask: xr.DataArray | None) -> xr.Dataset:
         """
@@ -395,8 +393,7 @@ class StyleDefBase(OWSExtensibleConfigEntry, OWSMetadataConfig):
             output_date_count = len(data.coords["time"])
             if output_date_count == 1:
                 img_data = img_data.squeeze(dim="time", drop=True)
-        img_data = self.apply_mask_to_image(img_data, mask, input_date_count, output_date_count)
-        return img_data
+        return self.apply_mask_to_image(img_data, mask, input_date_count, output_date_count)
 
     def transform_single_date_data(self, data: xr.Dataset) -> xr.Dataset:
         """
@@ -647,8 +644,7 @@ class StyleMask(AbstractMaskRule):
 
     @override
     def create_mask(self, data: xr.DataArray) -> xr.DataArray | None:
-        mask = super().create_mask(data)
-        return mask
+        return super().create_mask(data)
 
 # Minimum Viable Proxy Objects, for standalone API
 

--- a/datacube_ows/styles/colormap.py
+++ b/datacube_ows/styles/colormap.py
@@ -168,7 +168,7 @@ class MultiDateValueMapRule(AbstractValueMapRule):
                 or_flag: bool = False
                 if "or" in flags and "and" in flags:
                     raise ConfigException(f"MultiDateValueMap rule in {self.mdh.style.name} of layer {self.mdh.style.product.name} combines 'and' and 'or' rules")
-                elif "or" in flags:
+                if "or" in flags:
                     or_flag = True
                     sflags = cast(FlagSpec, flags["or"])
                 elif "and" in flags:
@@ -437,9 +437,8 @@ class ColorMapStyleDef(StyleDefBase):
             """
             if self.aggregator is None:
                 return apply_value_map(self.value_map, data, self.style.product.band_idx.band)
-            else:
-                agg = self.aggregator(data)
-                return apply_value_map(self.value_map, agg, self.style.product.band_idx.band)
+            agg = self.aggregator(data)
+            return apply_value_map(self.value_map, agg, self.style.product.band_idx.band)
 
         class Legend(ColorMapLegendBase):
             pass

--- a/datacube_ows/styles/colormap.py
+++ b/datacube_ows/styles/colormap.py
@@ -242,8 +242,7 @@ class MultiDateValueMapRule(AbstractValueMapRule):
 
 def convert_to_uint8(fval: float) -> int:
     scaled = int(fval * 255.0 + 0.5)
-    clipped = min(max(scaled, 0), 255)
-    return clipped
+    return min(max(scaled, 0), 255)
 
 
 def apply_value_map(value_map: MutableMapping[str, list[AbstractValueMapRule]],
@@ -378,8 +377,7 @@ class ColorMapStyleDef(StyleDefBase):
             c = numpy.full(data.shape, val)
             target[channel] = DataArray(c, dims=data.dims, coords=data.coords)
         # pyre-ignore[6]
-        masked = target.where(mask).where(numpy.isfinite(data))  # remask
-        return masked
+        return target.where(mask).where(numpy.isfinite(data))  # remask
 
     @override
     def transform_single_date_data(self, data: Dataset) -> Dataset:

--- a/datacube_ows/styles/component.py
+++ b/datacube_ows/styles/component.py
@@ -46,9 +46,8 @@ class ComponentStyleDef(StyleDefBase):
             if components is None:
                 if imgband == "alpha":
                     continue
-                else:
-                    raise ConfigException(f"No components defined for {imgband} band in style {self.name}, layer {product.name}")
-            elif callable(components) or "function" in components:
+                raise ConfigException(f"No components defined for {imgband} band in style {self.name}, layer {product.name}")
+            if callable(components) or "function" in components:
                 self.raw_rgb_components[imgband] = FunctionWrapper(self.product, cast(CFG_DICT | Callable, components),
                                                                    stand_alone=self.stand_alone)
                 if not self.stand_alone:
@@ -116,13 +115,12 @@ class ComponentStyleDef(StyleDefBase):
         """
         if self.stand_alone:
             return comp_in
-        elif comp_in is None:
+        if comp_in is None:
             return None
-        else:
-            return {
-                self.product.band_idx.band(self.local_band(band_alias)): value
-                for band_alias, value in comp_in.items() if band_alias not in ['scale_range']
-            }
+        return {
+            self.product.band_idx.band(self.local_band(band_alias)): value
+            for band_alias, value in comp_in.items() if band_alias not in ['scale_range']
+        }
 
     def compress_band(self, component_name: str, imgband_data: DataArray) -> DataArray:
         """

--- a/datacube_ows/styles/component.py
+++ b/datacube_ows/styles/component.py
@@ -173,8 +173,7 @@ class ComponentStyleDef(StyleDefBase):
                     imgband_data = self.compress_band(imgband, imgband_data)
                 imgdata[imgband] = imgband_data.astype("uint8")
 
-        image_dataset = Dataset(imgdata)
-        return image_dataset
+        return Dataset(imgdata)
 
 
 # Register ComponentStyleDef as a Style subclass.

--- a/datacube_ows/styles/ramp.py
+++ b/datacube_ows/styles/ramp.py
@@ -252,8 +252,7 @@ class ColorRamp:
         imgdata = cast(MutableMapping[Hashable, Any], {})
         for band in self.components:
             imgdata[band] = (data.dims, self.get_8bit_value(data, band))
-        imgdataset = Dataset(imgdata, coords=data.coords)
-        return imgdataset
+        return Dataset(imgdata, coords=data.coords)
 
     def rgba_at(self, val: float) -> tuple[float, float, float, float]:
         return (

--- a/datacube_ows/styles/ramp.py
+++ b/datacube_ows/styles/ramp.py
@@ -396,8 +396,7 @@ class RampLegendBase(StyleDefBase.Legend, OWSMetadataConfig):
             metaval = self.read_local_metadata(f"lbl_{tick}")
             if metaval:
                 return metaval
-            else:
-                return self.tick_labels[tick_idx]
+            return self.tick_labels[tick_idx]
         except ValueError:
             _LOG.error("'%s' is a not a valid tick", tick)
             return None
@@ -443,8 +442,7 @@ class RampLegendBase(StyleDefBase.Legend, OWSMetadataConfig):
     def display_title(self) -> str:
         if self.units:
             return f"{self.title}({self.units})"
-        else:
-            return self.title
+        return self.title
 
     def plot_name(self) -> str:
         return f"{self.style.product.name}_{self.style.name}"

--- a/datacube_ows/tile_matrix_sets.py
+++ b/datacube_ows/tile_matrix_sets.py
@@ -142,7 +142,6 @@ class TileMatrixSet(OWSConfigEntry):
             return (
                 maxs[1], mins[0], mins[1], maxs[0]
             )
-        else:
-            return (
-                mins[0], maxs[1], maxs[0], mins[1]
-            )
+        return (
+            mins[0], maxs[1], maxs[0], mins[1]
+        )

--- a/datacube_ows/utils.py
+++ b/datacube_ows/utils.py
@@ -159,10 +159,7 @@ def find_matching_date(dt, dates) -> bool:
         start, end = range_of(region[splitter])
         if dt >= start and dt < end:
             return True
-        elif dt < start:
-            region = region[0:splitter]
-        else:
-            region = region[splitter + 1:]
+        region = region[0:splitter] if dt < start else region[splitter + 1:]
 
     return False
 

--- a/datacube_ows/wcs1.py
+++ b/datacube_ows/wcs1.py
@@ -25,14 +25,13 @@ def handle_wcs1(nocase_args) -> tuple:
     operation = nocase_args.get("request", "").upper()
     if not operation:
         raise WCS1Exception("No operation specified", locator="Request parameter")
-    elif operation == "GETCAPABILITIES":
+    if operation == "GETCAPABILITIES":
         return get_capabilities(nocase_args)
-    elif operation == "DESCRIBECOVERAGE":
+    if operation == "DESCRIBECOVERAGE":
         return desc_coverages(nocase_args)
-    elif operation == "GETCOVERAGE":
+    if operation == "GETCOVERAGE":
         return get_coverage(nocase_args)
-    else:
-        raise WCS1Exception(f"Unrecognised operation: {operation}", locator="Request parameter")
+    raise WCS1Exception(f"Unrecognised operation: {operation}", locator="Request parameter")
 
 
 @log_call

--- a/datacube_ows/wcs1_utils.py
+++ b/datacube_ows/wcs1_utils.py
@@ -172,7 +172,7 @@ class WCS1GetCoverageRequest:
                     locator="TIME parameter",
                     valid_keys=[d.strftime('%Y-%m-%d') for d in self.layer.ranges.time_set]
                 )
-            elif len(self.times) > 1 and not self.format.multi_time:
+            if len(self.times) > 1 and not self.format.multi_time:
                 raise WCS1Exception(
                     f"Cannot select more than one time slice with the {self.format.name} format",
                     WCS1Exception.INVALID_PARAMETER_VALUE,

--- a/datacube_ows/wcs2.py
+++ b/datacube_ows/wcs2.py
@@ -38,14 +38,13 @@ def handle_wcs2(nocase_args) -> tuple:
     operation = nocase_args.get("request", "").upper()
     if not operation:
         raise WCS2Exception("No operation specified", locator="Request parameter")
-    elif operation == "GETCAPABILITIES":
+    if operation == "GETCAPABILITIES":
         return get_capabilities(nocase_args)
-    elif operation == "DESCRIBECOVERAGE":
+    if operation == "DESCRIBECOVERAGE":
         return desc_coverages(nocase_args)
-    elif operation == "GETCOVERAGE":
+    if operation == "GETCOVERAGE":
         return get_coverage(request.args.lists(), bool(nocase_args.get("ows_stats")), nocase_args.get("styles"))
-    else:
-        raise WCS2Exception(f"Unrecognised operation: {operation}", locator="Request parameter")
+    raise WCS2Exception(f"Unrecognised operation: {operation}", locator="Request parameter")
 
 
 @log_call

--- a/datacube_ows/wcs2.py
+++ b/datacube_ows/wcs2.py
@@ -185,7 +185,7 @@ def create_coverage_description(cfg: OWSConfig, product) -> CoverageDescription:
 
     # swap axes if necessary
     if product.native_CRS_def.get("vertical_coord_first"):
-        axes = list(reversed(axes))
+        axes.reverse()
 
     if product.regular_time_axis:
         start, end = product.time_range()

--- a/datacube_ows/wcs2_utils.py
+++ b/datacube_ows/wcs2_utils.py
@@ -171,13 +171,12 @@ def get_coverage_data(request, styles, qprof) -> tuple:
                                 WCS2Exception.INVALID_SCALE_FACTOR,
                                 locator=scale.axis
                                 )
-        else:
-            if isinstance(scale, ScaleAxis):
-                scaler.scale_axis(axis, scale.factor)
-            elif isinstance(scale, ScaleSize):
-                scaler.scale_size(axis, scale.size)
-            elif isinstance(scale, ScaleExtent):
-                scaler.scale_extent(axis, scale.low, scale.high)
+        if isinstance(scale, ScaleAxis):
+            scaler.scale_axis(axis, scale.factor)
+        elif isinstance(scale, ScaleSize):
+            scaler.scale_size(axis, scale.size)
+        elif isinstance(scale, ScaleExtent):
+            scaler.scale_extent(axis, scale.low, scale.high)
 
     #
     # Rangesubset

--- a/datacube_ows/wcs_scaler.py
+++ b/datacube_ows/wcs_scaler.py
@@ -37,24 +37,22 @@ class SpatialParameter:
     def is_x_dim(self, dimension: str) -> bool:
         if dimension == self.crs_def['horizontal_coord'].lower():
             return True
-        elif dimension == self.crs_def['vertical_coord'].lower():
+        if dimension == self.crs_def['vertical_coord'].lower():
             return False
-        elif dimension == self.layer.native_CRS_def['horizontal_coord'].lower():
+        if dimension == self.layer.native_CRS_def['horizontal_coord'].lower():
             return True
-        elif dimension == self.layer.native_CRS_def['vertical_coord'].lower():
+        if dimension == self.layer.native_CRS_def['vertical_coord'].lower():
             return False
-        elif dimension in ("x", "i", "lon", "long", "lng", "longitude"):
+        if dimension in ("x", "i", "lon", "long", "lng", "longitude"):
             return True
-        elif dimension in ("y", "j", "lat", "latitude"):
+        if dimension in ("y", "j", "lat", "latitude"):
             return False
-        else:
-            raise WCSScalerUnknownDimension(dimension)
+        raise WCSScalerUnknownDimension(dimension)
 
     def __getitem__(self, dim: str):
         if self.is_x_dim(dim):
             return self.x
-        else:
-            return self.y
+        return self.y
 
     def __setitem__(self, dim: str, val) -> None:
         if self.is_x_dim(dim):

--- a/datacube_ows/wcs_utils.py
+++ b/datacube_ows/wcs_utils.py
@@ -12,8 +12,7 @@ def get_bands_from_styles(styles, layer, version: int = 1) -> set:
     if len(styles) != 1:
         if version == 1:
             raise WCS1Exception("Multiple style parameters not supported")
-        else:
-            raise WCS2Exception("Multiple style parameters not supported")
+        raise WCS2Exception("Multiple style parameters not supported")
     style = layer.style_index.get(styles[0])
     bands = set()
     if style:

--- a/datacube_ows/wms.py
+++ b/datacube_ows/wms.py
@@ -23,17 +23,16 @@ def handle_wms(nocase_args: dict[str, str]) -> tuple | None:
     # WMS operation Map
     if not operation:
         raise WMSException("No operation specified", locator="Request parameter")
-    elif operation == "GETCAPABILITIES":
+    if operation == "GETCAPABILITIES":
         return get_capabilities(nocase_args)
-    elif operation == "GETMAP":
+    if operation == "GETMAP":
         return get_map(nocase_args)
-    elif operation == "GETFEATUREINFO":
+    if operation == "GETFEATUREINFO":
         return feature_info(nocase_args)
-    elif operation == "GETLEGENDGRAPHIC":
+    if operation == "GETLEGENDGRAPHIC":
         return legend_graphic(nocase_args)
-    else:
-        raise WMSException(f"Unrecognised operation: {operation}", WMSException.OPERATION_NOT_SUPPORTED,
-                           "Request parameter")
+    raise WMSException(f"Unrecognised operation: {operation}", WMSException.OPERATION_NOT_SUPPORTED,
+                       "Request parameter")
 
 
 @log_call

--- a/datacube_ows/wms_utils.py
+++ b/datacube_ows/wms_utils.py
@@ -197,17 +197,16 @@ def parse_time_item(item: str, layer: OWSNamedLayer) -> datetime | date:
         if matching_times:
             # default to the first matching time
             return matching_times[0]
-        elif layer.regular_time_axis:
+        if layer.regular_time_axis:
             raise WMSException(
                 f"No data available for time dimension range '{start}'-'{end}' for this layer",
                 WMSException.INVALID_DIMENSION_VALUE,
                 locator="Time parameter")
-        else:
-            raise WMSException(
-                f"Time dimension range '{start}'-'{end}' not valid for this layer",
-                WMSException.INVALID_DIMENSION_VALUE,
-                locator="Time parameter")
-    elif not times[0]:
+        raise WMSException(
+            f"Time dimension range '{start}'-'{end}' not valid for this layer",
+            WMSException.INVALID_DIMENSION_VALUE,
+            locator="Time parameter")
+    if not times[0]:
         # default to last available time if not supplied.
         product_times = get_times_for_layer(layer)
         return product_times[-1]
@@ -240,20 +239,19 @@ def parse_time_item(item: str, layer: OWSNamedLayer) -> datetime | date:
                 WMSException.INVALID_DIMENSION_VALUE,
                 locator="Time parameter")
         return day
-    elif layer.time_resolution.is_subday():
+    if layer.time_resolution.is_subday():
         if not find_matching_date(time, layer.ranges.times):
             raise WMSException(
                 f"Time dimension value '{times[0]}' not valid for this layer",
                 WMSException.INVALID_DIMENSION_VALUE,
                 locator="Time parameter")
         return time
-    else:
-        if day not in layer.ranges.time_set:
-            raise WMSException(
-                f"Time dimension value '{times[0]}' not valid for this layer",
-                WMSException.INVALID_DIMENSION_VALUE,
-                locator="Time parameter")
-        return day
+    if day not in layer.ranges.time_set:
+        raise WMSException(
+            f"Time dimension value '{times[0]}' not valid for this layer",
+            WMSException.INVALID_DIMENSION_VALUE,
+            locator="Time parameter")
+    return day
 
 
 def parse_time_delta(delta_str):
@@ -266,11 +264,10 @@ def parse_time_delta(delta_str):
 def parse_wms_time_string(t: str, start: bool = True) -> datetime | relativedelta:
     if t.upper() == 'PRESENT':
         return datetime.now(timezone.utc)
-    elif t.startswith('P'):
+    if t.startswith('P'):
         return parse_time_delta(t)
-    else:
-        default = datetime(1970, 1, 1) if start else datetime(1970, 12, 31, 23, 23, 59, 999999)  # default year ignored
-        return parse(t, default=default)
+    default = datetime(1970, 1, 1) if start else datetime(1970, 12, 31, 23, 23, 59, 999999)  # default year ignored
+    return parse(t, default=default)
 
 
 def parse_wms_time_strings(parts: list[str], with_tz: bool = False) -> tuple:

--- a/datacube_ows/wms_utils.py
+++ b/datacube_ows/wms_utils.py
@@ -96,8 +96,7 @@ def _get_geobox(args, crs: CRS) -> GeoBox:
 
 def _get_polygon(args, crs: CRS) -> geom.Geometry:
     minx, miny, maxx, maxy = _get_geobox_xy(args, crs)
-    poly = geom.polygon([(minx, maxy), (minx, miny), (maxx, miny), (maxx, maxy), (minx, maxy)], crs)
-    return poly
+    return geom.polygon([(minx, maxy), (minx, miny), (maxx, miny), (maxx, maxy), (minx, maxy)], crs)
 
 
 def zoom_factor(args, crs) -> float:
@@ -486,9 +485,8 @@ def cosine_of_solar_zenith(lat: float, lon: float, utc_dt) -> float:
     local_hour_angle_rad = math.radians(local_hour_deg_angle)
     latitude_rad = math.radians(lat)
     solar_decl_rad = declination_rad(utc_dt)
-    result = math.sin(latitude_rad) * math.sin(solar_decl_rad) \
+    return math.sin(latitude_rad) * math.sin(solar_decl_rad) \
              + math.cos(latitude_rad) * math.cos(solar_decl_rad) * math.cos(local_hour_angle_rad)
-    return result
 
 
 def solar_correct_data(data, dataset) -> float:

--- a/datacube_ows/wmts.py
+++ b/datacube_ows/wmts.py
@@ -29,15 +29,14 @@ def handle_wmts(nocase_args) -> tuple:
     # WMS operation Map
     if not operation:
         raise WMTSException("No operation specified", locator="Request parameter")
-    elif operation == "GETCAPABILITIES":
+    if operation == "GETCAPABILITIES":
         return get_capabilities(nocase_args)
-    elif operation == "GETTILE":
+    if operation == "GETTILE":
         return get_tile(nocase_args)
-    elif operation == "GETFEATUREINFO":
+    if operation == "GETFEATUREINFO":
         return get_feature_info(nocase_args)
-    else:
-        raise WMTSException(f"Unrecognised operation: {operation}", WMTSException.OPERATION_NOT_SUPPORTED,
-                           "Request parameter")
+    raise WMTSException(f"Unrecognised operation: {operation}", WMTSException.OPERATION_NOT_SUPPORTED,
+                       "Request parameter")
 
 
 @log_call

--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -61,13 +61,12 @@ def enclosed_bbox(bbox, flip: bool = False):
             lat_max - 0.45 * lat_range,
             lon_max - 0.45 * lon_range,
         )
-    else:
-        return (
-            lon_min + 0.45 * lon_range,
-            lat_min + 0.45 * lat_range,
-            lon_max - 0.45 * lon_range,
-            lat_max - 0.45 * lat_range,
-        )
+    return (
+        lon_min + 0.45 * lon_range,
+        lat_min + 0.45 * lat_range,
+        lon_max - 0.45 * lon_range,
+        lat_max - 0.45 * lat_range,
+    )
 
 
 @pytest.helpers.register
@@ -112,8 +111,7 @@ def write_role_name():
 def read_role_name(write_role_name: str):
     if read_role_name := os.environ.get("SERVER_DB_USERNAME"):
         return read_role_name
-    else:
-        return write_role_name
+    return write_role_name
 
 
 @pytest.fixture

--- a/integration_tests/utils.py
+++ b/integration_tests/utils.py
@@ -50,8 +50,7 @@ class WCS20Extent:
         if crs in ["EPSG:4326"]:
             # Vertical coordinate First
             return [("x", bbox[1], bbox[3]), ("y", bbox[0], bbox[2]), time]
-        else:
-            return [("x", bbox[0], bbox[2]), ("y", bbox[1], bbox[3]), time]
+        return [("x", bbox[0], bbox[2]), ("y", bbox[1], bbox[3]), time]
 
     def native_bbox(self) -> tuple[float, float, float, float]:
         return (
@@ -134,14 +133,13 @@ class ODCExtent:
                 if self == self.MIDDLE:
                     i = len(ls) // 2
                     return ls[i: i + 1]
-                elif self == self.FIRST_TWO:
+                if self == self.FIRST_TWO:
                     return ls[0:1]
-                elif self == self.LAST_TWO:
+                if self == self.LAST_TWO:
                     return ls[-2:]
-                elif self == self.LAST:
+                if self == self.LAST:
                     return ls[-1:]
-                else:
-                    return ls[self.value: self.value + 1]
+                return ls[self.value: self.value + 1]
             except IndexError:
                 return []
 

--- a/integration_tests/utils.py
+++ b/integration_tests/utils.py
@@ -194,8 +194,7 @@ class ODCExtent:
             if self == self.IN_FULL_BUT_OUTSIDE_OF_TIMES:
                 outside_times = full_extent.difference(time_extent)
                 outside_times = simplify_geom(outside_times)
-                sub = self.CENTRAL_SUBSET_FOR_TIMES.subset(outside_times, full_extent)
-                return sub
+                return self.CENTRAL_SUBSET_FOR_TIMES.subset(outside_times, full_extent)
 
             bbox = time_extent.boundingbox
             width = bbox.right - bbox.left

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ select = [
     "C4", # flake8-comprehensions
     "E",  # pycodestyle errors
     "EXE", # flake8-executable
+    "FLY", # flynt
     "I",  # isort
     "RUF", # Ruff-specific rules
     "SIM", # flake8-simplify

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ select = [
     "E",  # pycodestyle errors
     "EXE", # flake8-executable
     "FLY", # flynt
+    "FURB", # refurb
     "I",  # isort
     "RUF", # Ruff-specific rules
     "SIM", # flake8-simplify

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ select = [
     "FLY", # flynt
     "FURB", # refurb
     "I",  # isort
+    "RET", # flake8-ret
     "RUF", # Ruff-specific rules
     "SIM", # flake8-simplify
     "UP", # pyupgrade
@@ -45,7 +46,7 @@ ignore = [
 # Multiline string, no good place for adding a noqa.
 "integration_tests/cfg/ows_test_cfg.py" = ["RUF001"]
 # Third-party software, keep pristine.
-"licenseheaders.py" = ["B", "C", "I", "SIM", "UP"]
+"licenseheaders.py" = ["B", "C", "I", "RET", "SIM", "UP"]
 
 [tool.ruff.lint.pycodestyle]
 max-line-length = 120

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -323,14 +323,13 @@ def wcs_global_cfg():
 
 @pytest.fixture
 def dummy_raw_data():
-    output = xr.Dataset({
+    return xr.Dataset({
         "ir": dummy_da(3, "ir", coords),
         "red": dummy_da(5, "red", coords),
         "green": dummy_da(7, "green", coords),
         "blue": dummy_da(2, "blue", coords),
         "uv": dummy_da(-1, "uv", coords),
     })
-    return output
 
 
 @pytest.fixture
@@ -341,7 +340,7 @@ def null_mask():
 @pytest.fixture
 def dummy_raw_calc_data():
     dim_coords = [-2.0, -1.0, 0.0, -1.0, -2.0, -3.0]
-    output = xr.Dataset({
+    return xr.Dataset({
         "ir": dim1_da("ir", [800, 100, 1000, 600, 200, 1000], dim_coords),
         "red": dim1_da("red", [200, 500, 0, 200, 200, 700], dim_coords),
         "green": dim1_da("green", [100, 500, 0, 400, 300, 200], dim_coords),
@@ -377,7 +376,6 @@ def dummy_raw_calc_data():
                                 }
                             })
     })
-    return output
 
 
 def dim1_null_mask(coords):
@@ -443,19 +441,18 @@ flags_def = {
 @pytest.fixture
 def dummy_col_map_data():
     dim_coords = [-2.0, -1.0, 0.0, -1.0, -2.0, -3.0]
-    output = xr.Dataset({
+    return xr.Dataset({
         "pq": dim1_da("pq", [0b01000, 0b11001, 0b00010, 0b10011, 0b00100, 0b10001], dim_coords,
                       attrs={
                           "flags_definition": flags_def
                       })
     })
-    return output
 
 @pytest.fixture
 def dummy_col_map_time_data():
     dim_coords = [-2.0, -1.0, 0.0, -1.0, -2.0, -3.0]
     dates = [datetime.datetime(2000, 1, 1), datetime.datetime(2020, 1, 1)]
-    output = xr.Dataset({
+    return xr.Dataset({
         "pq": dim1_da_time("pq", [
                 [0b01000, 0b11110],
                 [0b11001, 0b10001],
@@ -469,12 +466,11 @@ def dummy_col_map_time_data():
                       "flags_definition": flags_def
                   })
     })
-    return output
 
 
 @pytest.fixture
 def dummy_raw_ls_data():
-    output = xr.Dataset({
+    return xr.Dataset({
         "red": dummy_da(5, "red", coords, dtype=np.int16),
         "green": dummy_da(7, "green", coords, dtype=np.int16),
         "blue": dummy_da(2, "blue", coords, dtype=np.int16),
@@ -482,12 +478,11 @@ def dummy_raw_ls_data():
         "swir1": dummy_da(1051, "swir1", coords, dtype=np.int16),
         "swir2": dummy_da(1051, "swir2", coords, dtype=np.int16),
     })
-    return output
 
 
 @pytest.fixture
 def dummy_raw_wo_data():
-    output = xr.Dataset({
+    return xr.Dataset({
         "water": dummy_da(0b101,
                         "red",
                         coords,
@@ -561,17 +556,15 @@ def dummy_raw_wo_data():
                                 }
                             })
     })
-    return output
 
 
 @pytest.fixture
 def dummy_raw_fc_data():
-    output = xr.Dataset({
+    return xr.Dataset({
         "bs": dummy_da(546, "bs", coords, dtype=np.int16),
         "pv": dummy_da(723, "pv", coords, dtype=np.int16),
         "npv": dummy_da(209, "npv", coords, dtype=np.int16),
     })
-    return output
 
 
 @pytest.fixture
@@ -587,8 +580,7 @@ def configs_for_landsat():
         # Calculate NDVI (-1.0 to 1.0)
         unscaled = (data["nir"] - data["red"]) / (data["nir"] + data["red"])
         # Scale to [-1.0 - 1.0] to [0 - 255]
-        scaled = ((unscaled + 1.0) * 255 / 2).clip(0, 255)
-        return scaled
+        return ((unscaled + 1.0) * 255 / 2).clip(0, 255)
 
     from datacube_ows.styles.api import scalable
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1148,7 +1148,6 @@ def xyt_dummydata():
 
 
 @pytest.fixture
-def empty_driver_cache():
+def empty_driver_cache() -> None:
     from datacube_ows.index.driver import OWSIndexDriverCache
     OWSIndexDriverCache._instance = None
-    return None

--- a/tests/test_startup.py
+++ b/tests/test_startup.py
@@ -139,8 +139,7 @@ def babel_cfg():
 
 @pytest.fixture
 def flask_app():
-    app = flask.Flask("test_flask_app")
-    return app
+    return flask.Flask("test_flask_app")
 
 def test_init_babel_on(babel_cfg, flask_app) -> None:
     from datacube_ows.startup_utils import initialise_babel

--- a/tests/test_styles.py
+++ b/tests/test_styles.py
@@ -104,7 +104,7 @@ def product_layer():
 
 @pytest.fixture
 def style_cfg_lin():
-    cfg = {
+    return {
         "name": "test_style",
         "title": "Test Style",
         "abstract": "This is a Test Style for Datacube WMS",
@@ -116,12 +116,11 @@ def style_cfg_lin():
             "blue": {"blue": 1.0}
         }
     }
-    return cfg
 
 
 @pytest.fixture
 def style_cfg_lin_clone():
-    cfg = {
+    return {
         "inherits": {
             "style": "test_style",
         },
@@ -130,12 +129,11 @@ def style_cfg_lin_clone():
         "scale_factor": None,
         "scale_range": [0, 12000],
     }
-    return cfg
 
 
 @pytest.fixture
 def style_cfg_nonlin():
-    cfg = {
+    return {
         "name": "test_style",
         "title": "Test Style",
         "abstract": "This is a Test Style for Datacube WMS",
@@ -154,12 +152,11 @@ def style_cfg_nonlin():
         },
         "additional_bands": [],
     }
-    return cfg
 
 
 @pytest.fixture
 def style_cfg_map():
-    cfg = {
+    return {
         "name": "test_style",
         "title": "Test Style",
         "abstract": "This is a Test Style for Datacube WMS",
@@ -189,7 +186,6 @@ def style_cfg_map():
             ]
         }
     }
-    return cfg
 
 
 @pytest.fixture
@@ -212,7 +208,7 @@ def product_layer_alpha_map():
 
 @pytest.fixture
 def style_cfg_map_alpha_1():
-    cfg = {
+    return {
         "name": "test_style",
         "title": "Test Style",
         "abstract": "This is a Test Style for Datacube WMS",
@@ -231,12 +227,11 @@ def style_cfg_map_alpha_1():
             ]
         }
     }
-    return cfg
 
 
 @pytest.fixture
 def style_cfg_map_alpha_2():
-    cfg = {
+    return {
         "name": "test_style",
         "title": "Test Style",
         "abstract": "This is a Test Style for Datacube WMS",
@@ -255,12 +250,11 @@ def style_cfg_map_alpha_2():
             ]
         }
     }
-    return cfg
 
 
 @pytest.fixture
 def style_cfg_map_alpha_3():
-    cfg = {
+    return {
         "name": "test_style",
         "title": "Test Style",
         "abstract": "This is a Test Style for Datacube WMS",
@@ -278,7 +272,6 @@ def style_cfg_map_alpha_3():
             ]
         }
     }
-    return cfg
 
 
 def test_valuemap_ctor() -> None:
@@ -338,7 +331,7 @@ def test_valuemap_ctor() -> None:
 
 @pytest.fixture
 def style_cfg_ramp():
-    cfg = {
+    return {
         "name": "test_style",
         "title": "Test Style",
         "abstract": "This is a Test Style for Datacube WMS",
@@ -355,23 +348,21 @@ def style_cfg_ramp():
             {"value": 1.0, "color": "#000000", "alpha": 1.0}
         ]
     }
-    return cfg
 
 
 @pytest.fixture
 def style_cfg_ramp_clone(style_cfg_ramp):
-    cfg = {
+    return {
         "inherits": style_cfg_ramp,
         "name": "test_style2",
         "title": "Test Style 2",
         "needed_bands": ["bar"],
     }
-    return cfg
 
 
 @pytest.fixture
 def style_cfg_ramp_mapped():
-    cfg = {
+    return {
         "name": "test_style",
         "title": "Test Style",
         "abstract": "This is a Test Style for Datacube WMS",
@@ -389,7 +380,6 @@ def style_cfg_ramp_mapped():
             {"value": 1.0, "color": "#000000", "alpha": 1.0}
         ]
     }
-    return cfg
 
 
 def test_correct_style_hybrid(product_layer, style_cfg_lin) -> None:
@@ -642,7 +632,7 @@ def product_layer_mask_map():
 
 @pytest.fixture
 def style_cfg_map_mask():
-    cfg = {
+    return {
         "name": "test_style",
         "title": "Test Style",
         "abstract": "This is a Test Style for Datacube WMS",
@@ -677,7 +667,6 @@ def style_cfg_map_mask():
             ]
         }
     }
-    return cfg
 
 
 def test_RGBAMapped_Masking(product_layer_mask_map, style_cfg_map_mask) -> None:
@@ -812,7 +801,7 @@ def test_bad_mpl_ramp() -> None:
 
 @pytest.fixture
 def style_with_pq_masking():
-    cfg = {
+    return {
         "name": "test_style",
         "title": "Test Style",
         "abstract": "This is a Test Style for Datacube WMS",
@@ -830,7 +819,6 @@ def style_with_pq_masking():
             }
         ]
     }
-    return cfg
 
 def test_style_with_pq_masks(product_layer, style_with_pq_masking, minimal_dc) -> None:
     def fake_make_mask(data, **kwargs):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -33,14 +33,13 @@ def dummy_da(val, name: str, coords, attrs=None, dtype=np.float64) -> xr.DataArr
     data = np.ndarray([len(a) for n, a in coords], dtype=dtype)
     coords = dict(coords)
     data.fill(val)
-    output = xr.DataArray(
+    return xr.DataArray(
         data,
         coords=coords,
         dims=dims,
         attrs=attrs,
         name=name,
     )
-    return output
 
 
 def dim1_da(name: str, vals: list, coords: list, with_time: bool = True, attrs=None) -> xr.DataArray:
@@ -59,14 +58,13 @@ def dim1_da(name: str, vals: list, coords: list, with_time: bool = True, attrs=N
         shape.append(1)
     buff_arr = np.array(vals)
     data = np.ndarray(shape, buffer=buff_arr, dtype=buff_arr.dtype)
-    output = xr.DataArray(
+    return xr.DataArray(
         data,
         coords=coords,
         dims=dims,
         attrs=attrs,
         name=name,
     )
-    return output
 
 def dim1_da_time(name: str, vals, dates, coords, attrs=None) -> xr.DataArray:
     if len(coords) != len(vals):
@@ -82,11 +80,10 @@ def dim1_da_time(name: str, vals, dates, coords, attrs=None) -> xr.DataArray:
     }
     buff_arr = np.array(vals)
     data = np.ndarray(shape, buffer=buff_arr, dtype=buff_arr.dtype)
-    output = xr.DataArray(
+    return xr.DataArray(
         data,
         coords=coords,
         dims=dims,
         attrs=attrs,
         name=name,
     )
-    return output


### PR DESCRIPTION
Enable the Flynt, Furb and RET rules.

Line-wise, the main change is removing else/elif
after return/raise, which removes some lines
of code and saves a level of indentation.

<!-- readthedocs-preview datacube-ows start -->
----
📚 Documentation preview 📚: https://datacube-ows--1215.org.readthedocs.build/en/1215/

<!-- readthedocs-preview datacube-ows end -->