### PR TITLE
CI: use OIDC for CodeCov

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,8 @@ jobs:
   unit-integration-performance-tests:
     timeout-minutes: 30
     runs-on: ubuntu-latest
-
+    permissions:
+      id-token: write
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
@@ -84,5 +85,4 @@ jobs:
         with:
           directory: ./artifacts/
           fail_ci_if_error: false
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+          use_oidc: true


### PR DESCRIPTION
This uses a short-lived token
which is better for security.

<!-- readthedocs-preview datacube-ows start -->
----
📚 Documentation preview 📚: https://datacube-ows--1250.org.readthedocs.build/en/1250/

<!-- readthedocs-preview datacube-ows end -->