### PR TITLE
cfg_parser_impl: respect depth parameter

### DIFF
--- a/datacube_ows/cfg_parser_impl.py
+++ b/datacube_ows/cfg_parser_impl.py
@@ -382,7 +382,7 @@ def print_layers(layers: list[OWSLayer], styles: bool, depth: int) -> None:
 def print_styles(lyr: OWSNamedLayer, depth: int = 0) -> None:
     for styl in lyr.styles:
         indent(depth, for_styles=True)
-        print(f". {styl.name}")
+        click.echo(f". {styl.name}")
 
 
 def indent(depth: int, for_styles: bool = False) -> None:

--- a/datacube_ows/cfg_parser_impl.py
+++ b/datacube_ows/cfg_parser_impl.py
@@ -368,12 +368,11 @@ def layers_report(config_values: dict[str, OWSNamedLayer], input_file: str, outp
 
 def print_layers(layers: list[OWSLayer], styles: bool, depth: int) -> None:
     for lyr in layers:
+        indent(depth)
         if isinstance(lyr, OWSFolder):
-            indent(depth)
             click.echo(f"* {lyr.title}")
             click.echo(f"{lyr.child_layers} {styles} {depth + 1}")
         else:
-            indent(depth)
             click.echo(f"{lyr.name} [{','.join(lyr.product_names)}]")
             if styles:
                 click.echo(f"{lyr} {depth}")

--- a/datacube_ows/cfg_parser_impl.py
+++ b/datacube_ows/cfg_parser_impl.py
@@ -381,7 +381,7 @@ def print_layers(layers: list[OWSLayer], styles: bool, depth: int) -> None:
 
 def print_styles(lyr: OWSNamedLayer, depth: int = 0) -> None:
     for styl in lyr.styles:
-        indent(0, for_styles=True)
+        indent(depth, for_styles=True)
         print(f". {styl.name}")
 
 


### PR DESCRIPTION
There is a single caller that uses
the default value, so this should not
make a difference in practice.

Also add a couple of cleanup commits
to the PR since I'm already changing
these lines.

<!-- readthedocs-preview datacube-ows start -->
----
📚 Documentation preview 📚: https://datacube-ows--1221.org.readthedocs.build/en/1221/

<!-- readthedocs-preview datacube-ows end -->