### PR TITLE
mv_index: remove dead code

### DIFF
--- a/datacube_ows/index/postgres/mv_index.py
+++ b/datacube_ows/index/postgres/mv_index.py
@@ -116,10 +116,7 @@ def mv_search(index: Index,
         or_clauses = []
         for t in times:
             if isinstance(t, datetime.datetime):
-                st: datetime.datetime = datetime.datetime(t.year, t.month, t.day, t.hour, t.minute, t.second)
                 st = default_to_utc(t)
-                if not st.tzinfo:
-                    st = st.replace(tzinfo=pytz.utc)
                 tmax = st + datetime.timedelta(seconds=1)
                 or_clauses.append(
                     and_(

--- a/datacube_ows/ows_configuration.py
+++ b/datacube_ows/ows_configuration.py
@@ -1124,7 +1124,6 @@ class OWSMultiProductLayer(OWSNamedLayer):
 
     @override
     def parse_pq_names(self, cfg: CFG_DICT) -> dict[str, tuple | bool]:
-        main_products = False
         if "datasets" in cfg:
             raise ConfigException(f"The 'datasets' entry in the flags section is no longer supported. Please refer to the documentation for the correct format (layer {self.name})")
         if "products" in cfg:


### PR DESCRIPTION
The value of st is immediately
re-assigned, and the if-statement
will never be true immediately
after calling default_to_utc.

<!-- readthedocs-preview datacube-ows start -->
----
📚 Documentation preview 📚: https://datacube-ows--1223.org.readthedocs.build/en/1223/

<!-- readthedocs-preview datacube-ows end -->