### PR TITLE
CI: fixate time stamp for image layers (towards reproducible docker builds)

### DIFF
--- a/.github/workflows/complementary-config-test.yaml
+++ b/.github/workflows/complementary-config-test.yaml
@@ -60,6 +60,11 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
 
+      - name: Get Git commit timestamps
+        run: |
+          TIMESTAMP=$(cd datacube-ows && git log -1 --pretty=%ct pyproject.toml uv.lock datacube_ows)
+          echo "TIMESTAMP=$TIMESTAMP" >> $GITHUB_ENV
+
       - name: Build Docker
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         with:
@@ -69,6 +74,8 @@ jobs:
           load: true
           cache-from: type=gha
           cache-to: type=gha,mode=max
+        env:
+          SOURCE_DATE_EPOCH: ${{ env.TIMESTAMP }}
 
       - name: Config parser check
         run: |

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -51,6 +51,11 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
+      - name: Get Git commit timestamps
+        run: |
+          TIMESTAMP=$(git log -1 --pretty=%ct pyproject.toml uv.lock datacube_ows)
+          echo "TIMESTAMP=$TIMESTAMP" >> $GITHUB_ENV
+
       - name: Build and push Docker image
         id: push
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
@@ -59,6 +64,8 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+        env:
+          SOURCE_DATE_EPOCH: ${{ env.TIMESTAMP }}
 
       - name: Attest Docker image
         uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2.4.0

--- a/.github/workflows/pyspy-profiling.yaml
+++ b/.github/workflows/pyspy-profiling.yaml
@@ -53,6 +53,11 @@ jobs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
 
+    - name: Get Git commit timestamps
+      run: |
+        TIMESTAMP=$(git log -1 --pretty=%ct pyproject.toml uv.lock datacube_ows)
+        echo "TIMESTAMP=$TIMESTAMP" >> $GITHUB_ENV
+
     - name: Build Docker
       uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
       with:
@@ -62,6 +67,8 @@ jobs:
         load: true
         cache-from: type=gha
         cache-to: type=gha,mode=max
+      env:
+        SOURCE_DATE_EPOCH: ${{ env.TIMESTAMP }}
 
     # Run performance profiling
     - name: setup performance profiling with py-spy (stage 1 - run profiling containers)

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -54,6 +54,11 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
 
+      - name: Get Git commit timestamps
+        run: |
+          TIMESTAMP=$(git log -1 --pretty=%ct pyproject.toml uv.lock datacube_ows)
+          echo "TIMESTAMP=$TIMESTAMP" >> $GITHUB_ENV
+
       - name: Build Docker
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         with:
@@ -63,6 +68,8 @@ jobs:
           load: true
           cache-from: type=gha
           cache-to: type=gha,mode=max
+        env:
+          SOURCE_DATE_EPOCH: ${{ env.TIMESTAMP }}
 
       - name: Run vulnerability scanner
         uses: aquasecurity/trivy-action@dc5a429b52fcf669ce959baa2c2dd26090d2a6c4 # 0.32.0

--- a/.github/workflows/test-prod.yaml
+++ b/.github/workflows/test-prod.yaml
@@ -52,6 +52,11 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
 
+      - name: Get Git commit timestamps
+        run: |
+          TIMESTAMP=$(git log -1 --pretty=%ct pyproject.toml uv.lock datacube_ows)
+          echo "TIMESTAMP=$TIMESTAMP" >> $GITHUB_ENV
+
       - name: Build Docker
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         with:
@@ -61,6 +66,8 @@ jobs:
           load: true
           cache-from: type=gha
           cache-to: type=gha,mode=max
+        env:
+          SOURCE_DATE_EPOCH: ${{ env.TIMESTAMP }}
 
       - name: Run prod OWS image
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,6 +53,11 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
 
+      - name: Get Git commit timestamps
+        run: |
+          TIMESTAMP=$(git log -1 --pretty=%ct pyproject.toml uv.lock datacube_ows)
+          echo "TIMESTAMP=$TIMESTAMP" >> $GITHUB_ENV
+
       - name: Build Docker
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         with:
@@ -64,6 +69,8 @@ jobs:
           load: true
           cache-from: type=gha
           cache-to: type=gha,mode=max
+        env:
+          SOURCE_DATE_EPOCH: ${{ env.TIMESTAMP }}
 
       - name: Test and lint dev OWS image
         run: |


### PR DESCRIPTION
Set the timestamp of the layers in
the Docker image according to:

https://docs.docker.com/build/ci/github-actions/reproducible-builds/

We improve on that solution by
just getting the time of the last
commit for the package-related
files, so timestamps change
less often.

<!-- readthedocs-preview datacube-ows start -->
----
📚 Documentation preview 📚: https://datacube-ows--1253.org.readthedocs.build/en/1253/

<!-- readthedocs-preview datacube-ows end -->