### PR TITLE
pre-commit: update ruff hook name

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,10 +15,6 @@ repos:
     hooks:
     # Ensure uv.lock is up-to-date if pyproject.toml has changed.
     -   id: uv-lock
-# -   repo: https://github.com/PyCQA/bandit
-#     rev: 1.7.4
-#     hooks:
-#     -   id: bandit
 -   repo: https://github.com/PyCQA/pylint
     rev: v3.3.7
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
 -   repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.12.5
     hooks:
-    -   id: ruff
+    -   id: ruff-check
         args: [--fix, --show-fixes, --output-format, grouped]
 -   repo: https://github.com/astral-sh/uv-pre-commit
     rev: 0.8.3


### PR DESCRIPTION
The new name is ruff-check, so use
that.

Also remove the commented out bandit
lines that have been there since 2022.

<!-- readthedocs-preview datacube-ows start -->
----
📚 Documentation preview 📚: https://datacube-ows--1247.org.readthedocs.build/en/1247/

<!-- readthedocs-preview datacube-ows end -->