### PR TITLE
Make methods static

### DIFF
--- a/datacube_ows/index/api.py
+++ b/datacube_ows/index/api.py
@@ -153,7 +153,8 @@ class OWSAbstractIndex(ABC):
             return ext.to_crs(crs)
         return ext
 
-    def _prep_geom(self, layer: "OWSNamedLayer", any_geom: Geometry | None) -> Geometry | None:
+    @staticmethod
+    def _prep_geom(layer: "OWSNamedLayer", any_geom: Geometry | None) -> Geometry | None:
         # Prepare a Geometry for geospatial search
         # Perhaps Core can be updated so this is not needed?
         if any_geom is None:

--- a/datacube_ows/loading.py
+++ b/datacube_ows/loading.py
@@ -236,7 +236,8 @@ class DataStacker:
             results.append((query, grpd_result))
         return OrderedDict(results)
 
-    def create_nodata_filled_flag_bands(self, data: xarray.Dataset, pbq: ProductBandQuery) -> xarray.Dataset:
+    @staticmethod
+    def create_nodata_filled_flag_bands(data: xarray.Dataset, pbq: ProductBandQuery) -> xarray.Dataset:
         var = None
         for var in data.data_vars.variables:  # noqa: B007
             break

--- a/datacube_ows/protocol_versions.py
+++ b/datacube_ows/protocol_versions.py
@@ -53,7 +53,8 @@ class SupportedSvc:
         else:
             self.default_exception_class = self.versions[0].exception_class
 
-    def _clean_version_parts(self, unclean: list[str]) -> list[int]:
+    @staticmethod
+    def _clean_version_parts(unclean: list[str]) -> list[int]:
         clean = []
         for part in unclean:
             try:


### PR DESCRIPTION
These methods do not currently use
any class data, so make them static.
The methods can be converted back
to non-static methods if/when
the need arises in the future.

<!-- readthedocs-preview datacube-ows start -->
----
📚 Documentation preview 📚: https://datacube-ows--1226.org.readthedocs.build/en/1226/

<!-- readthedocs-preview datacube-ows end -->