### PR TITLE
Fix Ruff configuration

### DIFF
--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -11,9 +11,10 @@ pytest_plugins = ["helpers_namespace"]
 import pytest
 from click.testing import CliRunner
 from datacube.cfg import ODCConfig
+from pytest_localserver.http import WSGIServer
+
 from datacube_ows import ogc
 from datacube_ows.ogc import app
-from pytest_localserver.http import WSGIServer
 
 
 @pytest.fixture

--- a/integration_tests/test_cfg_parser.py
+++ b/integration_tests/test_cfg_parser.py
@@ -7,6 +7,7 @@
 import os
 
 import pytest
+
 from datacube_ows.cfg_parser_impl import main
 
 

--- a/integration_tests/test_mv_index.py
+++ b/integration_tests/test_mv_index.py
@@ -5,10 +5,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
+from odc.geo.geom import box
+
 from datacube_ows.index.postgres.mv_index import MVSelectOpts, mv_search
 from datacube_ows.ows_configuration import get_config
 from datacube_ows.time_utils import local_solar_date_range
-from odc.geo.geom import box
 
 
 def test_full_layer() -> None:

--- a/integration_tests/test_wcs_server.py
+++ b/integration_tests/test_wcs_server.py
@@ -8,11 +8,11 @@ from urllib import request
 
 import pytest
 import requests
-from datacube_ows.ows_configuration import OWSConfig, get_config
 from lxml import etree
 from owslib.util import ServiceException
 from owslib.wcs import WebCoverageService
 
+from datacube_ows.ows_configuration import OWSConfig, get_config
 from integration_tests.utils import ODCExtent
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,9 +107,6 @@ warn_unused_ignores = true
 [tool.pytest.ini_options]
 console_output_style = "times"
 
