### PR TITLE
CI: cache docker layers

### DIFF
--- a/.github/workflows/complementary-config-test.yaml
+++ b/.github/workflows/complementary-config-test.yaml
@@ -29,8 +29,7 @@ on:
       - '.github/workflows/complementary-config-test.yaml'
 
 env:
-  ORG: opendatacube
-  IMAGE: ows
+  DOCKER_IMAGE: ghcr.io/opendatacube/ows:tests
 
 # When a PR is updated, cancel the jobs from the previous version. Merges
 # do not define head_ref, so use run_id to never cancel those jobs.
@@ -56,12 +55,18 @@ jobs:
           repository: GeoscienceAustralia/dea-config
           path: dea-config
 
-      - name: Build dev OWS image
-        run: |
-          cd ./datacube-ows
-          docker build \
-            --tag    ${ORG}/${IMAGE}:_builder \
-            .
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+
+      - name: Build Docker
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        with:
+          file: datacube-ows/Dockerfile
+          context: datacube-ows
+          tags: ${{ env.DOCKER_IMAGE }}
+          load: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - name: Config parser check
         run: |

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -22,7 +22,7 @@ on:
     - cron: '0 0 * * *'
 
 env:
-  IMAGE_NAME: opendatacube/ows
+  IMAGE_NAME: ghcr.io/opendatacube/ows
 
 # When a PR is updated, cancel the jobs from the previous version. Merges
 # do not define head_ref, so use run_id to never cancel those jobs.
@@ -34,30 +34,33 @@ jobs:
   cve-scanner:
     timeout-minutes: 15
     runs-on: ubuntu-latest
+    if: github.event_name != 'release'
     steps:
       - name: Checkout git
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
 
-      - name: Get unstable git tag
-        run: >
-          echo "UNSTABLE_TAG=$(git describe --tags)" >> $GITHUB_ENV
+      - name: Get and log unstable git tag
+        run: |
+          set -ex
+          UNSTABLE_TAG=$(git describe --tags)
+          echo "UNSTABLE_TAG=$UNSTABLE_TAG" >> $GITHUB_ENV
 
-      - name: Log the unstable tag
-        run: echo $UNSTABLE_TAG
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
 
-      - name: Build unstable + latest Docker image tag
-        if: github.event_name != 'release'
-        uses: whoan/docker-build-with-cache-action@d8d3ad518e7ac382b880720d0751815e656fe032 # v8.1.0
+      - name: Build Docker
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         with:
-          image_name: ${{ env.IMAGE_NAME }}
-          image_tag: ${{ env.UNSTABLE_TAG }},latest
-          build_extra_args: "--build-arg=ENVIRONMENT=deployment"
-          push_image_and_stages: false
+          file: Dockerfile
+          context: .
+          tags: ${{ env.IMAGE_NAME }}:${{ env.UNSTABLE_TAG }}
+          load: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - name: Run vulnerability scanner
-        if: github.event_name != 'release'
         uses: aquasecurity/trivy-action@dc5a429b52fcf669ce959baa2c2dd26090d2a6c4 # 0.32.0
         with:
           image-ref: "${{ env.IMAGE_NAME }}:${{ env.UNSTABLE_TAG }}"

--- a/.github/workflows/test-prod.yaml
+++ b/.github/workflows/test-prod.yaml
@@ -29,8 +29,7 @@ on:
       - '.github/workflows/test-prod.yaml'
 
 env:
-  ORG: opendatacube
-  IMAGE: ows
+  DOCKER_IMAGE: ghcr.io/opendatacube/ows:tests
 
 # When a PR is updated, cancel the jobs from the previous version. Merges
 # do not define head_ref, so use run_id to never cancel those jobs.
@@ -48,12 +47,25 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Build and run prod OWS image
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+
+      - name: Build Docker
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        with:
+          file: Dockerfile
+          context: .
+          tags: ${{ env.DOCKER_IMAGE }}
+          load: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Run prod OWS image
         run: |
           export LOCAL_UID=$(id -u $USER)
           export LOCAL_GID=$(id -g $USER)
           export $(grep -v '^#' .env_simple | xargs)
