### PR TITLE
CI: make curl retry more

### DIFF
--- a/.github/workflows/test-prod.yaml
+++ b/.github/workflows/test-prod.yaml
@@ -63,6 +63,7 @@ jobs:
           --connect-timeout 5 \
           --max-time 10 \
           --retry 5 \
+          --retry-all-errors \
           --retry-delay 0 \
           --retry-max-time 40 \
           "localhost:8000/ping" \


### PR DESCRIPTION
Curl does not retry everything when passing `--retry`, so add the parameter that makes curl retry on all errors.

This will not make any difference when things are working as they should, but having this parameter present will prevent me from wasting time on chasing that particular red herring again.

<!-- readthedocs-preview datacube-ows start -->
----
📚 Documentation preview 📚: https://datacube-ows--1227.org.readthedocs.build/en/1227/

<!-- readthedocs-preview datacube-ows end -->