### PR TITLE
CI: shorten job timeout

### DIFF
--- a/.github/workflows/complementary-config-test.yaml
+++ b/.github/workflows/complementary-config-test.yaml
@@ -40,6 +40,7 @@ concurrency:
 
 jobs:
   dea-config:
+    timeout-minutes: 15
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -22,6 +22,7 @@ env:
 
 jobs:
   build-and-push-image:
+    timeout-minutes: 15
     runs-on: ubuntu-latest
 
     permissions:

--- a/.github/workflows/dockerfile-lint.yml
+++ b/.github/workflows/dockerfile-lint.yml
@@ -26,6 +26,7 @@ concurrency:
 
 jobs:
   dockerfile-lint:
+    timeout-minutes: 15
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/docpreview.yaml
+++ b/.github/workflows/docpreview.yaml
@@ -16,8 +16,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-
   documentation-preview:
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
       - uses: readthedocs/actions/preview@b8bba1484329bda1a3abe986df7ebc80a8950333 # v1.5

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -36,6 +36,7 @@ concurrency:
 
 jobs:
   lint:
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   build-n-publish:
+    timeout-minutes: 15
     name: Build and publish datacube-ows distributions 📦 to PyPI and TestPyPI
     runs-on: ubuntu-24.04
     if: github.event_name == 'release'

--- a/.github/workflows/pyspy-profiling.yaml
+++ b/.github/workflows/pyspy-profiling.yaml
@@ -36,6 +36,7 @@ concurrency:
 
 jobs:
   build:
+    timeout-minutes: 15
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -32,6 +32,7 @@ concurrency:
 
 jobs:
   cve-scanner:
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
       - name: Checkout git

--- a/.github/workflows/spellcheck.yaml
+++ b/.github/workflows/spellcheck.yaml
@@ -30,8 +30,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-
   pyspellcheck:
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/test-prod.yaml
+++ b/.github/workflows/test-prod.yaml
@@ -40,6 +40,7 @@ concurrency:
 
 jobs:
   prod-docker-compose-tests:
+    timeout-minutes: 15
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,6 +40,7 @@ concurrency:
 
 jobs:
   unit-integration-performance-tests:
+    timeout-minutes: 30
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
This prevents us from having to
wait for 6 hours if someone
hangs the CI machines.

<!-- readthedocs-preview datacube-ows start -->
----
📚 Documentation preview 📚: https://datacube-ows--1228.org.readthedocs.build/en/1228/

<!-- readthedocs-preview datacube-ows end -->