### PR TITLE
Remove pytz

### DIFF
--- a/datacube_ows/index/postgres/mv_index.py
+++ b/datacube_ows/index/postgres/mv_index.py
@@ -12,7 +12,6 @@ from types import UnionType
 from typing import cast
 from uuid import UUID as UUID_
 
-import pytz
 from datacube.index import Index
 from datacube.model import Dataset, Product
 from geoalchemy2 import Geometry
@@ -125,7 +124,7 @@ def mv_search(index: Index,
                     )
                 )
             elif isinstance(t, datetime.date):
-                st = datetime.datetime(t.year, t.month, t.day, tzinfo=pytz.utc)
+                st = datetime.datetime(t.year, t.month, t.day, tzinfo=datetime.timezone.utc)
                 tmax = st + datetime.timedelta(days=1)
                 or_clauses.append(
                     and_(

--- a/datacube_ows/time_utils.py
+++ b/datacube_ows/time_utils.py
@@ -6,12 +6,13 @@
 
 import datetime
 import logging
+from datetime import timezone
+from zoneinfo import ZoneInfo
 
 from datacube.model import Dataset
 from dateutil.parser import parse
 from odc.geo import CRS, Geometry
 from odc.geo.geobox import GeoBox
-from pytz import timezone, utc
 from timezonefinder import TimezoneFinder
 
 from datacube_ows.config_utils import OWSExtensibleConfigEntry
@@ -100,7 +101,7 @@ def tz_for_coord(lon: float | int, lat: float | int) -> datetime.tzinfo:
         raise
     if not tzn:
         raise NoTimezoneException("tz find failed.")
-    return timezone(tzn)
+    return ZoneInfo(tzn)
 
 
 def local_solar_date_range(geobox: GeoBox, date: datetime.date) -> tuple[datetime.datetime, datetime.datetime]:
@@ -114,7 +115,7 @@ def local_solar_date_range(geobox: GeoBox, date: datetime.date) -> tuple[datetim
     tz: datetime.tzinfo = tz_for_geometry(geobox.extent)
     start = datetime.datetime(date.year, date.month, date.day, 0, 0, 0, tzinfo=tz)
     end = datetime.datetime(date.year, date.month, date.day, 23, 59, 59, tzinfo=tz)
-    return start.astimezone(utc), end.astimezone(utc)
+    return start.astimezone(timezone.utc), end.astimezone(timezone.utc)
 
 
 def month_date_range(date: datetime.date) -> tuple[datetime.datetime, datetime.datetime]:
@@ -126,13 +127,13 @@ def month_date_range(date: datetime.date) -> tuple[datetime.datetime, datetime.d
     :param date: A date or datetime object to take the month and year from
     :return: A tuple of two UTC datetime objects, delimiting an entire calendar month.
     """
-    start = datetime.datetime(date.year, date.month, 1, 0, 0, 0, tzinfo=utc)
+    start = datetime.datetime(date.year, date.month, 1, 0, 0, 0, tzinfo=timezone.utc)
     y: int = date.year
     m: int = date.month + 1
     if m == 13:
         m = 1
         y = y + 1
-    end = datetime.datetime(y, m, 1, 0, 0, 0, tzinfo=utc) - datetime.timedelta(days=1)
+    end = datetime.datetime(y, m, 1, 0, 0, 0, tzinfo=timezone.utc) - datetime.timedelta(days=1)
     return start, end
 
 
@@ -145,8 +146,8 @@ def year_date_range(date: datetime.date) -> tuple[datetime.datetime, datetime.da
     :param date: A date or datetime object to take the year from
     :return: A tuple of two UTC datetime objects, delimiting an entire calendar year.
     """
-    start = datetime.datetime(date.year, 1, 1, 0, 0, 0, tzinfo=utc)
-    end = datetime.datetime(date.year, 12, 31, 23, 59, 59, tzinfo=utc)
+    start = datetime.datetime(date.year, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+    end = datetime.datetime(date.year, 12, 31, 23, 59, 59, tzinfo=timezone.utc)
     return start, end
 
 
@@ -159,8 +160,8 @@ def day_summary_date_range(date: datetime.date) -> tuple[datetime.datetime, date
     :param date: A date or datetime object to take the day, month and year from
     :return: A tuple of two UTC datetime objects, delimiting a calendar day.
     """
-    start = datetime.datetime(date.year, date.month, date.day, 0, 0, 0, tzinfo=utc)
-    end = datetime.datetime(date.year, date.month, date.day, 23, 59, 59, tzinfo=utc)
+    start = datetime.datetime(date.year, date.month, date.day, 0, 0, 0, tzinfo=timezone.utc)
+    end = datetime.datetime(date.year, date.month, date.day, 23, 59, 59, tzinfo=timezone.utc)
     return start, end
 
 

--- a/datacube_ows/utils.py
+++ b/datacube_ows/utils.py
@@ -7,11 +7,11 @@
 import datetime
 import logging
 from collections.abc import Callable
+from datetime import timezone
 from functools import wraps
 from time import monotonic
 from typing import Any, TypeVar, cast
 
-import pytz
 from datacube import Datacube
 from datacube.api.query import GroupBy, solar_day
 from datacube.model import Dataset
@@ -166,5 +166,5 @@ def find_matching_date(dt, dates) -> bool:
 
 def default_to_utc(dt: datetime.datetime) -> datetime.datetime:
     if not dt.tzinfo:
-        dt = dt.replace(tzinfo=pytz.utc)
+        dt = dt.replace(tzinfo=timezone.utc)
     return dt

--- a/datacube_ows/wcs1_utils.py
+++ b/datacube_ows/wcs1_utils.py
@@ -4,8 +4,9 @@
 # Copyright (c) 2017-2024 OWS Contributors
 # SPDX-License-Identifier: Apache-2.0
 
+from datetime import timezone
+
 import numpy
-import pytz
 import xarray
 import xarray as xr
 from affine import Affine
@@ -347,7 +348,7 @@ def get_coverage_data(req, qprof) -> tuple | tuple[int, tuple]:
         )
         if req.layer.time_resolution.is_subday():
             timevals = [
-                numpy.datetime64(dt.astimezone(pytz.utc).isoformat(), "ns")
+                numpy.datetime64(dt.astimezone(timezone.utc).isoformat(), "ns")
                 for dt in req.times
             ]
         else:

--- a/datacube_ows/wms_utils.py
+++ b/datacube_ows/wms_utils.py
@@ -16,7 +16,6 @@ from matplotlib import pyplot as plt
 from odc.geo import geom
 from odc.geo.crs import CRS
 from odc.geo.geobox import GeoBox
-from pytz import utc
 from rasterio.warp import Resampling
 from typing_extensions import override
 
@@ -467,7 +466,7 @@ class GetFeatureInfoParameters(GetParameters):
 def declination_rad(dt) -> float:
     # Estimate solar declination from a datetime.  (value returned in radians).
     # Formula taken from https://en.wikipedia.org/wiki/Position_of_the_Sun#Declination_of_the_Sun_as_seen_from_Earth
-    timedel = dt - datetime(dt.year, 1, 1, 0, 0, 0, tzinfo=utc)
+    timedel = dt - datetime(dt.year, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
     day_count = timedel.days + timedel.seconds / (60.0 * 60.0 * 24.0)
     return -1.0 * math.radians(23.44) * math.cos(2 * math.pi / 365 * (day_count + 10))
 
@@ -493,7 +492,7 @@ def solar_correct_data(data, dataset) -> float:
     native_y = (dataset.bounds.top + dataset.bounds.bottom) / 2.0
     pt = geom.point(native_x, native_y, dataset.crs)
     geo_pt = pt.to_crs("epsg:4326")
-    data_time = dataset.center_time.astimezone(utc)
+    data_time = dataset.center_time.astimezone(timezone.utc)
     data_lon, data_lat = geo_pt.coords[0]
 
     csz = cosine_of_solar_zenith(data_lat, data_lon, data_time)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,6 @@ dependencies = [
     "pyparsing",
     "python_dateutil",
     "python_slugify",
-    "pytz",
     "rasterio>=1.3.2",
     "regex",
     "requests",
@@ -65,7 +64,6 @@ dev = [
     "pylint",
     "ruff",
     "types-python-dateutil",
-    "types-pytz",
     "types-PyYAML",  # Used by metadata_importer.py.
     "types-requests",
 ]

--- a/tests/test_ogc_utils.py
+++ b/tests/test_ogc_utils.py
@@ -5,12 +5,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import datetime
+from datetime import timezone
 from unittest.mock import MagicMock
+from zoneinfo import ZoneInfo
 
 import pytest
 import xarray
 from odc.geo.geom import polygon
-from pytz import utc
 
 import datacube_ows.http_utils
 import datacube_ows.ogc_utils
@@ -59,13 +60,13 @@ def dummy_ds():
         ],
         crs="EPSG:4326"
     )
-    ds.center_time = datetime.datetime(2020, 12, 25, 15, 11, 11, tzinfo=utc)
+    ds.center_time = datetime.datetime(2020, 12, 25, 15, 11, 11, tzinfo=timezone.utc)
     ds.metadata_doc = {}
     return ds
 
 def test_tz_for_dataset(dummy_ds) -> None:
     ret = datacube_ows.time_utils.tz_for_dataset(dummy_ds)
-    assert ret.zone == "Australia/Sydney"
+    assert ret == ZoneInfo("Australia/Sydney")
 
 
 def test_tz_bad_coords() -> None:
@@ -86,8 +87,8 @@ def test_local_date(dummy_ds) -> None:
 def test_month_date_range_wrap() -> None:
     d = datetime.date(2019, 12, 1)
     a, b = datacube_ows.time_utils.month_date_range(d)
-    assert a == datetime.datetime(2019, 12, 1, 0, 0, 0, tzinfo=utc)
-    assert b == datetime.datetime(2019, 12, 31, 0, 0, 0, tzinfo=utc)
+    assert a == datetime.datetime(2019, 12, 1, 0, 0, 0, tzinfo=timezone.utc)
+    assert b == datetime.datetime(2019, 12, 31, 0, 0, 0, tzinfo=timezone.utc)
 
 
 def test_get_service_base_url() -> None:
@@ -278,8 +279,8 @@ def test_rolling_window() -> None:
 
 def test_day_summary_date_range() -> None:
     start, end = datacube_ows.time_utils.day_summary_date_range(datetime.date(2015, 5, 12))
-    assert start == datetime.datetime(2015, 5, 12, 0, 0, 0, tzinfo=utc)
-    assert end == datetime.datetime(2015, 5, 12, 23, 59, 59, tzinfo=utc)
+    assert start == datetime.datetime(2015, 5, 12, 0, 0, 0, tzinfo=timezone.utc)
+    assert end == datetime.datetime(2015, 5, 12, 23, 59, 59, tzinfo=timezone.utc)
 
 xy_coords = [
     ("x", [-1.0, -0.5, 0.0, 0.5, 1.0]),

--- a/tests/test_time_res_method.py
+++ b/tests/test_time_res_method.py
@@ -4,10 +4,9 @@
 # Copyright (c) 2017-2024 OWS Contributors
 # SPDX-License-Identifier: Apache-2.0
 
-from datetime import datetime
+from datetime import datetime, timezone
 
 import pytest
-import pytz
 from odc.geo.geobox import GeoBox
 
 from datacube_ows.ows_configuration import TimeRes
@@ -47,15 +46,15 @@ def test_solar(simple_geobox) -> None:
     assert not res.is_summary()
 
     with pytest.raises(ValueError) as e:
-        res.search_times(datetime(2020, 6, 7, 20, 20, 0, tzinfo=pytz.utc))
+        res.search_times(datetime(2020, 6, 7, 20, 20, 0, tzinfo=timezone.utc))
     assert "Solar time resolution search_times requires a geobox" in str(e.value)
 
     assert res.search_times(
-        datetime(2020, 6, 7, 20, 20, 0, tzinfo=pytz.utc),
+        datetime(2020, 6, 7, 20, 20, 0, tzinfo=timezone.utc),
         simple_geobox,
     ) == (
-        datetime(2020, 6, 6, 13, 55, tzinfo=pytz.utc),
-        datetime(2020, 6, 7, 13, 54, 59, tzinfo=pytz.utc),
+        datetime(2020, 6, 6, 14, 0, tzinfo=timezone.utc),
+        datetime(2020, 6, 7, 13, 59, 59, tzinfo=timezone.utc),
     )
 
 
@@ -65,8 +64,8 @@ def test_summary() -> None:
     assert not res.is_solar()
     assert res.is_summary()
     assert res.search_times(
-        datetime(2020, 6, 7, 0, 0, 0, tzinfo=pytz.utc)
-    ) == datetime(2020, 6, 7, 0, 0, 0, tzinfo=pytz.utc)
+        datetime(2020, 6, 7, 0, 0, 0, tzinfo=timezone.utc)
+    ) == datetime(2020, 6, 7, 0, 0, 0, tzinfo=timezone.utc)
 
 
 def test_legacy_aliases() -> None:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5,10 +5,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import datetime
+from datetime import timezone
 from unittest.mock import MagicMock
 
 import pytest
-import pytz
 
 
 def mock_ds_for_sort(id_: str, st: datetime, ct: datetime, lon: float, prod_name: str):
@@ -24,7 +24,7 @@ def mock_ds_for_sort(id_: str, st: datetime, ct: datetime, lon: float, prod_name
 
 @pytest.fixture
 def datasets_for_sorting() -> list:
-    utc = datetime.timezone.utc
+    utc = timezone.utc
     DT = datetime.datetime
     return [
         mock_ds_for_sort("A", DT(2022, 7, 15, 0, 0, tzinfo=utc), DT(2022, 7, 15, 9, 45, tzinfo=utc), 148.0, "prod_a"),
@@ -107,22 +107,22 @@ def test_group_by_mosaic(datasets_for_sorting) -> None:
 def test_find_in_dates() -> None:
     from datacube_ows.utils import find_matching_date
     dates = [
-        datetime.datetime(1991, 8, 3, 22, 15, 24, 122234, tzinfo=pytz.utc),
-        datetime.datetime(1991, 8, 5, 14, 6, 12, 156238, tzinfo=pytz.utc),
-        datetime.datetime(1992, 2, 5, 15, 45, 11, 832438, tzinfo=pytz.utc),
-        datetime.datetime(1995, 2, 13, 21, 9, 55, 722242, tzinfo=pytz.utc),
-        datetime.datetime(1996, 1, 23, 12, 15, 25, 723411, tzinfo=pytz.utc),
-        datetime.datetime(1996, 1, 23, 12, 15, 27, 523410, tzinfo=pytz.utc),
-        datetime.datetime(1996, 1, 23, 12, 15, 28, 0, tzinfo=pytz.utc),
-        datetime.datetime(1999, 12, 31, 22, 22, 22, 222222, tzinfo=pytz.utc),
-        datetime.datetime(2011, 7, 23, 12, 4, 12, 723494, tzinfo=pytz.utc),
+        datetime.datetime(1991, 8, 3, 22, 15, 24, 122234, tzinfo=timezone.utc),
+        datetime.datetime(1991, 8, 5, 14, 6, 12, 156238, tzinfo=timezone.utc),
+        datetime.datetime(1992, 2, 5, 15, 45, 11, 832438, tzinfo=timezone.utc),
+        datetime.datetime(1995, 2, 13, 21, 9, 55, 722242, tzinfo=timezone.utc),
+        datetime.datetime(1996, 1, 23, 12, 15, 25, 723411, tzinfo=timezone.utc),
+        datetime.datetime(1996, 1, 23, 12, 15, 27, 523410, tzinfo=timezone.utc),
+        datetime.datetime(1996, 1, 23, 12, 15, 28, 0, tzinfo=timezone.utc),
+        datetime.datetime(1999, 12, 31, 22, 22, 22, 222222, tzinfo=timezone.utc),
+        datetime.datetime(2011, 7, 23, 12, 4, 12, 723494, tzinfo=timezone.utc),
     ]
-    assert find_matching_date(datetime.datetime(1991, 8, 3, 22, 15, 24, 122234, tzinfo=pytz.utc), dates)
-    assert find_matching_date(datetime.datetime(2011, 7, 23, 12, 4, 12, 723494, tzinfo=pytz.utc), dates)
-    assert find_matching_date(datetime.datetime(1992, 2, 5, 15, 45, 11, 234110, tzinfo=pytz.utc), dates)
-    assert find_matching_date(datetime.datetime(1996, 1, 23, 12, 15, 25, 723411, tzinfo=pytz.utc), dates)
-    assert not find_matching_date(datetime.datetime(1996, 1, 23, 12, 15, 26, 723411, tzinfo=pytz.utc), dates)
-    assert find_matching_date(datetime.datetime(1996, 1, 23, 12, 15, 27, 723411, tzinfo=pytz.utc), dates)
-    assert not find_matching_date(datetime.datetime(1896, 1, 23, 12, 15, 26, 723411, tzinfo=pytz.utc), dates)
-    assert not find_matching_date(datetime.datetime(2016, 1, 23, 12, 15, 26, 723411, tzinfo=pytz.utc), dates)
-    assert not find_matching_date(datetime.datetime(2011, 7, 23, 12, 4, 12, 723494, tzinfo=pytz.utc), [])
+    assert find_matching_date(datetime.datetime(1991, 8, 3, 22, 15, 24, 122234, tzinfo=timezone.utc), dates)
+    assert find_matching_date(datetime.datetime(2011, 7, 23, 12, 4, 12, 723494, tzinfo=timezone.utc), dates)
+    assert find_matching_date(datetime.datetime(1992, 2, 5, 15, 45, 11, 234110, tzinfo=timezone.utc), dates)
+    assert find_matching_date(datetime.datetime(1996, 1, 23, 12, 15, 25, 723411, tzinfo=timezone.utc), dates)
+    assert not find_matching_date(datetime.datetime(1996, 1, 23, 12, 15, 26, 723411, tzinfo=timezone.utc), dates)
+    assert find_matching_date(datetime.datetime(1996, 1, 23, 12, 15, 27, 723411, tzinfo=timezone.utc), dates)
+    assert not find_matching_date(datetime.datetime(1896, 1, 23, 12, 15, 26, 723411, tzinfo=timezone.utc), dates)
+    assert not find_matching_date(datetime.datetime(2016, 1, 23, 12, 15, 26, 723411, tzinfo=timezone.utc), dates)
+    assert not find_matching_date(datetime.datetime(2011, 7, 23, 12, 4, 12, 723494, tzinfo=timezone.utc), [])

--- a/uv.lock
+++ b/uv.lock
@@ -749,7 +749,6 @@ dependencies = [
     { name = "pyparsing" },
     { name = "python-dateutil" },
     { name = "python-slugify" },
-    { name = "pytz" },
     { name = "rasterio" },
     { name = "regex" },
     { name = "requests" },
@@ -782,7 +781,6 @@ all = [
     { name = "ruff" },
     { name = "sentry-sdk" },
     { name = "types-python-dateutil" },
-    { name = "types-pytz" },
     { name = "types-pyyaml" },
     { name = "types-requests" },
 ]
@@ -792,7 +790,6 @@ dev = [
     { name = "pylint" },
     { name = "ruff" },
     { name = "types-python-dateutil" },
-    { name = "types-pytz" },
     { name = "types-pyyaml" },
     { name = "types-requests" },
 ]
@@ -873,7 +870,6 @@ requires-dist = [
     { name = "pytest-mock", marker = "extra == 'test'" },
     { name = "python-dateutil" },
     { name = "python-slugify" },
-    { name = "pytz" },
     { name = "rasterio", specifier = ">=1.3.2" },
     { name = "regex" },
     { name = "requests" },
@@ -885,7 +881,6 @@ requires-dist = [
     { name = "setuptools-scm", marker = "extra == 'setup'" },
     { name = "timezonefinder", specifier = "!=6.6.0" },
     { name = "types-python-dateutil", marker = "extra == 'dev'" },
-    { name = "types-pytz", marker = "extra == 'dev'" },
     { name = "types-pyyaml", marker = "extra == 'dev'" },
     { name = "types-requests", marker = "extra == 'dev'" },
     { name = "xarray" },
@@ -3465,15 +3460,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c9/95/6bdde7607da2e1e99ec1c1672a759d42f26644bbacf939916e086db34870/types_python_dateutil-2.9.0.20250708.tar.gz", hash = "sha256:ccdbd75dab2d6c9696c350579f34cffe2c281e4c5f27a585b2a2438dd1d5c8ab", size = 15834, upload-time = "2025-07-08T03:14:03.382Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/72/52/43e70a8e57fefb172c22a21000b03ebcc15e47e97f5cb8495b9c2832efb4/types_python_dateutil-2.9.0.20250708-py3-none-any.whl", hash = "sha256:4d6d0cc1cc4d24a2dc3816024e502564094497b713f7befda4d5bc7a8e3fd21f", size = 17724, upload-time = "2025-07-08T03:14:02.593Z" },
-]
-
-[[package]]
-name = "types-pytz"
-version = "2025.2.0.20250516"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/bd/72/b0e711fd90409f5a76c75349055d3eb19992c110f0d2d6aabbd6cfbc14bf/types_pytz-2025.2.0.20250516.tar.gz", hash = "sha256:e1216306f8c0d5da6dafd6492e72eb080c9a166171fa80dd7a1990fd8be7a7b3", size = 10940, upload-time = "2025-05-16T03:07:01.91Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c1/ba/e205cd11c1c7183b23c97e4bcd1de7bc0633e2e867601c32ecfc6ad42675/types_pytz-2025.2.0.20250516-py3-none-any.whl", hash = "sha256:e0e0c8a57e2791c19f718ed99ab2ba623856b11620cb6b637e5f62ce285a7451", size = 10136, upload-time = "2025-05-16T03:07:01.075Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This functionality is available
in the standard library since
Python 3.9.

<!-- readthedocs-preview datacube-ows start -->
----
📚 Documentation preview 📚: https://datacube-ows--1255.org.readthedocs.build/en/1255/

<!-- readthedocs-preview datacube-ows end -->