### PR TITLE
Require setuptools_scm >= 8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -149,7 +149,7 @@ ignore = [
 max-line-length = 120
 
 [build-system]
-requires = ["setuptools>=69", "setuptools_scm[toml]>3.4"]
+requires = ["setuptools>=69", "setuptools_scm[toml]>=8"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
I fixed a bunch of build issues
in Explorer about a year ago, and
I no longer remember the details,
but the outcome was to require
setuptools_scm >= 8, so do
the same in this repository.

<!-- readthedocs-preview datacube-ows start -->
----
📚 Documentation preview 📚: https://datacube-ows--1220.org.readthedocs.build/en/1220/

<!-- readthedocs-preview datacube-ows end -->