-[tool.ruff]
-src = ["datacube_ows", "docs", "tests", "integration_tests"]
-
 [tool.ruff.lint]
 select = [
     "A",  # Don't shadow built-ins

--- a/tests/test_band_utils.py
+++ b/tests/test_band_utils.py
@@ -11,6 +11,7 @@ from collections.abc import Sequence
 import numpy as np
 import pytest
 import xarray as xr
+
 from datacube_ows.band_utils import (
     band_quotient,
     band_quotient_sum,

--- a/tests/test_cfg_bandidx.py
+++ b/tests/test_cfg_bandidx.py
@@ -7,6 +7,7 @@
 from unittest.mock import MagicMock
 
 import pytest
+
 from datacube_ows.config_utils import ConfigException, OWSConfigNotReady
 from datacube_ows.ows_configuration import BandIndex
 

--- a/tests/test_cfg_cache_ctrl.py
+++ b/tests/test_cfg_cache_ctrl.py
@@ -7,6 +7,7 @@
 from unittest.mock import MagicMock
 
 import pytest
+
 from datacube_ows.config_utils import ConfigException
 from datacube_ows.resource_limits import CacheControlRules
 

--- a/tests/test_cfg_global.py
+++ b/tests/test_cfg_global.py
@@ -5,6 +5,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
+
 from datacube_ows.config_utils import ConfigException
 from datacube_ows.ows_configuration import ContactInfo, OWSConfig
 

--- a/tests/test_cfg_inclusion.py
+++ b/tests/test_cfg_inclusion.py
@@ -8,6 +8,7 @@ import os
 import sys
 
 import pytest
+
 from datacube_ows.config_utils import ConfigException, get_file_loc
 from datacube_ows.ows_configuration import read_config
 

--- a/tests/test_cfg_layer.py
+++ b/tests/test_cfg_layer.py
@@ -9,6 +9,7 @@ import math
 from unittest.mock import MagicMock, patch
 
 import pytest
+
 from datacube_ows.config_utils import ConfigException
 from datacube_ows.index import CoordRange, LayerExtent
 from datacube_ows.ows_configuration import OWSFolder, OWSLayer, parse_ows_layer

--- a/tests/test_cfg_metadata_types.py
+++ b/tests/test_cfg_metadata_types.py
@@ -7,6 +7,7 @@
 from unittest.mock import MagicMock
 
 import pytest
+
 from datacube_ows.config_utils import ConfigException
 from datacube_ows.ows_configuration import AttributionCfg, SuppURL
 

--- a/tests/test_cfg_tile_matrix_set.py
+++ b/tests/test_cfg_tile_matrix_set.py
@@ -7,6 +7,7 @@
 from unittest.mock import MagicMock
 
 import pytest
+
 from datacube_ows.config_utils import ConfigException
 from datacube_ows.tile_matrix_sets import TileMatrixSet
 

--- a/tests/test_cfg_wcs.py
+++ b/tests/test_cfg_wcs.py
@@ -7,6 +7,7 @@
 from unittest.mock import patch
 
 import pytest
+
 from datacube_ows.config_utils import ConfigException
 from datacube_ows.ows_configuration import WCSFormat, parse_ows_layer
 

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -7,17 +7,17 @@
 import datetime
 from unittest.mock import MagicMock
 
-import datacube_ows.data
-import datacube_ows.feature_info
 import numpy as np
 import pytest
-from datacube_ows.feature_info import get_s3_browser_uris
-from datacube_ows.loading import DataStacker, ProductBandQuery
-from datacube_ows.ogc_exceptions import WMSException
 from odc.geo.geom import polygon
 from typing_extensions import override
 from xarray import Dataset
 
+import datacube_ows.data
+import datacube_ows.feature_info
+from datacube_ows.feature_info import get_s3_browser_uris
+from datacube_ows.loading import DataStacker, ProductBandQuery
+from datacube_ows.ogc_exceptions import WMSException
 from tests.test_styles import product_layer  # noqa: F401
 
 

--- a/tests/test_legend_generator.py
+++ b/tests/test_legend_generator.py
@@ -8,11 +8,11 @@ from decimal import Decimal
 from unittest.mock import MagicMock
 
 import pytest
+
 from datacube_ows.legend_utils import get_image_from_url
 from datacube_ows.ogc_exceptions import WMSException
 from datacube_ows.styles.base import StyleDefBase
 from datacube_ows.styles.ramp import ColorRamp, ColorRampDef
-
 from tests.test_band_utils import dummy_layer  # noqa: F401
 
 

--- a/tests/test_multidate_handler.py
+++ b/tests/test_multidate_handler.py
@@ -6,6 +6,7 @@
 
 import numpy as np
 import pytest
+
 from datacube_ows.config_utils import ConfigException
 from datacube_ows.styles.base import StyleDefBase
 

--- a/tests/test_ogc_utils.py
+++ b/tests/test_ogc_utils.py
@@ -7,15 +7,15 @@
 import datetime
 from unittest.mock import MagicMock
 
-import datacube_ows.http_utils
-import datacube_ows.ogc_utils
-import datacube_ows.time_utils
-import datacube_ows.utils
 import pytest
 import xarray
 from odc.geo.geom import polygon
 from pytz import utc
 
+import datacube_ows.http_utils
+import datacube_ows.ogc_utils
+import datacube_ows.time_utils
+import datacube_ows.utils
 from tests.utils import dummy_da
 
 

--- a/tests/test_ows_configuration.py
+++ b/tests/test_ows_configuration.py
@@ -6,11 +6,11 @@
 
 from unittest.mock import MagicMock
 
+import pytest
+
 import datacube_ows.config_utils
 import datacube_ows.ogc_utils
 import datacube_ows.ows_configuration
-import pytest
-
 from tests.utils import a_function
 
 

--- a/tests/test_protocol_versions.py
+++ b/tests/test_protocol_versions.py
@@ -4,8 +4,9 @@
 # Copyright (c) 2017-2024 OWS Contributors
 # SPDX-License-Identifier: Apache-2.0
 
-import datacube_ows.protocol_versions
 import pytest
+
+import datacube_ows.protocol_versions
 
 
 class DummyException1(Exception):

--- a/tests/test_resource_limits.py
+++ b/tests/test_resource_limits.py
@@ -4,10 +4,11 @@
 # Copyright (c) 2017-2024 OWS Contributors
 # SPDX-License-Identifier: Apache-2.0
 
-import datacube_ows.resource_limits
 import pytest
-from datacube_ows.ogc_utils import create_geobox
 from odc.geo import CRS
+
+import datacube_ows.resource_limits
+from datacube_ows.ogc_utils import create_geobox
 
 
 def test_request_scale() -> None:

--- a/tests/test_style_api.py
+++ b/tests/test_style_api.py
@@ -7,6 +7,7 @@
 from decimal import Decimal
 
 import pytest
+
 from datacube_ows.config_utils import ConfigException
 from datacube_ows.styles.api import (
     StandaloneStyle,

--- a/tests/test_styles.py
+++ b/tests/test_styles.py
@@ -7,13 +7,14 @@
 import datetime
 from unittest.mock import MagicMock, patch
 
-import datacube_ows.styles
 import numpy as np
 import pytest
-from datacube_ows.config_utils import ConfigException, OWSEntryNotFound
-from datacube_ows.ows_configuration import BandIndex, OWSProductLayer
 from typing_extensions import override
 from xarray import DataArray, Dataset, concat
+
+import datacube_ows.styles
+from datacube_ows.config_utils import ConfigException, OWSEntryNotFound
+from datacube_ows.ows_configuration import BandIndex, OWSProductLayer
 
 
 @pytest.fixture
@@ -723,8 +724,9 @@ def test_reint() -> None:
 
 
 def test_createcolordata() -> None:
-    from datacube_ows.styles.colormap import ColorMapStyleDef
     from matplotlib.colors import to_rgba
+
+    from datacube_ows.styles.colormap import ColorMapStyleDef
 
     band = np.array([0, 0, 1, 1, 2, 2])
     da = DataArray(band, name='foo')
@@ -735,8 +737,9 @@ def test_createcolordata() -> None:
 
 
 def test_createcolordata_alpha() -> None:
-    from datacube_ows.styles.colormap import ColorMapStyleDef
     from matplotlib.colors import to_rgba
+
+    from datacube_ows.styles.colormap import ColorMapStyleDef
 
     band = np.array([0, 0, 1, 1, 2, 2])
     da = DataArray(band, name='foo')
@@ -747,8 +750,9 @@ def test_createcolordata_alpha() -> None:
 
 
 def test_createcolordata_mask() -> None:
-    from datacube_ows.styles.colormap import ColorMapStyleDef
     from matplotlib.colors import to_rgba
+
+    from datacube_ows.styles.colormap import ColorMapStyleDef
 
     band = np.array([0, 0, 1, 1, 2, 2])
     da = DataArray(band, name='foo')
@@ -760,8 +764,9 @@ def test_createcolordata_mask() -> None:
 
 
 def test_createcolordata_remask() -> None:
-    from datacube_ows.styles.colormap import ColorMapStyleDef
     from matplotlib.colors import to_rgba
+
+    from datacube_ows.styles.colormap import ColorMapStyleDef
 
     band = np.array([0, 0, 1, 1, np.nan, np.nan])
     da = DataArray(band, name='foo')

--- a/tests/test_time_res_method.py
+++ b/tests/test_time_res_method.py
@@ -8,6 +8,7 @@ from datetime import datetime
 
 import pytest
 import pytz
+
 from datacube_ows.ows_configuration import TimeRes
 
 

--- a/tests/test_update_ranges.py
+++ b/tests/test_update_ranges.py
@@ -9,6 +9,7 @@ https://click.palletsprojects.com/en/7.x/testing/
 """
 import pytest
 from click.testing import CliRunner
+
 from datacube_ows.index.sql import run_sql
 from datacube_ows.update_ranges_impl import main
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -46,6 +46,7 @@ def datasets_for_sorting():
 
 def test_group_by_stat(datasets_for_sorting) -> None:
     from datacube import Datacube
+
     from datacube_ows.utils import group_by_begin_datetime
 
     gby = group_by_begin_datetime()
@@ -65,6 +66,7 @@ def test_group_by_stat(datasets_for_sorting) -> None:
 
 def test_group_by_solar(datasets_for_sorting) -> None:
     from datacube import Datacube
+
     from datacube_ows.utils import group_by_solar
 
     gby = group_by_solar()
@@ -85,6 +87,7 @@ def test_group_by_solar(datasets_for_sorting) -> None:
 
 def test_group_by_mosaic(datasets_for_sorting) -> None:
     from datacube import Datacube
+
     from datacube_ows.utils import group_by_mosaic
 
     gby = group_by_mosaic()

--- a/tests/test_wcs2_utils.py
+++ b/tests/test_wcs2_utils.py
@@ -7,6 +7,7 @@
 from unittest.mock import MagicMock
 
 import pytest
+
 from datacube_ows.ogc_exceptions import WCS2Exception
 from datacube_ows.wcs2_utils import uniform_crs
 

--- a/tests/test_wcs_scaler.py
+++ b/tests/test_wcs_scaler.py
@@ -8,6 +8,7 @@ import datetime
 
 import pytest
 from affine import Affine
+
 from datacube_ows.index.api import CoordRange, LayerExtent
 from datacube_ows.ows_configuration import OWSConfig, OWSProductLayer
 from datacube_ows.wcs_scaler import (

--- a/tests/test_wms_utils.py
+++ b/tests/test_wms_utils.py
@@ -7,12 +7,13 @@
 import datetime
 from unittest.mock import MagicMock
 
-import datacube_ows.wms_utils
 import pytest
+from odc.geo import CRS
+
+import datacube_ows.wms_utils
 from datacube_ows.index import CoordRange, LayerExtent
 from datacube_ows.ogc_exceptions import WMSException
 from datacube_ows.ows_configuration import TimeRes
-from odc.geo import CRS
 
 
 def test_parse_time_delta() -> None:


### PR DESCRIPTION
The src directive configures module
name resolution, not directories
to lint.

Fixing the configuration causes
a shuffling of imports since Ruff
now correctly detects that this
package is datacube_ows.

<!-- readthedocs-preview datacube-ows start -->
----
📚 Documentation preview 📚: https://datacube-ows--1217.org.readthedocs.build/en/1217/

<!-- readthedocs-preview datacube-ows end -->