-          docker compose -f docker-compose.yaml -f docker-compose.db.yaml -f docker-compose.prod.yaml up --quiet-pull --build -d --wait
+          docker compose -f docker-compose.yaml -f docker-compose.db.yaml -f docker-compose.prod.yaml up --quiet-pull -d --wait
           docker compose -f docker-compose.yaml -f docker-compose.db.yaml exec -T ows /bin/sh -c "cd /src && ./check-code-all.sh --no-test"
 
       # Run some tests on the images

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,8 +29,7 @@ on:
       - '.github/workflows/test.yml'
 
 env:
-  ORG: opendatacube
-  IMAGE: ows
+  DOCKER_IMAGE: ghcr.io/opendatacube/ows:tests
 
 # When a PR is updated, cancel the jobs from the previous version. Merges
 # do not define head_ref, so use run_id to never cancel those jobs.
@@ -48,22 +47,25 @@ jobs:
         with:
           fetch-depth: 0
 
-      # We build the stage 1 image, then run test on it
-      # These tests require extra files we don't want in
-      # the production image
-      # We build the stage 1 image, then run test on it
-      # These tests require extra files we don't want in
-      # the production image
-      - name: Build dev OWS image
-        run: |
-          docker build --build-arg ENVIRONMENT=test \
-            --tag    ${ORG}/${IMAGE}:_builder \
-            .
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+
+      - name: Build Docker
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        with:
+          file: Dockerfile
+          context: .
+          build-args: |
+            ENVIRONMENT=test
+          tags: ${{ env.DOCKER_IMAGE }}
+          load: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - name: Test and lint dev OWS image
         run: |
           mkdir artifacts
-          docker run -e LOCAL_UID=$(id -u $USER) -e LOCAL_GID=$(id -g $USER) -v ./:/src -v ${PWD}/artifacts:/mnt/artifacts ${ORG}/${IMAGE}:_builder /bin/sh -c "cd /src && ./check-code.sh"
+          docker run -e LOCAL_UID=$(id -u $USER) -e LOCAL_GID=$(id -g $USER) -v ./:/src -v ${PWD}/artifacts:/mnt/artifacts ${{ env.DOCKER_IMAGE }} /bin/sh -c "cd /src && ./check-code.sh"
           mv ./artifacts/coverage.xml ./artifacts/coverage-unit.xml
 
       - name: Dockerized Integration Pytest
@@ -71,7 +73,7 @@ jobs:
           export LOCAL_UID=$(id -u $USER)
           export LOCAL_GID=$(id -g $USER)
           export $(grep -v '^#' .env_simple | xargs)
-          docker compose -f docker-compose.yaml -f docker-compose.db.yaml up --quiet-pull -d --wait --build
+          docker compose -f docker-compose.yaml -f docker-compose.db.yaml up --quiet-pull -d --wait
           docker compose -f docker-compose.yaml -f docker-compose.db.yaml exec -T ows /bin/sh -c "cd /src && ./check-code-all.sh"
           docker compose -f docker-compose.yaml -f docker-compose.db.yaml down
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,9 +6,7 @@ services:
       args:
         PYDEV_DEBUG: "${PYDEV_DEBUG}"
         ENVIRONMENT: test
-      cache_from:
-        - opendatacube/ows:_builder
-    image: opendatacube/ows:latest
+    image: ghcr.io/opendatacube/ows:tests
     # Uncomment for use with non-dockerised postgres (for docker-compose 1.x)
     # network_mode: host
     environment:


### PR DESCRIPTION
Switch to the same image build setup as used by datacube-core to speed up image
building.

The release build workflow is untouched so it will avoid any problems caused by
cache pollution.

<!-- readthedocs-preview datacube-ows start -->
----
📚 Documentation preview 📚: https://datacube-ows--1234.org.readthedocs.build/en/1234/

<!-- readthedocs-preview datacube-ows end -->
