### PR TITLE
Run Ruff format on everything

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Run Ruff format on everything.
+58235bd5047618f46e7a6c848518353118f62ad3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,6 +10,7 @@ repos:
     hooks:
     -   id: ruff-check
         args: [--fix, --show-fixes, --output-format, grouped]
+    -   id: ruff-format
 -   repo: https://github.com/astral-sh/uv-pre-commit
     rev: 0.8.11
     hooks:

--- a/cfg_parser.py
+++ b/cfg_parser.py
@@ -7,6 +7,6 @@
 from datacube_ows.cfg_parser_impl import main
 from datacube_ows.startup_utils import initialise_debugging
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     initialise_debugging()
     main()

--- a/datacube_ows/band_utils.py
+++ b/datacube_ows/band_utils.py
@@ -12,8 +12,9 @@ import xarray as xr
 # Style index functions
 
 
-def scale_data(imgband_data: numpy.ndarray, scale_from: list[float],
-               scale_to: list[float]) -> numpy.ndarray:
+def scale_data(
+    imgband_data: numpy.ndarray, scale_from: list[float], scale_to: list[float]
+) -> numpy.ndarray:
     sc_min, sc_max = scale_from
     tc_min, tc_max = scale_to
     clipped = imgband_data.clip(sc_min, sc_max)
@@ -46,11 +47,14 @@ def band_modulator(undecorated):
         if mult_band:
             return data[mult_band] * raw_data
         return raw_data
+
     return decorated
+
 
 def pre_scaled_band(data: xr.Dataset, band, scale: float, offset: float):
     # Pre-scale a band as `data[band] * scale + offset`
     return data[band] * scale + offset
+
 
 def sum_bands(data, band1, band2, band_mapper=None):
     if band_mapper:
@@ -58,11 +62,17 @@ def sum_bands(data, band1, band2, band_mapper=None):
         band2 = band_mapper(band2)
     return data[band1] + data[band2]
 
+
 def pre_scaled_sum_bands(
-    data: xr.Dataset, band1, band2,
-    scale1: float = 1.0, offset1: float = 0.0,
-    scale2: float = 1.0, offset2: float = 0.0,
-    band_mapper: Callable | None = None):
+    data: xr.Dataset,
+    band1,
+    band2,
+    scale1: float = 1.0,
+    offset1: float = 0.0,
+    scale2: float = 1.0,
+    offset2: float = 0.0,
+    band_mapper: Callable | None = None,
+):
     # Calculate the sum of two bands, after pre-scaling them with a scale and offset
     if band_mapper:
         band1 = band_mapper(band1)
@@ -79,23 +89,29 @@ def delta_bands(data: xr.Dataset, band1, band2, band_mapper: Callable | None = N
         band2 = band_mapper(band2)
     typ1 = data[band1].dtype
     typ2 = data[band2].dtype
-    if typ1.name.startswith('uint'):
+    if typ1.name.startswith("uint"):
         nodata = data[band1].nodata
-        data[band1] = data[band1].astype('int32')
+        data[band1] = data[band1].astype("int32")
         data[band1].attrs["nodata"] = nodata
-    if typ2.name.startswith('uint'):
+    if typ2.name.startswith("uint"):
         nodata = data[band2].nodata
-        data[band2] = data[band2].astype('int32')
+        data[band2] = data[band2].astype("int32")
         data[band2].attrs["nodata"] = nodata
     # if typ1.name.startswith('uint') or typ2.name.startswith('uint'):
-        # data = data.astype('int32', copy=False)
+    # data = data.astype('int32', copy=False)
     return data[band1] - data[band2]
 
+
 def pre_scaled_delta_bands(
-    data: xr.Dataset, band1, band2,
-    scale1: float = 1.0, offset1: float = 0.0,
-    scale2: float = 1.0, offset2: float = 0.0,
-    band_mapper: Callable | None = None):
+    data: xr.Dataset,
+    band1,
+    band2,
+    scale1: float = 1.0,
+    offset1: float = 0.0,
+    scale2: float = 1.0,
+    offset2: float = 0.0,
+    band_mapper: Callable | None = None,
+):
     # Calculate the difference between two bands, after pre-scaling them with a scale
     # and offset
     if band_mapper:
@@ -103,40 +119,52 @@ def pre_scaled_delta_bands(
         band2 = band_mapper(band2)
     typ1 = data[band1].dtype
     typ2 = data[band2].dtype
-    if typ1.name.startswith('uint'):
+    if typ1.name.startswith("uint"):
         nodata = data[band1].nodata
-        data[band1] = data[band1].astype('int32')
+        data[band1] = data[band1].astype("int32")
         data[band1].attrs["nodata"] = nodata
-    if typ2.name.startswith('uint'):
+    if typ2.name.startswith("uint"):
         nodata = data[band2].nodata
-        data[band2] = data[band2].astype('int32')
+        data[band2] = data[band2].astype("int32")
         data[band2].attrs["nodata"] = nodata
     # if typ1.name.startswith('uint') or typ2.name.startswith('uint'):
-        # data = data.astype('int32', copy=False)
-        # Pre-scaled bands data
+    # data = data.astype('int32', copy=False)
+    # Pre-scaled bands data
     data1 = pre_scaled_band(data, band1, scale1, offset1)
     data2 = pre_scaled_band(data, band2, scale2, offset2)
     return data1 - data2
+
 
 # N.B. Modifying scale_to would be dangerous - don't do it.
 # pylint: disable=dangerous-default-value
 @scalable
 def norm_diff(data: xr.Dataset, band1, band2, band_mapper: Callable | None = None):
     # Calculate a normalised difference index.
-    return delta_bands(data, band1, band2, band_mapper) / sum_bands(data, band1, band2, band_mapper)
+    return delta_bands(data, band1, band2, band_mapper) / sum_bands(
+        data, band1, band2, band_mapper
+    )
+
 
 @scalable
-def pre_scaled_norm_diff(data: xr.Dataset, band1, band2,
-                         scale1: float = 1.0, offset1: float = 0.0,
-                         scale2: float = 1.0, offset2: float = 0.0,
-                         band_mapper: Callable | None = None):
+def pre_scaled_norm_diff(
+    data: xr.Dataset,
+    band1,
+    band2,
+    scale1: float = 1.0,
+    offset1: float = 0.0,
+    scale2: float = 1.0,
+    offset2: float = 0.0,
+    band_mapper: Callable | None = None,
+):
     # Calculate a normalised difference index, after scaling the input bands with a
     # scale and offset
-    return (pre_scaled_delta_bands(
-        data, band1, band2, scale1, offset1, scale2, offset2, band_mapper) /
-        pre_scaled_sum_bands(
-            data, band1, band2, scale1, offset1, scale2, offset2, band_mapper)
+    return pre_scaled_delta_bands(
+        data, band1, band2, scale1, offset1, scale2, offset2, band_mapper
+    ) / pre_scaled_sum_bands(
+        data, band1, band2, scale1, offset1, scale2, offset2, band_mapper
     )
+
+
 @scalable
 def constant(data: xr.Dataset, band, const, band_mapper: Callable | None = None):
     # Covert an xarray for a flat constant.
@@ -166,12 +194,28 @@ def band_quotient(data: xr.Dataset, band1, band2, band_mapper: Callable | None =
 
 
 @scalable
-def band_quotient_sum(data: xr.Dataset, band1a, band1b, band2a, band2b, band_mapper: Callable | None = None):
-    return band_quotient(data, band1a, band1b, band_mapper) + band_quotient(data, band2a, band2b, band_mapper)
+def band_quotient_sum(
+    data: xr.Dataset,
+    band1a,
+    band1b,
+    band2a,
+    band2b,
+    band_mapper: Callable | None = None,
+):
+    return band_quotient(data, band1a, band1b, band_mapper) + band_quotient(
+        data, band2a, band2b, band_mapper
+    )
 
 
 @scalable
-def sentinel2_ndci(data: xr.Dataset, b_red_edge, b_red, b_green, b_swir, band_mapper: Callable | None = None):
+def sentinel2_ndci(
+    data: xr.Dataset,
+    b_red_edge,
+    b_red,
+    b_green,
+    b_swir,
+    band_mapper: Callable | None = None,
+):
     red_delta = delta_bands(data, b_red_edge, b_red, band_mapper)
     red_sum = sum_bands(data, b_red_edge, b_red, band_mapper)
     mndwi = norm_diff(data, b_green, b_swir, band_mapper)
@@ -182,33 +226,37 @@ def sentinel2_ndci(data: xr.Dataset, b_red_edge, b_red, b_green, b_swir, band_ma
 def multi_date_delta(data: xr.Dataset, time_direction: Literal[-1, 0, 1] = -1):
     data1, data2 = (data.sel(time=dt) for dt in data.coords["time"].values)
 
-#    data1, data2 = data.values.item(0), data.values.item(1)
+    #    data1, data2 = data.values.item(0), data.values.item(1)
     if time_direction >= 0:
         return data1 - data2
     return data2 - data1
 
+
 def multi_date_pass(data: xr.Dataset) -> xr.Dataset:
     return data
 
-def multi_date_raw_example(data: xr.Dataset, band1, band2, band_mapper: Callable | None = None):
+
+def multi_date_raw_example(
+    data: xr.Dataset, band1, band2, band_mapper: Callable | None = None
+):
     if band_mapper:
         band1 = band_mapper(band1)
         band2 = band_mapper(band2)
     data1, data2 = (data.sel(time=dt) for dt in data.coords["time"].values)
-    return (
-            (data2[band1] - data1[band1]) - (data2[band2] - data1[band2])
-    ) / (
-            data1[band1] + data1[band2] + data2[band1] + data2[band2]
+    return ((data2[band1] - data1[band1]) - (data2[band2] - data1[band2])) / (
+        data1[band1] + data1[band2] + data2[band1] + data2[band2]
     )
 
 
 @band_modulator
 @scalable
-def single_band_log(data: xr.Dataset, band, scale_factor, exponent, band_mapper: Callable | None = None):
+def single_band_log(
+    data: xr.Dataset, band, scale_factor, exponent, band_mapper: Callable | None = None
+):
     if band_mapper:
         band = band_mapper(band)
     d = data[band]
-    return scale_factor * ((d ** exponent) - 1.0)
+    return scale_factor * ((d**exponent) - 1.0)
 
 
 @band_modulator
@@ -222,7 +270,13 @@ def single_band_arcsec(data: xr.Dataset, band, band_mapper: Callable | None = No
 
 @band_modulator
 @scalable
-def single_band_offset_log(data: xr.Dataset, band, scale: float = 1.0, offset: int | float | None = None, band_mapper: Callable | None = None):
+def single_band_offset_log(
+    data: xr.Dataset,
+    band,
+    scale: float = 1.0,
+    offset: int | float | None = None,
+    band_mapper: Callable | None = None,
+):
     if band_mapper:
         band = band_mapper(band)
     d = data[band]
@@ -235,7 +289,9 @@ def single_band_offset_log(data: xr.Dataset, band, scale: float = 1.0, offset: i
 
 
 @scalable
-def radar_vegetation_index(data: xr.Dataset, band_hv, band_hh, band_mapper: Callable | None = None) -> xr.Dataset:
+def radar_vegetation_index(
+    data: xr.Dataset, band_hv, band_hh, band_mapper: Callable | None = None
+) -> xr.Dataset:
     if band_mapper:
         band_hv = band_mapper(band_hv)
         band_hh = band_mapper(band_hh)

--- a/datacube_ows/cfg_parser_impl.py
+++ b/datacube_ows/cfg_parser_impl.py
@@ -34,7 +34,9 @@ from datacube_ows.ows_configuration import (
 def main(version: bool) -> int:
     # --version
     if version:
-        click.echo(f"Open Data Cube Open Web Services (datacube-ows) version {__version__}")
+        click.echo(
+            f"Open Data Cube Open Web Services (datacube-ows) version {__version__}"
+        )
     return 0
 
 
@@ -71,7 +73,14 @@ def main(version: bool) -> int:
     "--output-file",
     help="Provide an output inventory file name with extension .json",
 )
-def check(parse_only: bool, folders: bool, styles: bool, input_file: str, output_file: str, paths: list[str]) -> int:
+def check(
+    parse_only: bool,
+    folders: bool,
+    styles: bool,
+    input_file: str,
+    output_file: str,
+    paths: list[str],
+) -> int:
     """Check configuration files
 
     Takes a list of configuration specifications which are each loaded and validated in turn,
@@ -98,7 +107,14 @@ def check(parse_only: bool, folders: bool, styles: bool, input_file: str, output
     return 0
 
 
-def parse_path(path: str | None, parse_only: bool, folders: bool, styles: bool, input_file: str, output_file: str) -> bool:
+def parse_path(
+    path: str | None,
+    parse_only: bool,
+    folders: bool,
+    styles: bool,
+    input_file: str,
+    output_file: str,
+) -> bool:
     try:
         raw_cfg = read_config(path)
         cfg = OWSConfig(refresh=True, cfg=raw_cfg)
@@ -142,7 +158,7 @@ def parse_path(path: str | None, parse_only: bool, folders: bool, styles: bool, 
     "-m",
     "--msg-file",
     default="messages.po",
-    help="Write to a message file with the translatable metadata from the configuration. (Defaults to 'messages.po')"
+    help="Write to a message file with the translatable metadata from the configuration. (Defaults to 'messages.po')",
 )
 @click.argument("path", nargs=1, required=False)
 def extract(path: str, cfg_only: bool, msg_file: str) -> int:
@@ -174,35 +190,41 @@ def extract(path: str, cfg_only: bool, msg_file: str) -> int:
     "--new",
     is_flag=True,
     default=False,
-    help="Create a new translation template. (Default is to update an existing one.)"
+    help="Create a new translation template. (Default is to update an existing one.)",
 )
 @click.option(
     "-m",
     "--msg-file",
     default=None,
-    help="Use this message file as the template for translation files. (defaults to message filename from configuration)"
+    help="Use this message file as the template for translation files. (defaults to message filename from configuration)",
 )
 @click.option(
     "-d",
     "--translations-dir",
     default=None,
-    help="Path to the output translations directory. Defaults to value from configuration"
+    help="Path to the output translations directory. Defaults to value from configuration",
 )
 @click.option(
     "-D",
     "--domain",
     default=None,
-    help="The domain of the translation files. Defaults to value from configuration"
+    help="The domain of the translation files. Defaults to value from configuration",
 )
 @click.option(
     "-c",
     "--cfg",
     default=None,
-    help="Configuration specification to use to determine translations directory and domain (defaults to environment $DATACUBE_OWS_CFG)"
+    help="Configuration specification to use to determine translations directory and domain (defaults to environment $DATACUBE_OWS_CFG)",
 )
 @click.argument("languages", nargs=-1)
-def translation(languages: list[str], msg_file: str | None, new: bool,
-                domain: str | None, translations_dir: str | None, cfg: str | None) -> int:
+def translation(
+    languages: list[str],
+    msg_file: str | None,
+    new: bool,
+    domain: str | None,
+    translations_dir: str | None,
+    cfg: str | None,
+) -> int:
     """Generate a new translations catalog based on the specified message file.
 
     Takes a list of languages to generate catalogs for. "all" can be included as a shorthand
@@ -211,7 +233,12 @@ def translation(languages: list[str], msg_file: str | None, new: bool,
     if len(languages) == 0:
         click.echo("No language(s) specified.")
         sys.exit(1)
-    if msg_file is None or domain is None or translations_dir is None or "all" in languages:
+    if (
+        msg_file is None
+        or domain is None
+        or translations_dir is None
+        or "all" in languages
+    ):
         try:
             raw_cfg = read_config(cfg)
             config = OWSConfig(refresh=True, cfg=raw_cfg)
@@ -219,19 +246,25 @@ def translation(languages: list[str], msg_file: str | None, new: bool,
             click.echo(f"Config exception for path: {e!s}")
             sys.exit(1)
         if domain is None:
-            click.echo(f"Using message domain '{config.message_domain}' from configuration")
+            click.echo(
+                f"Using message domain '{config.message_domain}' from configuration"
+            )
             domain = config.message_domain
         if translations_dir is None and config.translations_dir is None:
             click.echo("No translations directory was supplied or is configured")
             sys.exit(1)
         elif translations_dir is None:
-            click.echo(f"Using translations directory '{config.translations_dir}' from configuration")
+            click.echo(
+                f"Using translations directory '{config.translations_dir}' from configuration"
+            )
             translations_dir = config.translations_dir
         if msg_file is None and config.msg_file_name is None:
             click.echo("No message file name was supplied or is configured")
             sys.exit(1)
         elif msg_file is None:
-            click.echo(f"Using message file location '{config.msg_file_name}' from configuration")
+            click.echo(
+                f"Using message file location '{config.msg_file_name}' from configuration"
+            )
             msg_file = config.msg_file_name
         all_langs = config.locales
     else:
@@ -261,16 +294,24 @@ def translation(languages: list[str], msg_file: str | None, new: bool,
     return 0
 
 
-def create_translation(msg_file: str, translations_dir: str, domain: str, locale: str) -> bool:
+def create_translation(
+    msg_file: str, translations_dir: str, domain: str, locale: str
+) -> bool:
     click.echo(f"Creating template for language: {locale}")
-    os.system(f"pybabel init -i {msg_file} -d {translations_dir} -D {domain} -l {locale}")
+    os.system(
+        f"pybabel init -i {msg_file} -d {translations_dir} -D {domain} -l {locale}"
+    )
     return True
 
 
-def update_translation(msg_file: str, translations_dir: str, domain: str, locale: str) -> bool:
+def update_translation(
+    msg_file: str, translations_dir: str, domain: str, locale: str
+) -> bool:
     click.echo(f"Updating template for language: {locale}")
-    os.system(f"pybabel update --no-fuzzy-matching --ignore-obsolete "
-              f"-i {msg_file} -d {translations_dir} -D {domain} -l {locale}")
+    os.system(
+        f"pybabel update --no-fuzzy-matching --ignore-obsolete "
+        f"-i {msg_file} -d {translations_dir} -D {domain} -l {locale}"
+    )
     return True
 
 
@@ -279,22 +320,27 @@ def update_translation(msg_file: str, translations_dir: str, domain: str, locale
     "-d",
     "--translations-dir",
     default=None,
-    help="Path to the output translations directory. Defaults to value from configuration"
+    help="Path to the output translations directory. Defaults to value from configuration",
 )
 @click.option(
     "-D",
     "--domain",
     default=None,
-    help="The domain of the translation files. Defaults to value from configuration"
+    help="The domain of the translation files. Defaults to value from configuration",
 )
 @click.option(
     "-c",
     "--cfg",
     default=None,
-    help="Configuration specification to use to determine translations directory and domain (defaults to environment $DATACUBE_OWS_CFG)"
+    help="Configuration specification to use to determine translations directory and domain (defaults to environment $DATACUBE_OWS_CFG)",
 )
 @click.argument("languages", nargs=-1)
-def compile_cmd(languages: list[str], domain: str | None, translations_dir: str | None, cfg: str | None) -> int:
+def compile_cmd(
+    languages: list[str],
+    domain: str | None,
+    translations_dir: str | None,
+    cfg: str | None,
+) -> int:
     """Compile completed translation files.
 
     Takes a list of languages to generate catalogs for. "all" can be included as a shorthand
@@ -311,13 +357,17 @@ def compile_cmd(languages: list[str], domain: str | None, translations_dir: str 
             click.echo(f"Config exception for path: {e!s}")
             sys.exit(1)
         if domain is None:
-            click.echo(f"Using message domain '{config.message_domain}' from configuration")
+            click.echo(
+                f"Using message domain '{config.message_domain}' from configuration"
+            )
             domain = config.message_domain
         if translations_dir is None and config.translations_dir is None:
             click.echo("No translations directory was supplied or is configured")
             sys.exit(1)
         elif translations_dir is None:
-            click.echo(f"Using translations directory '{config.translations_dir}' from configuration")
+            click.echo(
+                f"Using translations directory '{config.translations_dir}' from configuration"
+            )
             translations_dir = config.translations_dir
         all_langs = config.locales
     else:
@@ -347,7 +397,9 @@ def write_msg_file(msg_file: str, cfg: OWSConfig) -> None:
         write_po(fp, cfg.export_metadata())
 
 
-def layers_report(config_values: dict[str, OWSNamedLayer], input_file: str, output_file: str) -> None:
+def layers_report(
+    config_values: dict[str, OWSNamedLayer], input_file: str, output_file: str
+) -> None:
     report = {"total_layers_count": len(config_values.values()), "layers": []}
     for lyr in config_values.values():
         layer = {
@@ -365,7 +417,7 @@ def layers_report(config_values: dict[str, OWSNamedLayer], input_file: str, outp
             click.echo(ddiff)
             sys.exit(1)
     elif output_file:
-        with open(output_file, 'w') as reportfile:
+        with open(output_file, "w") as reportfile:
             json.dump(report, reportfile, indent=4)
 
 

--- a/datacube_ows/config_utils.py
+++ b/datacube_ows/config_utils.py
@@ -505,7 +505,7 @@ class OWSMetadataConfig(OWSConfigEntry):
 
     @override
     def __getattribute__(self, name: str) -> Any:
-        """"
+        """
         Expose separated or internationalised metadata as attributes
         """
         if name in (FLD_TITLE, FLD_ABSTRACT, FLD_FEES,
@@ -636,7 +636,7 @@ class OWSExtensibleConfigEntry(OWSIndexedConfigEntry):
 # Managing multiproduct flag-bands
 
 class OWSFlagBandStandalone:
-    """"
+    """
     Minimal proxy for OWSFlagBand, for use in StandAlone API which doesn't need anything more than the band name.
     """
     def __init__(self, band: str) -> None:

--- a/datacube_ows/config_utils.py
+++ b/datacube_ows/config_utils.py
@@ -33,15 +33,20 @@ if TYPE_CHECKING:
 
 _LOG: logging.Logger = logging.getLogger(__name__)
 
-RAW_CFG: TypeAlias = None | str | int | float | bool | list["RAW_CFG"] | dict[str, "RAW_CFG"]
+RAW_CFG: TypeAlias = (
+    None | str | int | float | bool | list["RAW_CFG"] | dict[str, "RAW_CFG"]
+)
 
 CFG_DICT: TypeAlias = dict[str, RAW_CFG]
 
 F: TypeAlias = Callable[..., Any]
 
 
-def cfg_expand(cfg_unexpanded: CFG_DICT,
-               cwd: str | None = None, inclusions: list[str] | None = None) -> RAW_CFG:
+def cfg_expand(
+    cfg_unexpanded: CFG_DICT,
+    cwd: str | None = None,
+    inclusions: list[str] | None = None,
+) -> RAW_CFG:
     """
     Recursively expand config inclusions.
 
@@ -88,14 +93,20 @@ def cfg_expand(cfg_unexpanded: CFG_DICT,
                 return cfg_expand(json_obj, cwd=cwd, inclusions=ninclusions)
             if cfg_unexpanded["type"] == "python":
                 # Python Expansion
-                return cfg_expand(import_python_obj(raw_path), cwd=cwd, inclusions=ninclusions)
-            raise ConfigException(f"Unsupported inclusion type: {cfg_unexpanded['type']!s}")
+                return cfg_expand(
+                    import_python_obj(raw_path), cwd=cwd, inclusions=ninclusions
+                )
+            raise ConfigException(
+                f"Unsupported inclusion type: {cfg_unexpanded['type']!s}"
+            )
         return {
             k: cfg_expand(cast(CFG_DICT, v), cwd=cwd, inclusions=inclusions)
             for k, v in cfg_unexpanded.items()
         }
     if isinstance(cfg_unexpanded, Sequence) and not isinstance(cfg_unexpanded, str):
-        return [cfg_expand(elem, cwd=cwd, inclusions=inclusions) for elem in cfg_unexpanded]
+        return [
+            cfg_expand(elem, cwd=cwd, inclusions=inclusions) for elem in cfg_unexpanded
+        ]
     return cfg_unexpanded
 
 
@@ -106,14 +117,18 @@ def get_file_loc(x: str) -> str:
     and the URL location of a remote file.
     """
     xp = urlparse(x)
-    if xp.scheme in ("s3",): # NOTE: could add http/s, ...
+    if xp.scheme in ("s3",):  # NOTE: could add http/s, ...
         enable_s3 = os.environ.get("DATACUBE_OWS_CFG_ALLOW_S3", "no")
         if enable_s3.lower() not in ("yes", "true", "1", "y"):
-            raise ConfigException("Please set environment variable 'DATACUBE_OWS_CFG_ALLOW_S3=YES' "
-                              + "to enable OWS config from AWS S3")
-        cwd = xp.scheme + "://" + xp.netloc +  xp.path.rsplit("/", 1)[0]
+            raise ConfigException(
+                "Please set environment variable 'DATACUBE_OWS_CFG_ALLOW_S3=YES' "
+                + "to enable OWS config from AWS S3"
+            )
+        cwd = xp.scheme + "://" + xp.netloc + xp.path.rsplit("/", 1)[0]
     elif xp.scheme:
-        raise ConfigException(f"Unsupported URL scheme in config inheritance: {xp.scheme}")
+        raise ConfigException(
+            f"Unsupported URL scheme in config inheritance: {xp.scheme}"
+        )
     else:
         abs_path = os.path.abspath(x)
         cwd = os.path.dirname(abs_path)
@@ -136,7 +151,7 @@ def import_python_obj(path: str) -> CFG_DICT:
     :param: A fully qualified python path.
     :return: a Python object, or None
     """
-    mod_name, obj_name = path.rsplit('.', 1)
+    mod_name, obj_name = path.rsplit(".", 1)
     try:
         mod = import_module(mod_name)
         obj = getattr(mod, obj_name)
@@ -163,11 +178,11 @@ class ODCInitException(ConfigException):
     """
 
 
-
 class OWSConfigEntry:
     """
     Base class for all configuration objects
     """
+
     # Parse and validate the json but don't access the database.
     def __init__(self, cfg: RAW_CFG, *args, **kwargs) -> None:
         """
@@ -219,7 +234,9 @@ class OWSConfigEntry:
         if name == "_unready_attributes":
             pass
         elif hasattr(self, "_unready_attributes") and name in self._unready_attributes:
-            raise OWSConfigNotReady(f"The following parameters have not been initialised: {self._unready_attributes}")
+            raise OWSConfigNotReady(
+                f"The following parameters have not been initialised: {self._unready_attributes}"
+            )
         return object.__getattribute__(self, name)
 
     @override
@@ -250,8 +267,11 @@ class OWSConfigEntry:
         :return:
         """
         if self._unready_attributes:
-            raise OWSConfigNotReady(f"The following parameters have not been initialised: {self._unready_attributes}")
+            raise OWSConfigNotReady(
+                f"The following parameters have not been initialised: {self._unready_attributes}"
+            )
         self.ready = True
+
 
 #####################################################
 # Metadata separation and translation.
@@ -267,6 +287,7 @@ FLD_ACCESS_CONSTRAINTS = "access_constraints"
 FLD_ATTRIBUTION = "attribution_title"
 FLD_CONTACT_ORGANISATION = "contact_org"
 FLD_CONTACT_POSITION = "contact_position"
+
 
 class OWSMetadataConfig(OWSConfigEntry):
     """
@@ -304,7 +325,6 @@ class OWSMetadataConfig(OWSConfigEntry):
         """Return the metadata path prefix for this object."""
         return "global"
 
-
     def can_inherit_from(self) -> Optional["OWSMetadataConfig"]:
         """
         The parent config object this object can inherit metadata from.
@@ -336,25 +356,44 @@ class OWSMetadataConfig(OWSConfigEntry):
         inherit_from = self.can_inherit_from()
         if self.METADATA_TITLE:
             if self.default_title is not None:
-                self.register_metadata(self.get_obj_label(), FLD_TITLE, cast(str, cfg.get(FLD_TITLE, self.default_title)))
+                self.register_metadata(
+                    self.get_obj_label(),
+                    FLD_TITLE,
+                    cast(str, cfg.get(FLD_TITLE, self.default_title)),
+                )
             else:
                 try:
-                    self.register_metadata(self.get_obj_label(), FLD_TITLE, cast(str, cfg[FLD_TITLE]))
+                    self.register_metadata(
+                        self.get_obj_label(), FLD_TITLE, cast(str, cfg[FLD_TITLE])
+                    )
                 except KeyError:
-                    raise ConfigException(f"Entity {self.get_obj_label()} has no title.") from None
+                    raise ConfigException(
+                        f"Entity {self.get_obj_label()} has no title."
+                    ) from None
         if self.METADATA_ABSTRACT:
             local_abstract = cfg.get("abstract")
             if local_abstract is None and inherit_from is not None:
-                self.register_metadata(self.get_obj_label(), FLD_ABSTRACT, inherit_from.abstract, inherited=True)
+                self.register_metadata(
+                    self.get_obj_label(),
+                    FLD_ABSTRACT,
+                    inherit_from.abstract,
+                    inherited=True,
+                )
             elif local_abstract is None and self.default_abstract is not None:
-                self.register_metadata(self.get_obj_label(), FLD_ABSTRACT, self.default_abstract)
+                self.register_metadata(
+                    self.get_obj_label(), FLD_ABSTRACT, self.default_abstract
+                )
             elif local_abstract is None:
                 raise ConfigException(f"Entity {self.get_obj_label()} has no abstract")
             else:
-                self.register_metadata(self.get_obj_label(), "abstract", cast(str, local_abstract))
+                self.register_metadata(
+                    self.get_obj_label(), "abstract", cast(str, local_abstract)
+                )
         if self.METADATA_KEYWORDS:
             local_keyword_set = set(cast(list[str], cfg.get("keywords", [])))
-            self.register_metadata(self.get_obj_label(), FLD_KEYWORDS, ",".join(local_keyword_set))
+            self.register_metadata(
+                self.get_obj_label(), FLD_KEYWORDS, ",".join(local_keyword_set)
+            )
             keyword_set = inherit_from.keywords if inherit_from else set()
             self._keywords = keyword_set.union(local_keyword_set)
         if self.METADATA_ATTRIBUTION:
@@ -365,7 +404,9 @@ class OWSMetadataConfig(OWSConfigEntry):
                 inheriting = True
             attrib_title = attrib.get("title") if attrib else None
             if attrib_title:
-                self.register_metadata(self.get_obj_label(), FLD_ATTRIBUTION, attrib_title, inheriting)
+                self.register_metadata(
+                    self.get_obj_label(), FLD_ATTRIBUTION, attrib_title, inheriting
+                )
         if self.METADATA_FEES:
             fees = cast(str, cfg.get(FLD_FEES))
             if not fees:
@@ -377,13 +418,19 @@ class OWSMetadataConfig(OWSConfigEntry):
                 acc = "none"
             self.register_metadata(self.get_obj_label(), FLD_ACCESS_CONSTRAINTS, acc)
         if self.METADATA_CONTACT_INFO:
-            cfg_contact_info: dict[str, str] = cast(dict[str, str], cfg.get("contact_info", {}))
+            cfg_contact_info: dict[str, str] = cast(
+                dict[str, str], cfg.get("contact_info", {})
+            )
             org = cfg_contact_info.get("organisation")
             position = cfg_contact_info.get("position")
             if org:
-                self.register_metadata(self.get_obj_label(), FLD_CONTACT_ORGANISATION, org)
+                self.register_metadata(
+                    self.get_obj_label(), FLD_CONTACT_ORGANISATION, org
+                )
             if position:
-                self.register_metadata(self.get_obj_label(), FLD_CONTACT_POSITION, position)
+                self.register_metadata(
+                    self.get_obj_label(), FLD_CONTACT_POSITION, position
+                )
         if self.METADATA_DEFAULT_BANDS:
             band_map = cast(dict[str, list[str]], cfg)
             for k, v in band_map.items():
@@ -394,7 +441,9 @@ class OWSMetadataConfig(OWSConfigEntry):
         if self.METADATA_VALUE_RULES:
             # Note that parse_metadata must be called after the value map is parsed.
             for patch in self.patches:
-                self.register_metadata(self.get_obj_label(), f"rule_{patch.idx}", patch.label)
+                self.register_metadata(
+                    self.get_obj_label(), f"rule_{patch.idx}", patch.label
+                )
         if self.METADATA_LEGEND_UNITS:
             units = cast(str, cfg.get(FLD_UNITS))
             if units is not None:
@@ -458,7 +507,9 @@ class OWSMetadataConfig(OWSConfigEntry):
         lookup = f"{lbl}.{fld}"
         return self._inheritance_registry.get(lookup, False)
 
-    def register_metadata(self, lbl: str, fld: str, val: str, inherited: bool = False) -> None:
+    def register_metadata(
+        self, lbl: str, fld: str, val: str, inherited: bool = False
+    ) -> None:
         """
         Register a piece of metadata at config-parse time with it's raw config default value.
 
@@ -508,9 +559,15 @@ class OWSMetadataConfig(OWSConfigEntry):
         """
         Expose separated or internationalised metadata as attributes
         """
-        if name in (FLD_TITLE, FLD_ABSTRACT, FLD_FEES,
-                    FLD_ACCESS_CONSTRAINTS, FLD_CONTACT_POSITION, FLD_CONTACT_ORGANISATION,
-                    FLD_UNITS):
+        if name in (
+            FLD_TITLE,
+            FLD_ABSTRACT,
+            FLD_FEES,
+            FLD_ACCESS_CONSTRAINTS,
+            FLD_CONTACT_POSITION,
+            FLD_CONTACT_ORGANISATION,
+            FLD_UNITS,
+        ):
             return self.read_local_metadata(name)
         if name == FLD_KEYWORDS:
             kw = self.read_local_metadata(FLD_KEYWORDS)
@@ -521,8 +578,10 @@ class OWSMetadataConfig(OWSConfigEntry):
             return self.read_local_metadata(FLD_ATTRIBUTION)
         return super().__getattribute__(name)
 
+
 ###########################
 # Inheritable configuration
+
 
 class OWSEntryNotFound(ConfigException):
     """
@@ -534,6 +593,7 @@ class OWSIndexedConfigEntry(OWSConfigEntry):
     """
     A Config Entry object that can be looked up by name (i.e. so it can be inherited from)
     """
+
     INDEX_KEYS: list[str] = []
 
     def __init__(self, cfg: RAW_CFG, keyvals: dict[str, str], *args, **kwargs) -> None:
@@ -549,13 +609,18 @@ class OWSIndexedConfigEntry(OWSConfigEntry):
 
         for k in self.INDEX_KEYS:
             if k not in keyvals:
-                raise ConfigException(f"Key value {k} missing from keyvals: {keyvals!r}")
+                raise ConfigException(
+                    f"Key value {k} missing from keyvals: {keyvals!r}"
+                )
         self.keyvals = keyvals
 
     @classmethod
-    def lookup_impl(cls, cfg: "datacube_ows.ows_configuration.OWSConfig",
-                    keyvals: dict[str, str],
-                    subs: CFG_DICT | None = None) -> "OWSIndexedConfigEntry":
+    def lookup_impl(
+        cls,
+        cfg: "datacube_ows.ows_configuration.OWSConfig",
+        keyvals: dict[str, str],
+        subs: CFG_DICT | None = None,
+    ) -> "OWSIndexedConfigEntry":
         """
         Lookup a config entry of this type by identifying label(s)
 
@@ -573,13 +638,18 @@ class OWSExtensibleConfigEntry(OWSIndexedConfigEntry):
     """
     A configuration object that can inherit from and extend an existing configuration object of the same type.
     """
-    def __init__(self,
-                 cfg: RAW_CFG, keyvals: dict[str, str], global_cfg: "datacube_ows.ows_configuration.OWSConfig",
-                 *args,
-                 keyval_subs: dict[str, Any] | None = None,
-                 keyval_defaults: dict[str, str] | None = None,
-                 expanded: bool = False,
-                 **kwargs) -> None:
+
+    def __init__(
+        self,
+        cfg: RAW_CFG,
+        keyvals: dict[str, str],
+        global_cfg: "datacube_ows.ows_configuration.OWSConfig",
+        *args,
+        keyval_subs: dict[str, Any] | None = None,
+        keyval_defaults: dict[str, str] | None = None,
+        expanded: bool = False,
+        **kwargs,
+    ) -> None:
         """
         Apply inheritance expansion and overrides to raw config.
         :param cfg: Raw (unexpanded) configuration
@@ -590,16 +660,23 @@ class OWSExtensibleConfigEntry(OWSIndexedConfigEntry):
         :param expanded: (optional, defaults to False) If true, assume expansion has already been applied.
         """
         if not expanded:
-            cfg = self.expand_inherit(cast(CFG_DICT, cfg), global_cfg,
-                                      keyval_subs=keyval_subs, keyval_defaults=keyval_defaults)
+            cfg = self.expand_inherit(
+                cast(CFG_DICT, cfg),
+                global_cfg,
+                keyval_subs=keyval_subs,
+                keyval_defaults=keyval_defaults,
+            )
 
         super().__init__(cfg, keyvals, global_cfg=global_cfg, *args, **kwargs)
 
     @classmethod
-    def expand_inherit(cls,
-                       cfg: CFG_DICT, global_cfg: "datacube_ows.ows_configuration.OWSConfig",
-                       keyval_subs: dict[str, Any] | None = None,
-                       keyval_defaults: dict[str, str] | None = None) -> RAW_CFG:
+    def expand_inherit(
+        cls,
+        cfg: CFG_DICT,
+        global_cfg: "datacube_ows.ows_configuration.OWSConfig",
+        keyval_subs: dict[str, Any] | None = None,
+        keyval_defaults: dict[str, str] | None = None,
+    ) -> RAW_CFG:
         """
         Expand inherited config, and apply overrides.
 
@@ -615,7 +692,11 @@ class OWSExtensibleConfigEntry(OWSIndexedConfigEntry):
             lookup_keys: dict[str, str] = {}
             inherits = cast(dict[str, str], cfg["inherits"])
             for k in cls.INDEX_KEYS:
-                if k not in inherits and keyval_defaults is not None and k not in keyval_defaults:
+                if (
+                    k not in inherits
+                    and keyval_defaults is not None
+                    and k not in keyval_defaults
+                ):
                     lookup = False
                     break
                 if k in inherits:
@@ -623,7 +704,9 @@ class OWSExtensibleConfigEntry(OWSIndexedConfigEntry):
                 elif keyval_defaults and k in keyval_defaults:
                     lookup_keys[k] = str(keyval_defaults[k])
             if lookup and lookup_keys:
-                parent = cls.lookup_impl(global_cfg, keyvals=lookup_keys, subs=keyval_subs)
+                parent = cls.lookup_impl(
+                    global_cfg, keyvals=lookup_keys, subs=keyval_subs
+                )
                 # pylint: disable=protected-access
                 parent_cfg = parent._raw_cfg
             else:
@@ -632,13 +715,16 @@ class OWSExtensibleConfigEntry(OWSIndexedConfigEntry):
             cfg["inheritance_expanded"] = True
         return cfg
 
+
 ##################################
 # Managing multiproduct flag-bands
+
 
 class OWSFlagBandStandalone:
     """
     Minimal proxy for OWSFlagBand, for use in StandAlone API which doesn't need anything more than the band name.
     """
+
     def __init__(self, band: str) -> None:
         self.pq_band = band
         self.canonical_band_name = band
@@ -652,8 +738,13 @@ class OWSFlagBand(OWSConfigEntry):
     """
     Represents a flag band, which may come from the main product or a parallel secondary product.
     """
-    def __init__(self, cfg: CFG_DICT, product_cfg: "datacube_ows.ows_configuration.OWSNamedLayer",
-                 **kwargs) -> None:
+
+    def __init__(
+        self,
+        cfg: CFG_DICT,
+        product_cfg: "datacube_ows.ows_configuration.OWSNamedLayer",
+        **kwargs,
+    ) -> None:
         """
         Class constructor, first round initialisation
 
@@ -668,9 +759,11 @@ class OWSFlagBand(OWSConfigEntry):
         self.pq_low_res_names = pq_names["pq_low_res_names"]
         self.main_products = pq_names["main_products"]
         self.pq_band = str(cfg["band"])
-        self.canonical_band_name = self.pq_band # Update for aliasing on make_ready
+        self.canonical_band_name = self.pq_band  # Update for aliasing on make_ready
         if "fuse_func" in cfg:
-            self.pq_fuse_func: FunctionWrapper | None = FunctionWrapper(self.layer, cast(CFG_DICT, cfg["fuse_func"]))
+            self.pq_fuse_func: FunctionWrapper | None = FunctionWrapper(
+                self.layer, cast(CFG_DICT, cfg["fuse_func"])
+            )
         else:
             self.pq_fuse_func = None
         self.pq_ignore_time = bool(cfg.get("ignore_time", False))
@@ -696,13 +789,17 @@ class OWSFlagBand(OWSConfigEntry):
             if pqn is not None:
                 pq_product = self.layer.dc.index.products.get_by_name(pqn)
                 if pq_product is None:
-                    raise ConfigException(f"Could not find flags product {pqn} for layer {self.layer.name} in datacube")
+                    raise ConfigException(
+                        f"Could not find flags product {pqn} for layer {self.layer.name} in datacube"
+                    )
                 self.pq_products.append(pq_product)
         for pqn in self.pq_low_res_names:
             if pqn is not None:
                 pq_product = self.layer.dc.index.products.get_by_name(pqn)
                 if pq_product is None:
-                    raise ConfigException(f"Could not find flags low_res product {pqn} for layer {self.layer.name} in datacube")
+                    raise ConfigException(
+                        f"Could not find flags low_res product {pqn} for layer {self.layer.name} in datacube"
+                    )
                 self.pq_low_res_products.append(pq_product)
 
         # Resolve band alias if necessary.
@@ -710,18 +807,22 @@ class OWSFlagBand(OWSConfigEntry):
             with contextlib.suppress(ConfigException):
                 self.canonical_band_name = self.layer.band_idx.band(self.pq_band)
 
-    # pyre-ignore[16]
+        # pyre-ignore[16]
         self.info_mask: int = ~0
         # A (hopefully) representative product
         product = self.pq_products[0]
         try:
-            meas = product.lookup_measurements([str(self.canonical_band_name)])[str(self.canonical_band_name)]
+            meas = product.lookup_measurements([str(self.canonical_band_name)])[
+                str(self.canonical_band_name)
+            ]
         except KeyError:
             raise ConfigException(
                 f"Band {self.pq_band} does not exist in product {product.name} - cannot be used as a flag band for layer {self.layer.name}."
             ) from None
         if "flags_definition" not in meas:
-            raise ConfigException(f"Band {self.pq_band} in product {product.name} has no flags_definition in ODC - cannot be used as a flag band for layer {self.layer.name}.")
+            raise ConfigException(
+                f"Band {self.pq_band} in product {product.name} has no flags_definition in ODC - cannot be used as a flag band for layer {self.layer.name}."
+            )
         # pyre-ignore[16]
         self.flags_def: dict[str, dict[str, RAW_CFG]] = meas["flags_definition"]
         for bitname in self.ignore_info_flags:
@@ -740,8 +841,10 @@ class FlagProductBands(OWSConfigEntry):
     """
     A collection of flag bands for a layer that all come from the same product (or multi-product product collection).
     """
-    def __init__(self, flag_band: FlagBand,
-                 layer: "datacube_ows.ows_configuration.OWSNamedLayer") -> None:
+
+    def __init__(
+        self, flag_band: FlagBand, layer: "datacube_ows.ows_configuration.OWSNamedLayer"
+    ) -> None:
         """
         Class constructor, first round initialisation
 
@@ -782,9 +885,13 @@ class FlagProductBands(OWSConfigEntry):
         if fb.pq_manual_merge:
             fb.pq_manual_merge = True
         if fb.pq_fuse_func and self.fuse_func and fb.pq_fuse_func != self.fuse_func:
-            raise ConfigException(f"Fuse functions for flag bands in product set {self.product_names} do not match")
+            raise ConfigException(
+                f"Fuse functions for flag bands in product set {self.product_names} do not match"
+            )
         if fb.pq_ignore_time != self.ignore_time:
-            raise ConfigException(f"ignore_time option for flag bands in product set {self.product_names} do not match")
+            raise ConfigException(
+                f"ignore_time option for flag bands in product set {self.product_names} do not match"
+            )
         if fb.pq_fuse_func and not self.fuse_func:
             self.fuse_func = fb.pq_fuse_func
         self.declare_unready("products")
@@ -810,8 +917,11 @@ class FlagProductBands(OWSConfigEntry):
         super().make_ready(*args, **kwargs)
 
     @classmethod
-    def build_list_from_masks(cls, masks: Iterable["datacube_ows.styles.base.StyleMask"],
-                              layer: "datacube_ows.ows_configuration.OWSNamedLayer") -> list["FlagProductBands"]:
+    def build_list_from_masks(
+        cls,
+        masks: Iterable["datacube_ows.styles.base.StyleMask"],
+        layer: "datacube_ows.ows_configuration.OWSNamedLayer",
+    ) -> list["FlagProductBands"]:
         """
         Class method to instantiate a list of FlagProductBands from a list of style masks.
 
@@ -834,8 +944,11 @@ class FlagProductBands(OWSConfigEntry):
         return flag_products
 
     @classmethod
-    def build_list_from_flagbands(cls, flagbands: Iterable[OWSFlagBand],
-                                  layer: "datacube_ows.ows_configuration.OWSNamedLayer") -> list["FlagProductBands"]:
+    def build_list_from_flagbands(
+        cls,
+        flagbands: Iterable[OWSFlagBand],
+        layer: "datacube_ows.ows_configuration.OWSNamedLayer",
+    ) -> list["FlagProductBands"]:
         """
         Class method to instantiate a list of FlagProductBands from a list of OWS Flag Bands.
 
@@ -862,7 +975,9 @@ FlagSpec: TypeAlias = dict[str, bool | str]
 
 
 class AbstractMaskRule(OWSConfigEntry):
-    def __init__(self, band: str, cfg: CFG_DICT, mapper: Callable[[str], str] = lambda x: x) -> None:
+    def __init__(
+        self, band: str, cfg: CFG_DICT, mapper: Callable[[str], str] = lambda x: x
+    ) -> None:
         super().__init__(cfg)
         self.band = mapper(band)
         self.parse_rule_spec(cfg)
@@ -872,6 +987,7 @@ class AbstractMaskRule(OWSConfigEntry):
         return "a mask rule"
 
     VALUES_LABEL = "values"
+
     def parse_rule_spec(self, cfg: CFG_DICT) -> None:
         self.flags: list[FlagSpec] | FlagSpec | None = None
         self.or_flags: bool | list[bool] = False
@@ -881,7 +997,8 @@ class AbstractMaskRule(OWSConfigEntry):
             flags = cast(FlagSpec, cfg["flags"])
             if "or" in flags and "and" in flags:
                 raise ConfigException(
-                    f"ValueMap rule in {self.context} combines 'and' and 'or' rules")
+                    f"ValueMap rule in {self.context} combines 'and' and 'or' rules"
+                )
             if "or" in flags:
                 self.or_flags = True
                 flags = cast(FlagSpec, flags["or"])
@@ -905,10 +1022,12 @@ class AbstractMaskRule(OWSConfigEntry):
 
         if not self.flags and not self.values:
             raise ConfigException(
-                f"Mask rule in {self.context} must have a non-empty 'flags' or 'values' section.")
+                f"Mask rule in {self.context} must have a non-empty 'flags' or 'values' section."
+            )
         if self.flags and self.values:
             raise ConfigException(
-                f"Mask rule in {self.context} has both a 'flags' and a 'values' section - choose one.")
+                f"Mask rule in {self.context} has both a 'flags' and a 'values' section - choose one."
+            )
 
     def create_mask(self, data: DataArray) -> DataArray | None:
         """
@@ -936,7 +1055,7 @@ class AbstractMaskRule(OWSConfigEntry):
         else:
             mask = make_mask(data, **cast(CFG_DICT, self.flags))
         if mask is not None and self.invert:
-            mask = ~mask # pylint: disable=invalid-unary-operand-type
+            mask = ~mask  # pylint: disable=invalid-unary-operand-type
         return mask
 
 
@@ -946,10 +1065,12 @@ class FunctionWrapper:
     Function wrapper for configurable functional elements
     """
 
-    def __init__(self,
-                 product_or_style_cfg: OWSExtensibleConfigEntry | None,
-                 func_cfg: str | CFG_DICT | F,
-                 stand_alone: bool = False) -> None:
+    def __init__(
+        self,
+        product_or_style_cfg: OWSExtensibleConfigEntry | None,
+        func_cfg: str | CFG_DICT | F,
+        stand_alone: bool = False,
+    ) -> None:
         """
 
         :param product_or_style_cfg: An instance of either NamedLayer or Style,
@@ -962,7 +1083,8 @@ class FunctionWrapper:
         if callable(func_cfg):
             if not stand_alone:
                 raise ConfigException(
-                    "Directly including callable objects in configuration is no longer supported. Please reference callables by fully qualified name.")
+                    "Directly including callable objects in configuration is no longer supported. Please reference callables by fully qualified name."
+                )
             self._func: Callable = func_cfg
             self._args: list[RAW_CFG] = []
             self._kwargs: CFG_DICT = {}
@@ -979,25 +1101,30 @@ class FunctionWrapper:
                 self._func = func_cfg["function"]
             elif callable(func_cfg["function"]):
                 raise ConfigException(
-                    "Directly including callable objects in configuration is no longer supported. Please reference callables by fully qualified name.")
+                    "Directly including callable objects in configuration is no longer supported. Please reference callables by fully qualified name."
+                )
             else:
                 self._func = get_function(cast(str, func_cfg["function"]))
             self._args = cast(list[RAW_CFG], func_cfg.get("args", []))
             self._kwargs = cast(CFG_DICT, func_cfg.get("kwargs", {})).copy()
             self.pass_layer_cfg = bool(func_cfg.get("pass_layer_cfg", False))
             if "pass_product_cfg" in func_cfg:
-                _LOG.warning("WARNING: pass_product_cfg in function wrapper definitions has been renamed "
-                             "'mapped_bands'.  Please update your config accordingly")
+                _LOG.warning(
+                    "WARNING: pass_product_cfg in function wrapper definitions has been renamed "
+                    "'mapped_bands'.  Please update your config accordingly"
+                )
             if func_cfg.get("mapped_bands", func_cfg.get("pass_product_cfg", False)):
                 if hasattr(product_or_style_cfg, "band_idx"):
                     # NamedLayer
                     from datacube_ows.ows_configuration import OWSNamedLayer
+
                     named_layer = cast(OWSNamedLayer, product_or_style_cfg)
                     b_idx = named_layer.band_idx
                     self.band_mapper = b_idx.band
                 else:
                     # Style
                     from datacube_ows.styles import StyleDef
+
                     style = cast(StyleDef, product_or_style_cfg)
                     b_idx = style.product.band_idx
                     delocaliser = style.local_band
@@ -1024,7 +1151,7 @@ class FunctionWrapper:
             calling_kwargs["band_mapper"] = self.band_mapper
 
         if self.pass_layer_cfg:
-            calling_kwargs['layer_cfg'] = self.style_or_layer_cfg
+            calling_kwargs["layer_cfg"] = self.style_or_layer_cfg
 
         return self._func(*calling_args, **calling_kwargs)
 
@@ -1036,7 +1163,7 @@ def get_function(func: F | str) -> F:
     :return: a Callable object, or None
     """
     if func is not None and not callable(func):
-        mod_name, func_name = func.rsplit('.', 1)
+        mod_name, func_name = func.rsplit(".", 1)
         try:
             mod = import_module(mod_name)
             func = getattr(mod, func_name)

--- a/datacube_ows/data.py
+++ b/datacube_ows/data.py
@@ -32,8 +32,12 @@ from datacube_ows.wms_utils import GetMapParameters
 _LOG: logging.Logger = logging.getLogger(__name__)
 
 
-def user_date_sorter(layer: OWSNamedLayer, odc_dates: list[datetime],
-                     geometry: geom.Geometry, user_dates: list[datetime]) -> xarray.DataArray:
+def user_date_sorter(
+    layer: OWSNamedLayer,
+    odc_dates: list[datetime],
+    geometry: geom.Geometry,
+    user_dates: list[datetime],
+) -> xarray.DataArray:
     # TODO: Make more elegant.  Just a little bit elegant would do.
     result = []
     tz = tz_for_geometry(geometry) if layer.time_resolution.is_solar() else None
@@ -45,19 +49,15 @@ def user_date_sorter(layer: OWSNamedLayer, odc_dates: list[datetime],
             norm_date = solar_date(ts, tz)
             return norm_date == user_date
         if time_res.is_summary():
-            norm_date = date(ts.year,
-                             ts.month,
-                             ts.day)
+            norm_date = date(ts.year, ts.month, ts.day)
             return norm_date == user_date
-        norm_date = datetime(ts.year,
-                             ts.month,
-                             ts.day,
-                             ts.hour,
-                             ts.minute,
-                             ts.second,
-                             tzinfo=ts.tzinfo)
+        norm_date = datetime(
+            ts.year, ts.month, ts.day, ts.hour, ts.minute, ts.second, tzinfo=ts.tzinfo
+        )
         user_date = default_to_utc(user_date)
-        return user_date >= norm_date and user_date < norm_date + timedelta(hours=23, minutes=59, seconds=59)
+        return user_date >= norm_date and user_date < norm_date + timedelta(
+            hours=23, minutes=59, seconds=59
+        )
 
     for odc_date in odc_dates:
         for idx, user_date in enumerate(user_dates):
@@ -66,10 +66,7 @@ def user_date_sorter(layer: OWSNamedLayer, odc_dates: list[datetime],
                 break
     npresult = numpy.array(result, dtype="uint8")
     return xarray.DataArray(
-        npresult,
-        coords={"time": odc_dates},
-        dims=["time"],
-        name="user_date_sorter"
+        npresult, coords={"time": odc_dates}, dims=["time"], name="user_date_sorter"
     )
 
 
@@ -89,13 +86,22 @@ def get_map(args: dict[str, str]) -> FlaskResponse:
     else:
         mdh = params.style.get_multi_date_handler(n_dates)
         if mdh is None:
-            raise WMSException(f"Style {params.style.name} does not support GetMap "
-                               f"requests with {n_dates} dates",
-                               WMSException.INVALID_DIMENSION_VALUE, locator="Time parameter")
+            raise WMSException(
+                f"Style {params.style.name} does not support GetMap "
+                f"requests with {n_dates} dates",
+                WMSException.INVALID_DIMENSION_VALUE,
+                locator="Time parameter",
+            )
     qprof["n_dates"] = n_dates
     try:
         # Tiling.
-        stacker = DataStacker(params.layer, params.geobox, params.times, params.resampling, style=params.style)  # type: ignore[arg-type]
+        stacker = DataStacker(
+            params.layer,
+            params.geobox,
+            params.times,  # type: ignore[arg-type]
+            params.resampling,
+            style=params.style,
+        )
         qprof["zoom_factor"] = params.zf
         qprof.start_event("count-datasets")
         n_datasets = stacker.n_datasets()
@@ -104,7 +110,9 @@ def get_map(args: dict[str, str]) -> FlaskResponse:
         qprof["zoom_level_base"] = params.resources.base_zoom_level
         qprof["zoom_level_adjusted"] = params.resources.load_adjusted_zoom_level
         try:
-            params.layer.resource_limits.check_wms(n_datasets, params.zf, params.resources)
+            params.layer.resource_limits.check_wms(
+                n_datasets, params.zf, params.resources
+            )
         except ResourceLimited as e:
             stacker.resource_limited = True
             qprof["resource_limited"] = str(e)
@@ -117,7 +125,7 @@ def get_map(args: dict[str, str]) -> FlaskResponse:
                     "datasets": [
                         [f"{ds.id} ({ds.product.name})" for ds in tdss]
                         for tdss in dsxr.values
-                    ]
+                    ],
                 }
                 qprof["datasets"].append(query_res)
         if stacker.resource_limited and not params.layer.low_res_product_names:
@@ -133,7 +141,8 @@ def get_map(args: dict[str, str]) -> FlaskResponse:
                 params.geobox,
                 extent,
                 params.layer.resource_limits.zoom_fill,
-                params.layer)
+                params.layer,
+            )
             qprof.end_event("write")
         elif n_datasets == 0:
             qprof["write_action"] = "No datasets: Write Empty"
@@ -149,7 +158,9 @@ def get_map(args: dict[str, str]) -> FlaskResponse:
                 if not dss.any():
                     _LOG.warning("Flag band %s returned no data", str(flagband))
                 if len(dss.time) != n_dates and flagband.main:
-                    qprof["write_action"] = f"{n_dates} requested, only {len(dss.time)} found - returning empty image"
+                    qprof["write_action"] = (
+                        f"{n_dates} requested, only {len(dss.time)} found - returning empty image"
+                    )
                     raise EmptyResponse()
             qprof.end_event("fetch-datasets")
             _LOG.debug("load start %s %s", datetime.now().time(), args["requestid"])
@@ -184,11 +195,8 @@ def get_map(args: dict[str, str]) -> FlaskResponse:
                     td_ext_mask = xarray.DataArray(td_ext_mask_man)
                 if td_ext_mask is None:
                     td_ext_mask = xarray.DataArray(
-                                        ~numpy.zeros(
-                                                    td[band].values.shape,
-                                                    dtype=numpy.bool_
-                                        ),
-                                        td[band].coords
+                        ~numpy.zeros(td[band].values.shape, dtype=numpy.bool_),
+                        td[band].coords,
                     )
                 td_masks.append(td_ext_mask)
             extent_mask = xarray.concat(td_masks, dim=data.time)
@@ -196,10 +204,11 @@ def get_map(args: dict[str, str]) -> FlaskResponse:
             qprof["write_action"] = "Write Data"
             if mdh and mdh.preserve_user_date_order:
                 sorter = user_date_sorter(
-                                          params.layer,
-                                          data.time.values,
-                                          params.geobox.geographic_extent,
-                                          params.times)  # type: ignore[arg-type]
+                    params.layer,
+                    data.time.values,
+                    params.geobox.geographic_extent,
+                    params.times,  # type: ignore[arg-type]
+                )
                 data = data.sortby(sorter)
                 extent_mask = extent_mask.sortby(sorter)
 
@@ -211,12 +220,21 @@ def get_map(args: dict[str, str]) -> FlaskResponse:
 
     if params.ows_stats:
         return json_response(qprof.profile())
-    return png_response(body, extra_headers=params.layer.resource_limits.wms_cache_rules.cache_headers(n_datasets))
+    return png_response(
+        body,
+        extra_headers=params.layer.resource_limits.wms_cache_rules.cache_headers(
+            n_datasets
+        ),
+    )
 
 
 @log_call
-def _write_png(data: xarray.Dataset, style: StyleDef, extent_mask: xarray.DataArray,
-               qprof: QueryProfiler) -> bytes:
+def _write_png(
+    data: xarray.Dataset,
+    style: StyleDef,
+    extent_mask: xarray.DataArray,
+    qprof: QueryProfiler,
+) -> bytes:
     qprof.start_event("combine-masks")
     mask = style.to_mask(data, extent_mask)
     qprof.end_event("combine-masks")
@@ -228,7 +246,9 @@ def _write_png(data: xarray.Dataset, style: StyleDef, extent_mask: xarray.DataAr
     # Verified using : https://docs.dea.ga.gov.au/notebooks/Frequently_used_code/Animated_timeseries.html
     mdh = style.get_multi_date_handler(img_data)
     if mdh:
-        image = xarray_image_as_png(img_data, loop_over='time', animate=True, frame_duration=mdh.frame_duration)
+        image = xarray_image_as_png(
+            img_data, loop_over="time", animate=True, frame_duration=mdh.frame_duration
+        )
     else:
         image = xarray_image_as_png(img_data)
     qprof.end_event("write")
@@ -238,38 +258,41 @@ def _write_png(data: xarray.Dataset, style: StyleDef, extent_mask: xarray.DataAr
 @log_call
 def _write_empty(geobox: GeoBox) -> bytes:
     with MemoryFile() as memfile:
-        with memfile.open(driver='PNG',
-                          width=geobox.width,
-                          height=geobox.height,
-                          count=1,
-                          transform=None,
-                          nodata=0,
-                          dtype='uint8'):
+        with memfile.open(
+            driver="PNG",
+            width=geobox.width,
+            height=geobox.height,
+            count=1,
+            transform=None,
+            nodata=0,
+            dtype="uint8",
+        ):
             pass
         return memfile.read()
 
 
 @log_call
-def _write_polygon(geobox: GeoBox, polygon: geom.Geometry, zoom_fill: list[int], layer: OWSNamedLayer) -> bytes:
+def _write_polygon(
+    geobox: GeoBox, polygon: geom.Geometry, zoom_fill: list[int], layer: OWSNamedLayer
+) -> bytes:
     geobox_ext = geobox.extent
     if geobox_ext.within(polygon):
         data = numpy.full([geobox.height, geobox.width], fill_value=1, dtype="uint8")
     else:
         data = numpy.zeros([geobox.height, geobox.width], dtype="uint8")
-        data = rasterize(shapes=[polygon],
-                          fill=0,
-                          default_value=2,
-                          out=data,
-                          transform=geobox.affine
-                        )
+        data = rasterize(
+            shapes=[polygon], fill=0, default_value=2, out=data, transform=geobox.affine
+        )
     with MemoryFile() as memfile:
-        with memfile.open(driver='PNG',
-                          width=geobox.width,
-                          height=geobox.height,
-                          count=4,
-                          transform=None,
-                          nodata=0,
-                          dtype='uint8') as thing:
+        with memfile.open(
+            driver="PNG",
+            width=geobox.width,
+            height=geobox.height,
+            count=4,
+            transform=None,
+            nodata=0,
+            dtype="uint8",
+        ) as thing:
             for idx, fill in enumerate(zoom_fill, start=1):
                 thing.write_band(idx, data * fill)
         return memfile.read()

--- a/datacube_ows/feature_info.py
+++ b/datacube_ows/feature_info.py
@@ -31,9 +31,12 @@ from datacube_ows.wms_utils import GetFeatureInfoParameters, img_coords_to_geopo
 
 
 @log_call
-def get_s3_browser_uris(datasets: dict[ProductBandQuery, xarray.DataArray],
-                        pt: geom.Geometry | None = None,
-                        s3url: str = "", s3bucket: str = "") -> set[str]:
+def get_s3_browser_uris(
+    datasets: dict[ProductBandQuery, xarray.DataArray],
+    pt: geom.Geometry | None = None,
+    s3url: str = "",
+    s3bucket: str = "",
+) -> set[str]:
     uris = []
     last_crs = None
     for pbq, dss in datasets.items():
@@ -55,19 +58,24 @@ def get_s3_browser_uris(datasets: dict[ProductBandQuery, xarray.DataArray],
     uris = list(chain.from_iterable(uris))
     unique_uris = set(uris)
 
-    regex = re.compile(r"s3:\/\/(?P<bucket>[a-zA-Z0-9_\-\.]+)\/(?P<prefix>[\S]+)/[a-zA-Z0-9_\-\.]+.(yaml|json)")
+    regex = re.compile(
+        r"s3:\/\/(?P<bucket>[a-zA-Z0-9_\-\.]+)\/(?P<prefix>[\S]+)/[a-zA-Z0-9_\-\.]+.(yaml|json)"
+    )
 
     # convert to browsable link
     def convert(uri: str) -> str:
-        uri_format = "http://{bucket}.s3-website-ap-southeast-2.amazonaws.com/?prefix={prefix}"
+        uri_format = (
+            "http://{bucket}.s3-website-ap-southeast-2.amazonaws.com/?prefix={prefix}"
+        )
         uri_format_prod = str(s3url) + "/?prefix={prefix}"
         result = regex.match(uri)
         if result is not None:
             if result.group("bucket") == str(s3bucket):
                 new_uri = uri_format_prod.format(prefix=result.group("prefix"))
             else:
-                new_uri = uri_format.format(bucket=result.group("bucket"),
-                                            prefix=result.group("prefix"))
+                new_uri = uri_format.format(
+                    bucket=result.group("bucket"), prefix=result.group("prefix")
+                )
         else:
             new_uri = uri
         return new_uri
@@ -75,9 +83,10 @@ def get_s3_browser_uris(datasets: dict[ProductBandQuery, xarray.DataArray],
     return {convert(uri) for uri in unique_uris}
 
 
-
 @log_call
-def _make_band_dict(prod_cfg: OWSNamedLayer, pixel_dataset: xarray.Dataset) -> dict[str, dict[str, bool | str] | str]:
+def _make_band_dict(
+    prod_cfg: OWSNamedLayer, pixel_dataset: xarray.Dataset
+) -> dict[str, dict[str, bool | str] | str]:
     band_dict: dict[str, dict[str, bool | str] | str] = {}
     for k, _ in pixel_dataset.data_vars.items():
         band_val = pixel_dataset[k].item()
@@ -86,18 +95,18 @@ def _make_band_dict(prod_cfg: OWSNamedLayer, pixel_dataset: xarray.Dataset) -> d
             try:
                 flag_dict = mask_to_dict(flag_def, band_val)
             except TypeError:
-                logging.warning('Working around for float bands')
+                logging.warning("Working around for float bands")
                 flag_dict = mask_to_dict(flag_def, int(band_val))
             ret_val: dict[str, bool | str] = {}
             for flag, val in flag_dict.items():
                 if not val:
                     continue
-                ret_val[flag_def[flag].get('description', flag)] = val
+                ret_val[flag_def[flag].get("description", flag)] = val
             band_dict[k] = ret_val
         else:
             try:
                 band_lbl = prod_cfg.band_idx.band_label(k)
-                assert k is not None   # for type checker
+                assert k is not None  # for type checker
                 if band_val == pixel_dataset[k].nodata or numpy.isnan(band_val):
                     band_dict[band_lbl] = "n/a"
                 else:
@@ -123,7 +132,10 @@ def _make_derived_band_dict(
         if not style.include_in_feature_info:
             continue
 
-        if any(pixel_dataset[band] == pixel_dataset[band].nodata for band in style.needed_bands):
+        if any(
+            pixel_dataset[band] == pixel_dataset[band].nodata
+            for band in style.needed_bands
+        ):
             continue
 
         value = style.index_function(pixel_dataset).item()
@@ -151,7 +163,8 @@ def feature_info(args: dict[str, str]) -> FlaskResponse:
     else:
         # Make a 1x1 pixel geobox
         geo_point_geobox = GeoBox.from_geopolygon(
-            geo_point, params.geobox.resolution, crs=params.geobox.crs)
+            geo_point, params.geobox.resolution, crs=params.geobox.crs
+        )
     stacker = DataStacker(params.layer, geo_point_geobox, params.times)  # type: ignore[arg-type]
     # --- Begin code section requiring datacube.
     cfg = get_config()
@@ -162,16 +175,15 @@ def feature_info(args: dict[str, str]) -> FlaskResponse:
     v_coord = cast(str, cfg.published_CRSs[params.crsid]["vertical_coord"])
     s3_bucket = cfg.s3_bucket
     s3_url = cfg.s3_url
-    isel_kwargs = {
-        h_coord: 0,
-        v_coord: 0
-    }
+    isel_kwargs = {h_coord: 0, v_coord: 0}
     if any(all_time_datasets):
         # Group datasets by time, load only datasets that match the idx_date
         global_info_written = False
         feature_json["data"] = []
         fi_date_index: dict[datetime, RAW_CFG] = {}
-        time_datasets = stacker.datasets(all_flag_bands=True, point=geo_point_geobox.extent)
+        time_datasets = stacker.datasets(
+            all_flag_bands=True, point=geo_point_geobox.extent
+        )
         data = stacker.data(time_datasets, skip_corrections=True)
         if data is not None:
             for dt in data.time.values:
@@ -206,7 +218,9 @@ def feature_info(args: dict[str, str]) -> FlaskResponse:
                 assert ds is not None
                 if params.layer.multi_product:
                     if "platform" in ds.metadata_doc:
-                        date_info["source_product"] = f"{ds.product.name} ({ds.metadata_doc['platform']['code']})"
+                        date_info["source_product"] = (
+                            f"{ds.product.name} ({ds.metadata_doc['platform']['code']})"
+                        )
                     else:
                         date_info["source_product"] = ds.product.name
 
@@ -218,10 +232,16 @@ def feature_info(args: dict[str, str]) -> FlaskResponse:
                 if params.layer.time_resolution.is_summary():
                     date_info["time"] = ds.time.begin.strftime("%Y-%m-%d")
                 else:
-                    date_info["time"] = dataset_center_time(ds).strftime("%Y-%m-%d %H:%M:%S %Z")
+                    date_info["time"] = dataset_center_time(ds).strftime(
+                        "%Y-%m-%d %H:%M:%S %Z"
+                    )
                 # Collect raw band values for pixel and derived bands from styles
-                date_info["bands"] = cast(RAW_CFG, _make_band_dict(params.layer, pixel_ds))
-                derived_band_dict = cast(RAW_CFG, _make_derived_band_dict(pixel_ds, params.layer.style_index))
+                date_info["bands"] = cast(
+                    RAW_CFG, _make_band_dict(params.layer, pixel_ds)
+                )
+                derived_band_dict = cast(
+                    RAW_CFG, _make_derived_band_dict(pixel_ds, params.layer.style_index)
+                )
                 if derived_band_dict:
                     date_info["band_derived"] = derived_band_dict
                 # Add any legacy custom-defined fields.
@@ -247,16 +267,16 @@ def feature_info(args: dict[str, str]) -> FlaskResponse:
                         date_info[k] = f(pixel_ds, ds)
 
                 cast(list[RAW_CFG], feature_json["data"]).append(date_info)
-                fi_date_index[dt] = cast(dict[str, list[RAW_CFG]], feature_json)["data"][-1]
+                fi_date_index[dt] = cast(dict[str, list[RAW_CFG]], feature_json)[
+                    "data"
+                ][-1]
             # Multidate custom includes reflect all selected times on multidate requests,
             # and are added as an extra all-time data record after the date ones.
             times = list(data.time.values)
             if len(times) > 1 and params.style is not None:
                 mdh = params.style.get_multi_date_handler(times)
                 if mdh is not None:
-                    date_info = {
-                        "time": "all"
-                    }
+                    date_info = {"time": "all"}
                     for k, f in mdh.feature_info_includes.items():
                         # Function signature: pass in:
                         # * a multi-date single pixel (1x1xn) multiband xarray Dataset,
@@ -274,14 +294,21 @@ def feature_info(args: dict[str, str]) -> FlaskResponse:
                     # tolist() converts a numpy datetime64 to a python datatime
                     dt = Timestamp(stacker.group_by.group_by_func(ds)).to_pydatetime()
                     if params.layer.time_resolution.is_subday():
-                        cast(list[RAW_CFG], feature_json["data_available_for_dates"]).append(dt.isoformat())
+                        cast(
+                            list[RAW_CFG], feature_json["data_available_for_dates"]
+                        ).append(dt.isoformat())
                     else:
-                        cast(list[RAW_CFG], feature_json["data_available_for_dates"]).append(dt.strftime("%Y-%m-%d"))
+                        cast(
+                            list[RAW_CFG], feature_json["data_available_for_dates"]
+                        ).append(dt.strftime("%Y-%m-%d"))
                     break
         if time_datasets:
             feature_json["data_links"] = cast(
                 RAW_CFG,
-                sorted(get_s3_browser_uris(time_datasets, pt_native, s3_url, s3_bucket)))
+                sorted(
+                    get_s3_browser_uris(time_datasets, pt_native, s3_url, s3_bucket)
+                ),
+            )
         else:
             feature_json["data_links"] = []
         if params.layer.feature_info_include_utc_dates:
@@ -296,7 +323,8 @@ def feature_info(args: dict[str, str]) -> FlaskResponse:
                     else:
                         unsorted_dates.append(ds.time.begin.strftime("%Y-%m-%d"))
             feature_json["data_available_for_utc_dates"] = sorted(
-                d.center_time.strftime("%Y-%m-%d") for d in all_time_datasets)
+                d.center_time.strftime("%Y-%m-%d") for d in all_time_datasets
+            )
 
     result: CFG_DICT = {
         "type": "FeatureCollection",
@@ -306,10 +334,10 @@ def feature_info(args: dict[str, str]) -> FlaskResponse:
                 "properties": feature_json,
                 "geometry": {
                     "type": "Point",
-                    "coordinates": geo_point.coords[0]  # type: ignore[dict-item]
-                }
+                    "coordinates": geo_point.coords[0],  # type: ignore[dict-item]
+                },
             }
-        ]
+        ],
     }
     if params.format == "text/html":
         return html_json_response(result, cfg)

--- a/datacube_ows/gunicorn_config.py
+++ b/datacube_ows/gunicorn_config.py
@@ -4,8 +4,8 @@
 # Copyright (c) 2017-2024 OWS Contributors
 # SPDX-License-Identifier: Apache-2.0
 
-"""Gunicorn config for Prometheus internal metrics
-"""
+"""Gunicorn config for Prometheus internal metrics"""
+
 import os
 
 from prometheus_flask_exporter.multiprocess import GunicornInternalPrometheusMetrics

--- a/datacube_ows/http_utils.py
+++ b/datacube_ows/http_utils.py
@@ -20,7 +20,6 @@ if TYPE_CHECKING:
 FlaskResponse = tuple[str | bytes, int, dict[str, str]]
 
 
-
 def resp_headers(d: dict[str, str]) -> dict[str, str]:
     """
     Take a dictionary of http response headers and all required response headers from the configuration.
@@ -29,6 +28,7 @@ def resp_headers(d: dict[str, str]) -> dict[str, str]:
     :return:
     """
     from datacube_ows.ows_configuration import get_config
+
     return get_config().response_headers(d)
 
 
@@ -64,8 +64,9 @@ def get_service_base_url(allowed_urls: list[str] | str, request_url: str) -> str
     return url.rstrip("/")
 
 
-def capture_headers(req: Request,
-                    args_dict: dict[str, str | None]) -> dict[str, str | None]:
+def capture_headers(
+    req: Request, args_dict: dict[str, str | None]
+) -> dict[str, str | None]:
     """
     Capture significant flask metadata into the args dictionary
 
@@ -73,11 +74,11 @@ def capture_headers(req: Request,
     :param args_dict: A Flask args dictionary
     :return:
     """
-    args_dict['referer'] = req.headers.get('Referer', None)
-    args_dict['origin'] = req.headers.get('Origin', None)
-    args_dict['requestid'] = req.environ.get("FLASK_REQUEST_ID")
-    args_dict['host'] = req.headers.get('Host', None)
-    args_dict['url_root'] = req.url_root
+    args_dict["referer"] = req.headers.get("Referer", None)
+    args_dict["origin"] = req.headers.get("Origin", None)
+    args_dict["requestid"] = req.environ.get("FLASK_REQUEST_ID")
+    args_dict["host"] = req.headers.get("Host", None)
+    args_dict["url_root"] = req.url_root
 
     return args_dict
 
@@ -106,14 +107,22 @@ def lower_get_args() -> dict[str, str]:
 
 def json_response(result: CFG_DICT, cfg: Optional["OWSConfig"] = None) -> FlaskResponse:
     from datacube_ows.ows_configuration import get_config
+
     if not cfg:
         cfg = get_config()
     assert cfg is not None  # for type checker
-    return json.dumps(result), 200, cfg.response_headers({"Content-Type": "application/json"})
+    return (
+        json.dumps(result),
+        200,
+        cfg.response_headers({"Content-Type": "application/json"}),
+    )
 
 
-def html_json_response(result: CFG_DICT, cfg: Optional["OWSConfig"] = None) -> FlaskResponse:
+def html_json_response(
+    result: CFG_DICT, cfg: Optional["OWSConfig"] = None
+) -> FlaskResponse:
     from datacube_ows.ows_configuration import get_config
+
     if not cfg:
         cfg = get_config()
     assert cfg is not None  # for type checker
@@ -121,8 +130,13 @@ def html_json_response(result: CFG_DICT, cfg: Optional["OWSConfig"] = None) -> F
     return html_content, 200, cfg.response_headers({"Content-Type": "text/html"})
 
 
-def png_response(body: bytes, cfg: Optional["OWSConfig"] = None, extra_headers: Mapping[str, str] | None = None) -> FlaskResponse:
+def png_response(
+    body: bytes,
+    cfg: Optional["OWSConfig"] = None,
+    extra_headers: Mapping[str, str] | None = None,
+) -> FlaskResponse:
     from datacube_ows.ows_configuration import get_config
+
     if not cfg:
         cfg = get_config()
     assert cfg is not None  # For type checker

--- a/datacube_ows/index/api.py
+++ b/datacube_ows/index/api.py
@@ -23,6 +23,7 @@ TYPE_CHECKING = False
 if TYPE_CHECKING:
     from datacube_ows.ows_configuration import OWSNamedLayer
 
+
 class AbortRun(Exception):
     pass
 
@@ -44,7 +45,9 @@ class LayerSignature:
 
 
 DateOrDateTime: TypeAlias = datetime | date
-TimeSearchTerm: TypeAlias = tuple[datetime, datetime] | tuple[date, date] | DateOrDateTime
+TimeSearchTerm: TypeAlias = (
+    tuple[datetime, datetime] | tuple[date, date] | DateOrDateTime
+)
 
 
 class CoordRange(NamedTuple):
@@ -53,7 +56,13 @@ class CoordRange(NamedTuple):
 
 
 class LayerExtent:
-    def __init__(self, lat: CoordRange, lon: CoordRange, times: list[DateOrDateTime], bboxes: CFG_DICT) -> None:
+    def __init__(
+        self,
+        lat: CoordRange,
+        lon: CoordRange,
+        times: list[DateOrDateTime],
+        bboxes: CFG_DICT,
+    ) -> None:
         self.lat = lat
         self.lon = lon
         self.times = times
@@ -68,73 +77,71 @@ class OWSAbstractIndex(ABC):
 
     # method to check database access (for ping op)
     @abstractmethod
-    def check_db_access(self, dc: Datacube) -> bool:
-        ...
+    def check_db_access(self, dc: Datacube) -> bool: ...
 
     # method to delete obsolete schemas etc.
     @abstractmethod
-    def cleanup_schema(self, dc: Datacube):
-        ...
+    def cleanup_schema(self, dc: Datacube): ...
 
     # Schema creation method
     @abstractmethod
-    def create_schema(self, dc: Datacube):
-        ...
+    def create_schema(self, dc: Datacube): ...
 
     # Permission management method
     @abstractmethod
-    def grant_perms(self, dc: Datacube, role: str, read_only: bool = False):
-        ...
+    def grant_perms(self, dc: Datacube, role: str, read_only: bool = False): ...
 
     # Spatiotemporal index update method (e.g. refresh materialised views)
     @abstractmethod
-    def update_geotemporal_index(self, dc: Datacube):
-        ...
+    def update_geotemporal_index(self, dc: Datacube): ...
 
     # Range table update method
     @abstractmethod
-    def create_range_entry(self, layer: "OWSNamedLayer", cache: dict[LayerSignature, list[str]]) -> None:
-        ...
+    def create_range_entry(
+        self, layer: "OWSNamedLayer", cache: dict[LayerSignature, list[str]]
+    ) -> None: ...
 
     # Range table read method
     @abstractmethod
-    def get_ranges(self, layer: "OWSNamedLayer") -> LayerExtent | None:
-        ...
+    def get_ranges(self, layer: "OWSNamedLayer") -> LayerExtent | None: ...
 
     # Spatiotemporal search methods
     @abstractmethod
-    def ds_search(self,
-                  layer: "OWSNamedLayer",
-                  times: Iterable[TimeSearchTerm] | None = None,
-                  geom: Geometry | None = None,
-                  products: Iterable[Product] | None = None
-                  ) -> Iterable[Dataset]:
-        ...
+    def ds_search(
+        self,
+        layer: "OWSNamedLayer",
+        times: Iterable[TimeSearchTerm] | None = None,
+        geom: Geometry | None = None,
+        products: Iterable[Product] | None = None,
+    ) -> Iterable[Dataset]: ...
 
-    def dsid_search(self,
-                    layer: "OWSNamedLayer",
-                    times: Iterable[TimeSearchTerm] | None = None,
-                    geom: Geometry | None = None,
-                    products: Iterable[Product] | None = None
-                    ) -> Iterable[UUID]:
+    def dsid_search(
+        self,
+        layer: "OWSNamedLayer",
+        times: Iterable[TimeSearchTerm] | None = None,
+        geom: Geometry | None = None,
+        products: Iterable[Product] | None = None,
+    ) -> Iterable[UUID]:
         for ds in self.ds_search(layer, times, geom, products):
             yield ds.id
 
-    def count(self,
-              layer: "OWSNamedLayer",
-              times: Iterable[TimeSearchTerm] | None = None,
-              geom: Geometry | None = None,
-              products: Iterable[Product] | None = None
-              ) -> int:
+    def count(
+        self,
+        layer: "OWSNamedLayer",
+        times: Iterable[TimeSearchTerm] | None = None,
+        geom: Geometry | None = None,
+        products: Iterable[Product] | None = None,
+    ) -> int:
         return len(list(self.dsid_search(layer, times, geom, products)))
 
-    def extent(self,
-               layer: "OWSNamedLayer",
-               times: Iterable[TimeSearchTerm] | None = None,
-               geom: Geometry | None = None,
-               products: Iterable[Product] | None = None,
-               crs: CRS | None = None
-               ) -> Geometry | None:
+    def extent(
+        self,
+        layer: "OWSNamedLayer",
+        times: Iterable[TimeSearchTerm] | None = None,
+        geom: Geometry | None = None,
+        products: Iterable[Product] | None = None,
+        crs: CRS | None = None,
+    ) -> Geometry | None:
         geom = self._prep_geom(layer, geom)
         if crs is None:
             crs = CRS("epsg:4326")
@@ -154,7 +161,9 @@ class OWSAbstractIndex(ABC):
         return ext
 
     @staticmethod
-    def _prep_geom(layer: "OWSNamedLayer", any_geom: Geometry | None) -> Geometry | None:
+    def _prep_geom(
+        layer: "OWSNamedLayer", any_geom: Geometry | None
+    ) -> Geometry | None:
         # Prepare a Geometry for geospatial search
         # Perhaps Core can be updated so this is not needed?
         if any_geom is None:
@@ -173,7 +182,7 @@ class OWSAbstractIndex(ABC):
                     (x, y + delta_y),
                     (x, y),
                 ),
-                crs=layer.native_CRS
+                crs=layer.native_CRS,
             )
         if any_geom.geom_type in ("MultiPoint", "LineString", "MultiLineString"):
             # Not a point, but not a polygon or multipolygon?  Expand to polygon by taking convex hull
@@ -185,22 +194,25 @@ class OWSAbstractIndex(ABC):
 class OWSAbstractIndexDriver(ABC):
     @classmethod
     @abstractmethod
-    def ows_index_class(cls) -> type[OWSAbstractIndex]:
-        ...
+    def ows_index_class(cls) -> type[OWSAbstractIndex]: ...
 
     @classmethod
     @abstractmethod
-    def ows_index(cls) -> OWSAbstractIndex:
-        ...
+    def ows_index(cls) -> OWSAbstractIndex: ...
 
 
 def ows_index(odc: Datacube | AbstractIndex) -> OWSAbstractIndex:
     index = odc if isinstance(odc, AbstractIndex) else odc.index
     env = index.environment
     from datacube_ows.index.driver import ows_index_driver_by_name
-    idx_drv_name = "postgres" if env.index_driver in ('default', 'legacy') else env.index_driver
+
+    idx_drv_name = (
+        "postgres" if env.index_driver in ("default", "legacy") else env.index_driver
+    )
     ows_index_driver = ows_index_driver_by_name(idx_drv_name)
     if ows_index_driver is None:
-        raise ConfigException(f"ODC Environment {env._name} uses ODC index driver {env.index_driver} which is "
-                              f"not (yet) supported by OWS.")
+        raise ConfigException(
+            f"ODC Environment {env._name} uses ODC index driver {env.index_driver} which is "
+            f"not (yet) supported by OWS."
+        )
     return ows_index_driver.ows_index()

--- a/datacube_ows/index/driver.py
+++ b/datacube_ows/index/driver.py
@@ -19,6 +19,7 @@ cache_lock = Lock()
 class OWSIndexDriverCache:
     _instance = None
     _initialised = False
+
     def __new__(cls, *args, **kwargs) -> "OWSIndexDriverCache":
         if cls._instance is None:
             with cache_lock:
@@ -31,6 +32,7 @@ class OWSIndexDriverCache:
             if not self._initialised:
                 self._initialised = True
                 self._drivers = load_drivers(group)
+
     def __call__(self, name: str) -> Optional["OWSAbstractIndexDriver"]:
         """
         :returns: None if driver with a given name is not found
@@ -41,8 +43,7 @@ class OWSIndexDriverCache:
         return self._drivers.get(name, None)
 
     def drivers(self) -> list[str]:
-        """ Returns list of driver names
-        """
+        """Returns list of driver names"""
         return list(self._drivers.keys())
 
 

--- a/datacube_ows/index/postgis/api.py
+++ b/datacube_ows/index/postgis/api.py
@@ -42,7 +42,8 @@ class OWSPostgisIndex(OWSAbstractIndex):
         db_ok = False
         try:
             with dc.index._db._give_me_a_connection() as conn:  # type: ignore[attr-defined]
-                results = conn.execute(text("""
+                results = conn.execute(
+                    text("""
                     SELECT *
                     FROM ows.layer_ranges
                     LIMIT 1""")
@@ -80,19 +81,22 @@ class OWSPostgisIndex(OWSAbstractIndex):
         pass
 
     @override
-    def create_range_entry(self, layer: OWSNamedLayer, cache: dict[LayerSignature, list[str]]) -> None:
+    def create_range_entry(
+        self, layer: OWSNamedLayer, cache: dict[LayerSignature, list[str]]
+    ) -> None:
         create_range_entry_impl(layer, cache)
 
     @override
     def get_ranges(self, layer: OWSNamedLayer) -> LayerExtent | None:
         return get_ranges_impl(layer)
 
-    def _query(self,
-               layer: OWSNamedLayer,
-               times: Iterable[TimeSearchTerm] | None = None,
-               geom: Geometry | None = None,
-               products: Iterable[Product] | None = None
-               ) -> dict[str, Any]:
+    def _query(
+        self,
+        layer: OWSNamedLayer,
+        times: Iterable[TimeSearchTerm] | None = None,
+        geom: Geometry | None = None,
+        products: Iterable[Product] | None = None,
+    ) -> dict[str, Any]:
         query: dict[str, Any] = {}
         if geom:
             if geom.crs and geom.crs in layer.dc.index.spatial_indexes():
@@ -108,12 +112,19 @@ class OWSPostgisIndex(OWSAbstractIndex):
             query["product"] = [p.name for p in products]
         if times is not None:
 
-            def normalise_to_dtr(unnorm: datetime.datetime | datetime.date) -> tuple[datetime.datetime, datetime.datetime]:
+            def normalise_to_dtr(
+                unnorm: datetime.datetime | datetime.date,
+            ) -> tuple[datetime.datetime, datetime.datetime]:
                 if isinstance(unnorm, datetime.datetime):
                     st: datetime.datetime = default_to_utc(unnorm)
                     tmax = st + datetime.timedelta(seconds=1)
                 elif isinstance(t, datetime.date):
-                    st = datetime.datetime(unnorm.year, unnorm.month, unnorm.day, tzinfo=datetime.timezone.utc)
+                    st = datetime.datetime(
+                        unnorm.year,
+                        unnorm.month,
+                        unnorm.day,
+                        tzinfo=datetime.timezone.utc,
+                    )
                     tmax = st + datetime.timedelta(days=1)
                 else:
                     raise ValueError("Not a datetime object")
@@ -135,47 +146,55 @@ class OWSPostgisIndex(OWSAbstractIndex):
         return query
 
     @override
-    def ds_search(self,
-                  layer: OWSNamedLayer,
-                  times: Iterable[TimeSearchTerm] | None = None,
-                  geom: Geometry | None = None,
-                  products: Iterable[Product] | None = None
-                  ) -> Iterable[Dataset]:
-        return layer.dc.index.datasets.search(**self._query(layer, times, geom, products))
+    def ds_search(
+        self,
+        layer: OWSNamedLayer,
+        times: Iterable[TimeSearchTerm] | None = None,
+        geom: Geometry | None = None,
+        products: Iterable[Product] | None = None,
+    ) -> Iterable[Dataset]:
+        return layer.dc.index.datasets.search(
+            **self._query(layer, times, geom, products)
+        )
 
     @override
-    def dsid_search(self,
-                    layer: OWSNamedLayer,
-                    times: Iterable[TimeSearchTerm] | None = None,
-                    geom: Geometry | None = None,
-                    products: Iterable[Product] | None = None
-                    ) -> Iterable[UUID]:
-        for ds in layer.dc.index.datasets.search_returning(field_names=["id"],
-                                                           **self._query(layer, times, geom, products)):
+    def dsid_search(
+        self,
+        layer: OWSNamedLayer,
+        times: Iterable[TimeSearchTerm] | None = None,
+        geom: Geometry | None = None,
+        products: Iterable[Product] | None = None,
+    ) -> Iterable[UUID]:
+        for ds in layer.dc.index.datasets.search_returning(
+            field_names=["id"], **self._query(layer, times, geom, products)
+        ):
             yield ds.id  # type: ignore[attr-defined]
 
     @override
-    def count(self,
-              layer: OWSNamedLayer,
-              times: Iterable[TimeSearchTerm] | None = None,
-              geom: Geometry | None = None,
-              products: Iterable[Product] | None = None
-              ) -> int:
-        return layer.dc.index.datasets.count(**self._query(layer, times, geom, products))
+    def count(
+        self,
+        layer: OWSNamedLayer,
+        times: Iterable[TimeSearchTerm] | None = None,
+        geom: Geometry | None = None,
+        products: Iterable[Product] | None = None,
+    ) -> int:
+        return layer.dc.index.datasets.count(
+            **self._query(layer, times, geom, products)
+        )
 
     @override
-    def extent(self,
-               layer: OWSNamedLayer,
-               times: Iterable[TimeSearchTerm] | None = None,
-               geom: Geometry | None = None,
-               products: Iterable[Product] | None = None,
-               crs: CRS | None = None
-               ) -> Geometry | None:
+    def extent(
+        self,
+        layer: OWSNamedLayer,
+        times: Iterable[TimeSearchTerm] | None = None,
+        geom: Geometry | None = None,
+        products: Iterable[Product] | None = None,
+        crs: CRS | None = None,
+    ) -> Geometry | None:
         if crs is None:
             crs = CRS("epsg:4326")
         return layer.dc.index.datasets.spatial_extent(
-            self.dsid_search(layer, times=times, geom=geom, products=products),
-            crs=crs
+            self.dsid_search(layer, times=times, geom=geom, products=products), crs=crs
         )
 
     def _run_sql(self, dc: Datacube, path: str, **params: str) -> bool:
@@ -187,6 +206,7 @@ pgisdriverlock = Lock()
 
 class OWSPostgisIndexDriver(OWSAbstractIndexDriver):
     _driver = None
+
     @classmethod
     @override
     def ows_index_class(cls) -> type[OWSAbstractIndex]:

--- a/datacube_ows/index/postgis/product_ranges.py
+++ b/datacube_ows/index/postgis/product_ranges.py
@@ -33,11 +33,15 @@ def jsonise_bbox(bbox: odc.geo.geom.BoundingBox) -> dict[str, float]:
     }
 
 
-def create_range_entry(layer: OWSNamedLayer, cache: dict[LayerSignature, list[str]]) -> None:
-    meta = LayerSignature(time_res=layer.time_resolution.value,
-                          products=tuple(layer.product_names),
-                          env=layer.local_env._name,
-                          datasets=layer.dc.index.datasets.count(product=layer.product_names))
+def create_range_entry(
+    layer: OWSNamedLayer, cache: dict[LayerSignature, list[str]]
+) -> None:
+    meta = LayerSignature(
+        time_res=layer.time_resolution.value,
+        products=tuple(layer.product_names),
+        env=layer.local_env._name,
+        datasets=layer.dc.index.datasets.count(product=layer.product_names),
+    )
 
     click.echo(f"Postgis Updating range for layer {layer.name}")
     click.echo(f"(signature: {meta.as_json()!r})")
@@ -48,18 +52,18 @@ def create_range_entry(layer: OWSNamedLayer, cache: dict[LayerSignature, list[st
         click.echo(f"Layer {template} has same signature - reusing")
         cache[meta].append(layer.name)
         try:
-            conn.execute(text("""
+            conn.execute(
+                text("""
             INSERT INTO ows.layer_ranges
                 (layer, lat_min, lat_max, lon_min, lon_max, dates, bboxes, meta, last_updated)
             SELECT :layer_id, lat_min, lat_max, lon_min, lon_max, dates, bboxes, meta, last_updated
             FROM ows.layer_ranges lr2
             WHERE lr2.layer = :template_id"""),
-                         {
-                                      "layer_id": layer.name,
-                                      "template_id": template
-                                   })
+                {"layer_id": layer.name, "template_id": template},
+            )
         except sqlalchemy.exc.IntegrityError:
-            conn.execute(text("""
+            conn.execute(
+                text("""
             UPDATE ows.layer_ranges lr1
             SET lat_min = lr2.lat_min,
                 lat_max = lr2.lat_max,
@@ -72,23 +76,25 @@ def create_range_entry(layer: OWSNamedLayer, cache: dict[LayerSignature, list[st
             FROM ows.layer_ranges lr2
             WHERE lr1.layer = :layer_id
             AND   lr2.layer = :template_id"""),
-                         {
-                             "layer_id": layer.name,
-                             "template_id": template
-                         })
+                {"layer_id": layer.name, "template_id": template},
+            )
     else:
         # insert empty row if one does not already exist
-        conn.execute(text("""
+        conn.execute(
+            text("""
         INSERT INTO ows.layer_ranges
         (layer, lat_min, lat_max, lon_min, lon_max, dates, bboxes, meta, last_updated)
         VALUES
         (:p_layer, 0, 0, 0, 0, :empty, :empty, :meta, :now)
         ON CONFLICT (layer) DO NOTHING
         """),
-        {
-            "p_layer": layer.name, "empty": Json(""),
-            "meta": Json(meta.as_json()), "now": datetime.now(tz=timezone.utc)
-        })
+            {
+                "p_layer": layer.name,
+                "empty": Json(""),
+                "meta": Json(meta.as_json()),
+                "now": datetime.now(tz=timezone.utc),
+            },
+        )
 
         prodids = [p.id for p in layer.products]
 
@@ -98,8 +104,9 @@ def create_range_entry(layer: OWSNamedLayer, cache: dict[LayerSignature, list[st
         # Loop over dates
         dates = set()  # Should get to here!
         if layer.time_resolution.is_solar():
-          results = conn.execute(text(
-              """
+            results = conn.execute(
+                text(
+                    """
               select lower(dt.search_val), upper(dt.search_val),
                      lower(lon.search_val), upper(lon.search_val)
               from odc.dataset ds, odc.dataset_search_datetime dt, odc.dataset_search_num lon
@@ -108,19 +115,22 @@ def create_range_entry(layer: OWSNamedLayer, cache: dict[LayerSignature, list[st
               AND ds.id = lon.dataset_ref
               AND dt.search_key = :time
               AND lon.search_key = :lon
-              """),
-              {"prodids": prodids, "time": "time", "lon": "lon"})
-          for result in results:
-              dt1, dt2, ll, lu = result
-              lon = (ll + lu) / 2
-              dt = dt1 + (dt2 - dt1) / 2
-              dt = dt.astimezone(timezone.utc)
-
-              solar_day = datacube.api.query._convert_to_solar_time(dt, lon).date()
-              dates.add(solar_day)
-        else:
-          results = conn.execute(text(
               """
+                ),
+                {"prodids": prodids, "time": "time", "lon": "lon"},
+            )
+            for result in results:
+                dt1, dt2, ll, lu = result
+                lon = (ll + lu) / 2
+                dt = dt1 + (dt2 - dt1) / 2
+                dt = dt.astimezone(timezone.utc)
+
+                solar_day = datacube.api.query._convert_to_solar_time(dt, lon).date()
+                dates.add(solar_day)
+        else:
+            results = conn.execute(
+                text(
+                    """
               select
                     array_agg(dt.search_val)
               from odc.dataset_search_datetime dt,
@@ -128,28 +138,27 @@ def create_range_entry(layer: OWSNamedLayer, cache: dict[LayerSignature, list[st
               WHERE ds.product_ref = ANY(:prodids)
               AND   ds.id = dt.dataset_ref
               AND   dt.search_key = 'time'
-              """),
-              {"prodids": prodids}
-          )
-          for result in results:
-              for dat_ran in result[0]:
-                  dates.add(dat_ran.lower)
+              """
+                ),
+                {"prodids": prodids},
+            )
+            for result in results:
+                for dat_ran in result[0]:
+                    dates.add(dat_ran.lower)
 
         if layer.time_resolution.is_subday():
-          date_formatter = lambda d: d.isoformat()  # noqa: E731
+            date_formatter = lambda d: d.isoformat()  # noqa: E731
         else:
-          date_formatter = lambda d: d.strftime("%Y-%m-%d")  # noqa: E731
+            date_formatter = lambda d: d.strftime("%Y-%m-%d")  # noqa: E731
 
         dates = sorted(dates)
-        conn.execute(text("""
+        conn.execute(
+            text("""
            UPDATE ows.layer_ranges
            SET dates = :dates
            WHERE layer= :layer_id
         """),
-                   {
-                       "dates": Json(list(map(date_formatter, dates))),
-                       "layer_id": layer.name
-                   }
+            {"dates": Json(list(map(date_formatter, dates))), "layer_id": layer.name},
         )
         # calculate bounding boxes
         # Get extent polygon from materialised views
@@ -158,7 +167,8 @@ def create_range_entry(layer: OWSNamedLayer, cache: dict[LayerSignature, list[st
         if not all_bboxes:
             return
 
-        conn.execute(text("""
+        conn.execute(
+            text("""
         UPDATE ows.layer_ranges
         SET bboxes = :bbox,
             lat_min = :lat_min,
@@ -166,14 +176,16 @@ def create_range_entry(layer: OWSNamedLayer, cache: dict[LayerSignature, list[st
             lon_min = :lon_min,
             lon_max = :lon_max
         WHERE layer = :layer_id
-        """), {
-            "bbox": Json(all_bboxes),
-            "layer_id": layer.name,
-            "lat_min": all_bboxes['EPSG:4326']['bottom'],
-            "lat_max": all_bboxes['EPSG:4326']['top'],
-            "lon_min": all_bboxes['EPSG:4326']['left'],
-            "lon_max": all_bboxes['EPSG:4326']['right']
-        })
+        """),
+            {
+                "bbox": Json(all_bboxes),
+                "layer_id": layer.name,
+                "lat_min": all_bboxes["EPSG:4326"]["bottom"],
+                "lat_max": all_bboxes["EPSG:4326"]["top"],
+                "lon_min": all_bboxes["EPSG:4326"]["left"],
+                "lon_max": all_bboxes["EPSG:4326"]["right"],
+            },
+        )
 
         cache[meta] = [layer.name]
 
@@ -215,19 +227,26 @@ def extent_for_layer(layer: OWSNamedLayer, crs: CRS) -> odc.geo.Geometry | None:
     return ext
 
 
-def bbox_projections(starting_box: odc.geo.Geometry, crses: dict[str, odc.geo.CRS]) -> dict[str, dict[str, float]]:
-   result = {}
-   for crsid, crs in crses.items():
+def bbox_projections(
+    starting_box: odc.geo.Geometry, crses: dict[str, odc.geo.CRS]
+) -> dict[str, dict[str, float]]:
+    result = {}
+    for crsid, crs in crses.items():
         projbbox = starting_box.to_crs(crs).boundingbox
         result[crsid] = sanitise_bbox(projbbox)
-   return result
+    return result
 
 
 def sanitise_bbox(bbox: odc.geo.geom.BoundingBox) -> dict[str, float]:
     def sanitise_coordinate(coord: float, fallback: float, upper: bool) -> float:
-        if not math.isfinite(coord) or (upper and coord > fallback) or (not upper and coord < fallback):
+        if (
+            not math.isfinite(coord)
+            or (upper and coord > fallback)
+            or (not upper and coord < fallback)
+        ):
             return fallback
         return coord
+
     if bbox.crs == CRS("epsg:4326"):
         return {
             "top": sanitise_coordinate(bbox.top, float("90.0"), True),
@@ -245,17 +264,20 @@ def sanitise_bbox(bbox: odc.geo.geom.BoundingBox) -> dict[str, float]:
 
 def get_ranges(layer: OWSNamedLayer) -> LayerExtent | None:
     conn = get_sqlconn(layer.dc)
-    results = conn.execute(text("""
+    results = conn.execute(
+        text("""
         SELECT *
         FROM ows.layer_ranges
         WHERE layer=:pname"""),
-                           {"pname": layer.name}
-                          )
+        {"pname": layer.name},
+    )
 
     for result in results:
         conn.close()
         if layer.time_resolution.is_subday():
-            dt_parser: Callable[[str], datetime | date] = lambda dts: datetime.fromisoformat(dts)  # noqa: E731
+            dt_parser: Callable[[str], datetime | date] = (  # noqa: E731
+                lambda dts: datetime.fromisoformat(dts)
+            )
         else:
             dt_parser = lambda dts: datetime.strptime(dts, "%Y-%m-%d").date()  # noqa: E731
         times = [dt_parser(d) for d in result.dates if d is not None]
@@ -265,6 +287,6 @@ def get_ranges(layer: OWSNamedLayer) -> LayerExtent | None:
             lat=CoordRange(min=float(result.lat_min), max=float(result.lat_max)),
             lon=CoordRange(min=float(result.lon_min), max=float(result.lon_max)),
             times=times,
-            bboxes=result.bboxes
+            bboxes=result.bboxes,
         )
     return None

--- a/datacube_ows/index/postgres/api.py
+++ b/datacube_ows/index/postgres/api.py
@@ -40,7 +40,8 @@ class OWSPostgresIndex(OWSAbstractIndex):
         db_ok = False
         try:
             with dc.index._db.give_me_a_connection() as conn:  # type: ignore[attr-defined]
-                results = conn.execute(text("""
+                results = conn.execute(
+                    text("""
                     SELECT *
                     FROM ows.layer_ranges
                     LIMIT 1""")
@@ -82,7 +83,9 @@ class OWSPostgresIndex(OWSAbstractIndex):
         self._run_sql(dc, "extent_views/refresh")
 
     @override
-    def create_range_entry(self, layer: OWSNamedLayer, cache: dict[LayerSignature, list[str]]) -> None:
+    def create_range_entry(
+        self, layer: OWSNamedLayer, cache: dict[LayerSignature, list[str]]
+    ) -> None:
         create_range_entry_impl(layer, cache)
 
     @override
@@ -90,45 +93,81 @@ class OWSPostgresIndex(OWSAbstractIndex):
         return get_ranges_impl(layer)
 
     @override
-    def ds_search(self,
-                  layer: OWSNamedLayer,
-                  times: Iterable[TimeSearchTerm] | None = None,
-                  geom: Geometry | None = None,
-                  products: Iterable[Product] | None = None
-                  ) -> Iterable[Dataset]:
-        return cast(Iterable[Dataset], mv_search(layer.dc.index, MVSelectOpts.DATASETS,
-                                                 times=times, geom=geom, products=products))
+    def ds_search(
+        self,
+        layer: OWSNamedLayer,
+        times: Iterable[TimeSearchTerm] | None = None,
+        geom: Geometry | None = None,
+        products: Iterable[Product] | None = None,
+    ) -> Iterable[Dataset]:
+        return cast(
+            Iterable[Dataset],
+            mv_search(
+                layer.dc.index,
+                MVSelectOpts.DATASETS,
+                times=times,
+                geom=geom,
+                products=products,
+            ),
+        )
 
     @override
-    def dsid_search(self,
-                    layer: OWSNamedLayer,
-                    times: Iterable[TimeSearchTerm] | None = None,
-                    geom: Geometry | None = None,
-                    products: Iterable[Product] | None = None
-                    ) -> Iterable[UUID]:
-        return cast(Iterable[UUID], mv_search(layer.dc.index, MVSelectOpts.IDS,
-                                              times=times, geom=geom, products=products))
+    def dsid_search(
+        self,
+        layer: OWSNamedLayer,
+        times: Iterable[TimeSearchTerm] | None = None,
+        geom: Geometry | None = None,
+        products: Iterable[Product] | None = None,
+    ) -> Iterable[UUID]:
+        return cast(
+            Iterable[UUID],
+            mv_search(
+                layer.dc.index,
+                MVSelectOpts.IDS,
+                times=times,
+                geom=geom,
+                products=products,
+            ),
+        )
 
     @override
-    def count(self,
-              layer: OWSNamedLayer,
-              times: Iterable[TimeSearchTerm] | None = None,
-              geom: Geometry | None = None,
-              products: Iterable[Product] | None = None
-              ) -> int:
-        return cast(int, mv_search(layer.dc.index, MVSelectOpts.COUNT,
-                                   times=times, geom=geom, products=products))
+    def count(
+        self,
+        layer: OWSNamedLayer,
+        times: Iterable[TimeSearchTerm] | None = None,
+        geom: Geometry | None = None,
+        products: Iterable[Product] | None = None,
+    ) -> int:
+        return cast(
+            int,
+            mv_search(
+                layer.dc.index,
+                MVSelectOpts.COUNT,
+                times=times,
+                geom=geom,
+                products=products,
+            ),
+        )
 
     @override
-    def extent(self,
-               layer: OWSNamedLayer,
-               times: Iterable[TimeSearchTerm] | None = None,
-               geom: Geometry | None = None,
-               products: Iterable[Product] | None = None,
-               crs: CRS | None = None
-               ) -> Geometry | None:
-        extent = cast(Geometry | None, mv_search(layer.dc.index, MVSelectOpts.EXTENT,
-                                                 times=times, geom=geom, products=products))
+    def extent(
+        self,
+        layer: OWSNamedLayer,
+        times: Iterable[TimeSearchTerm] | None = None,
+        geom: Geometry | None = None,
+        products: Iterable[Product] | None = None,
+        crs: CRS | None = None,
+    ) -> Geometry | None:
+        extent = cast(
+            Geometry | None,
+            mv_search(
+                layer.dc.index,
+                MVSelectOpts.EXTENT,
+                times=times,
+                geom=geom,
+                products=products,
+            ),
+        )
         if extent is None or crs is None or crs == extent.crs:
             return extent
         return extent.to_crs(crs)
@@ -142,6 +181,7 @@ pgdriverlock = Lock()
 
 class OWSPostgresIndexDriver(OWSAbstractIndexDriver):
     _driver = None
+
     @classmethod
     @override
     def ows_index_class(cls) -> type[OWSAbstractIndex]:

--- a/datacube_ows/index/postgres/mv_index.py
+++ b/datacube_ows/index/postgres/mv_index.py
@@ -33,12 +33,17 @@ def get_sqlalc_engine(index: Index) -> Engine:
 
 
 def get_st_view(meta: MetaData) -> Table:
-    return Table('space_time_view', meta,
-                 Column('id', UUID()),
-                 Column('dataset_type_ref', SMALLINT()),
-                 Column('spatial_extent', Geometry(from_text='ST_GeomFromGeoJSON', name='geometry')),
-                 Column('temporal_extent', TSTZRANGE()),
-                 schema="ows")
+    return Table(
+        "space_time_view",
+        meta,
+        Column("id", UUID()),
+        Column("dataset_type_ref", SMALLINT()),
+        Column(
+            "spatial_extent", Geometry(from_text="ST_GeomFromGeoJSON", name="geometry")
+        ),
+        Column("temporal_extent", TSTZRANGE()),
+        schema="ows",
+    )
 
 
 _meta = MetaData()
@@ -55,6 +60,7 @@ class MVSelectOpts(Enum):
     COUNT: return a count of matching datasets
     EXTENT: return full extent of query result as a Geometry
     """
+
     ALL = 0
     IDS = 1
     COUNT = 2
@@ -84,14 +90,20 @@ selection_return_types: dict[MVSelectOpts, type | UnionType] = {
 
 SelectOut = Iterable[Row] | Iterable[UUID_] | Iterable[Dataset] | int | ODCGeom | None
 DateOrDateTime = datetime.datetime | datetime.date
-TimeSearchTerm = tuple[datetime.datetime, datetime.datetime] | tuple[datetime.date, datetime.date] | DateOrDateTime
+TimeSearchTerm = (
+    tuple[datetime.datetime, datetime.datetime]
+    | tuple[datetime.date, datetime.date]
+    | DateOrDateTime
+)
 
 
-def mv_search(index: Index,
-              sel: MVSelectOpts = MVSelectOpts.IDS,
-              times: Iterable[TimeSearchTerm] | None = None,
-              geom: ODCGeom | None = None,
-              products: Iterable[Product] | None = None) -> SelectOut:
+def mv_search(
+    index: Index,
+    sel: MVSelectOpts = MVSelectOpts.IDS,
+    times: Iterable[TimeSearchTerm] | None = None,
+    geom: ODCGeom | None = None,
+    products: Iterable[Product] | None = None,
+) -> SelectOut:
     """
     Perform a dataset query via the space_time_view
 
@@ -124,7 +136,9 @@ def mv_search(index: Index,
                     )
                 )
             elif isinstance(t, datetime.date):
-                st = datetime.datetime(t.year, t.month, t.day, tzinfo=datetime.timezone.utc)
+                st = datetime.datetime(
+                    t.year, t.month, t.day, tzinfo=datetime.timezone.utc
+                )
                 tmax = st + datetime.timedelta(days=1)
                 or_clauses.append(
                     and_(
@@ -133,9 +147,7 @@ def mv_search(index: Index,
                     )
                 )
             else:
-                or_clauses.append(
-                    stv.c.temporal_extent.op("&&")(DateTimeTZRange(*t))
-                )
+                or_clauses.append(stv.c.temporal_extent.op("&&")(DateTimeTZRange(*t)))
         s = s.where(or_(*or_clauses))
     orig_crs = None
     if geom is not None:
@@ -161,7 +173,7 @@ def mv_search(index: Index,
                 uniongeom = ODCGeom(json.loads(geojson), crs="EPSG:4326")
                 if geom:
                     intersect = uniongeom.intersection(geom)
-                    if intersect.wkt == 'POLYGON EMPTY':
+                    if intersect.wkt == "POLYGON EMPTY":
                         return None
                     if orig_crs and orig_crs != "EPSG:4326":
                         intersect = intersect.to_crs(orig_crs)

--- a/datacube_ows/index/postgres/product_ranges.py
+++ b/datacube_ows/index/postgres/product_ranges.py
@@ -38,11 +38,15 @@ def jsonise_bbox(bbox: odc.geo.geom.BoundingBox) -> dict[str, float]:
     }
 
 
-def create_range_entry(layer: OWSNamedLayer, cache: dict[LayerSignature, list[str]]) -> None:
-    meta = LayerSignature(time_res=layer.time_resolution.value,
-                          products=tuple(layer.product_names),
-                          env=layer.local_env._name,
-                          datasets=layer.dc.index.datasets.count(product=layer.product_names))
+def create_range_entry(
+    layer: OWSNamedLayer, cache: dict[LayerSignature, list[str]]
+) -> None:
+    meta = LayerSignature(
+        time_res=layer.time_resolution.value,
+        products=tuple(layer.product_names),
+        env=layer.local_env._name,
+        datasets=layer.dc.index.datasets.count(product=layer.product_names),
+    )
 
     click.echo(f"Postgres Updating range for layer {layer.name}")
     click.echo(f"(signature: {meta.as_json()!r})")
@@ -53,18 +57,18 @@ def create_range_entry(layer: OWSNamedLayer, cache: dict[LayerSignature, list[st
         click.echo(f"Layer {template} has same signature - reusing")
         cache[meta].append(layer.name)
         try:
-            conn.execute(text("""
+            conn.execute(
+                text("""
             INSERT INTO ows.layer_ranges
                 (layer, lat_min, lat_max, lon_min, lon_max, dates, bboxes, meta, last_updated)
             SELECT :layer_id, lat_min, lat_max, lon_min, lon_max, dates, bboxes, meta, last_updated
             FROM ows.layer_ranges lr2
             WHERE lr2.layer = :template_id"""),
-                         {
-                                      "layer_id": layer.name,
-                                      "template_id": template
-                                   })
+                {"layer_id": layer.name, "template_id": template},
+            )
         except sqlalchemy.exc.IntegrityError:
-            conn.execute(text("""
+            conn.execute(
+                text("""
             UPDATE ows.layer_ranges lr1
             SET lat_min = lr2.lat_min,
                 lat_max = lr2.lat_max,
@@ -77,28 +81,31 @@ def create_range_entry(layer: OWSNamedLayer, cache: dict[LayerSignature, list[st
             FROM ows.layer_ranges lr2
             WHERE lr1.layer = :layer_id
             AND   lr2.layer = :template_id"""),
-                         {
-                             "layer_id": layer.name,
-                             "template_id": template
-                         })
+                {"layer_id": layer.name, "template_id": template},
+            )
     else:
         # insert empty row if one does not already exist
-        conn.execute(text("""
+        conn.execute(
+            text("""
         INSERT INTO ows.layer_ranges
         (layer, lat_min, lat_max, lon_min, lon_max, dates, bboxes, meta, last_updated)
         VALUES
         (:p_layer, 0, 0, 0, 0, :empty, :empty, :meta, :now)
         ON CONFLICT (layer) DO NOTHING
         """),
-        {
-            "p_layer": layer.name, "empty": Json(""),
-            "meta": Json(meta.as_json()), "now": datetime.now(tz=timezone.utc)
-        })
+            {
+                "p_layer": layer.name,
+                "empty": Json(""),
+                "meta": Json(meta.as_json()),
+                "now": datetime.now(tz=timezone.utc),
+            },
+        )
 
         prodids = [p.id for p in layer.products]
         # Update min/max lat/longs
-        conn.execute(text(
-          """
+        conn.execute(
+            text(
+                """
           UPDATE ows.layer_ranges lr
           SET lat_min = st_ymin(subq.bbox),
               lat_max = st_ymax(subq.bbox),
@@ -110,8 +117,10 @@ def create_range_entry(layer: OWSNamedLayer, cache: dict[LayerSignature, list[st
             WHERE stv.dataset_type_ref = ANY(:prodids)
           ) as subq
           WHERE lr.layer = :layer_id
-          """),
-          {"layer_id": layer.name, "prodids": prodids})
+          """
+            ),
+            {"layer_id": layer.name, "prodids": prodids},
+        )
 
         # Set default timezone
         conn.execute(text("""set timezone to 'Etc/UTC'"""))
@@ -119,66 +128,73 @@ def create_range_entry(layer: OWSNamedLayer, cache: dict[LayerSignature, list[st
         # Loop over dates
         dates = set()  # Should get to here!
         if layer.time_resolution.is_solar():
-          results = conn.execute(text(
-              """
+            results = conn.execute(
+                text(
+                    """
               select
                     lower(temporal_extent), upper(temporal_extent),
                     ST_X(ST_Centroid(spatial_extent))
               from ows.space_time_view
               WHERE dataset_type_ref = ANY(:prodids)
-              """),
-              {"prodids": prodids})
-          for result in results:
-              dt1, dt2, lon = result
-              dt = dt1 + (dt2 - dt1) / 2
-              dt = dt.astimezone(timezone.utc)
-
-              solar_day = datacube.api.query._convert_to_solar_time(dt, lon).date()
-              dates.add(solar_day)
-        else:
-          results = conn.execute(text(
               """
+                ),
+                {"prodids": prodids},
+            )
+            for result in results:
+                dt1, dt2, lon = result
+                dt = dt1 + (dt2 - dt1) / 2
+                dt = dt.astimezone(timezone.utc)
+
+                solar_day = datacube.api.query._convert_to_solar_time(dt, lon).date()
+                dates.add(solar_day)
+        else:
+            results = conn.execute(
+                text(
+                    """
               select
                     array_agg(temporal_extent)
               from ows.space_time_view
               WHERE dataset_type_ref = ANY(:prodids)
-              """),
-              {"prodids": prodids}
-          )
-          for result in results:
-              for dat_ran in result[0]:
-                  dates.add(dat_ran.lower)
+              """
+                ),
+                {"prodids": prodids},
+            )
+            for result in results:
+                for dat_ran in result[0]:
+                    dates.add(dat_ran.lower)
 
         if layer.time_resolution.is_subday():
-          date_formatter = lambda d: d.isoformat()  # noqa: E731
+            date_formatter = lambda d: d.isoformat()  # noqa: E731
         else:
-          date_formatter = lambda d: d.strftime("%Y-%m-%d")  # noqa: E731
+            date_formatter = lambda d: d.strftime("%Y-%m-%d")  # noqa: E731
 
         dates = sorted(dates)
-        conn.execute(text("""
+        conn.execute(
+            text("""
            UPDATE ows.layer_ranges
            SET dates = :dates
            WHERE layer= :layer_id
         """),
-                   {
-                       "dates": Json(list(map(date_formatter, dates))),
-                       "layer_id": layer.name
-                   }
+            {"dates": Json(list(map(date_formatter, dates))), "layer_id": layer.name},
         )
         # calculate bounding boxes
         # Get extent polygon from materialised views
 
-        extent_4386 = cast(Geometry, mv_search(layer.dc.index, MVSelectOpts.EXTENT, products=layer.products))
+        extent_4386 = cast(
+            Geometry,
+            mv_search(layer.dc.index, MVSelectOpts.EXTENT, products=layer.products),
+        )
 
         all_bboxes = bbox_projections(extent_4386, layer.global_cfg.crses)
 
-        conn.execute(text("""
+        conn.execute(
+            text("""
         UPDATE ows.layer_ranges
         SET bboxes = :bbox
         WHERE layer = :layer_id
-        """), {
-        "bbox": Json(all_bboxes),
-        "layer_id": layer.name})
+        """),
+            {"bbox": Json(all_bboxes), "layer_id": layer.name},
+        )
 
         cache[meta] = [layer.name]
 
@@ -186,27 +202,30 @@ def create_range_entry(layer: OWSNamedLayer, cache: dict[LayerSignature, list[st
     conn.close()
 
 
-def bbox_projections(starting_box: odc.geo.Geometry, crses: dict[str, CRS]) -> dict[str, dict[str, float]]:
-   result = {}
-   for crsid, crs in crses.items():
-       if crs.valid_region is not None:
-           clipped_crs_region = (starting_box & crs.valid_region)
-           if clipped_crs_region.wkt == 'POLYGON EMPTY':
-               continue
-           clipped_crs_bbox = clipped_crs_region.to_crs(crs).boundingbox
-       else:
-           clipped_crs_bbox = None
-       if clipped_crs_bbox is not None:
-           result[crsid] = jsonise_bbox(clipped_crs_bbox)
-       else:
-           projbbox = starting_box.to_crs(crs).boundingbox
-           result[crsid] = sanitise_bbox(projbbox)
-   return result
+def bbox_projections(
+    starting_box: odc.geo.Geometry, crses: dict[str, CRS]
+) -> dict[str, dict[str, float]]:
+    result = {}
+    for crsid, crs in crses.items():
+        if crs.valid_region is not None:
+            clipped_crs_region = starting_box & crs.valid_region
+            if clipped_crs_region.wkt == "POLYGON EMPTY":
+                continue
+            clipped_crs_bbox = clipped_crs_region.to_crs(crs).boundingbox
+        else:
+            clipped_crs_bbox = None
+        if clipped_crs_bbox is not None:
+            result[crsid] = jsonise_bbox(clipped_crs_bbox)
+        else:
+            projbbox = starting_box.to_crs(crs).boundingbox
+            result[crsid] = sanitise_bbox(projbbox)
+    return result
 
 
 def sanitise_bbox(bbox: odc.geo.geom.BoundingBox) -> dict[str, float]:
     def sanitise_coordinate(coord: float, fallback: float) -> float:
         return coord if math.isfinite(coord) else fallback
+
     return {
         "top": sanitise_coordinate(bbox.top, float("9.999999999e99")),
         "bottom": sanitise_coordinate(bbox.bottom, float("-9.999999999e99")),
@@ -217,17 +236,20 @@ def sanitise_bbox(bbox: odc.geo.geom.BoundingBox) -> dict[str, float]:
 
 def get_ranges(layer: OWSNamedLayer) -> LayerExtent | None:
     conn = get_sqlconn(layer.dc)
-    results = conn.execute(text("""
+    results = conn.execute(
+        text("""
         SELECT *
         FROM ows.layer_ranges
         WHERE layer=:pname"""),
-                           {"pname": layer.name}
-                          )
+        {"pname": layer.name},
+    )
 
     for result in results:
         conn.close()
         if layer.time_resolution.is_subday():
-            dt_parser: Callable[[str], datetime | date] = lambda dts: datetime.fromisoformat(dts)  # noqa: E731
+            dt_parser: Callable[[str], datetime | date] = (  # noqa: E731
+                lambda dts: datetime.fromisoformat(dts)
+            )
         else:
             dt_parser = lambda dts: datetime.strptime(dts, "%Y-%m-%d").date()  # noqa: E731
         times = [dt_parser(d) for d in result.dates if d is not None]
@@ -237,6 +259,6 @@ def get_ranges(layer: OWSNamedLayer) -> LayerExtent | None:
             lat=CoordRange(min=float(result.lat_min), max=float(result.lat_max)),
             lon=CoordRange(min=float(result.lon_min), max=float(result.lon_max)),
             times=times,
-            bboxes=result.bboxes
+            bboxes=result.bboxes,
         )
     return None

--- a/datacube_ows/index/sql.py
+++ b/datacube_ows/index/sql.py
@@ -28,15 +28,25 @@ def get_sqlconn(dc: Datacube) -> sqlalchemy.Connection:
 
 
 def run_sql(dc: Datacube, driver_name: str, path: str, **params: str) -> bool:
-    if not importlib.resources.files("datacube_ows").joinpath(f"sql/{driver_name}/{path}").is_dir():
-        print("Cannot find SQL resource directory - check your datacube-ows installation")
+    if (
+        not importlib.resources.files("datacube_ows")
+        .joinpath(f"sql/{driver_name}/{path}")
+        .is_dir()
+    ):
+        print(
+            "Cannot find SQL resource directory - check your datacube-ows installation"
+        )
         return False
 
     files = sorted(
-        importlib.resources.files("datacube_ows").joinpath(f"sql/{driver_name}/{path}").iterdir()  # type: ignore[type-var]
+        importlib.resources.files("datacube_ows")
+        .joinpath(f"sql/{driver_name}/{path}")
+        .iterdir()  # type: ignore[type-var]
     )
 
-    filename_req_pattern = re.compile(r"\d+[_a-zA-Z0-9]+_requires_(?P<reqs>[_a-zA-Z0-9]+)\.sql")
+    filename_req_pattern = re.compile(
+        r"\d+[_a-zA-Z0-9]+_requires_(?P<reqs>[_a-zA-Z0-9]+)\.sql"
+    )
     filename_pattern = re.compile(r"\d+[_a-zA-Z0-9]+\.sql")
     conn = get_sqlconn(dc)
     try:
@@ -54,7 +64,9 @@ def run_sql(dc: Datacube, driver_name: str, path: str, **params: str) -> bool:
                 try:
                     kwargs = {v: params[v] for v in reqs}
                 except KeyError as e:
-                    click.echo(f"Required parameter {e} for file {fname} not supplied - skipping")
+                    click.echo(
+                        f"Required parameter {e} for file {fname} not supplied - skipping"
+                    )
                     all_ok = False
                     continue
             else:
@@ -70,7 +82,9 @@ def run_sql(dc: Datacube, driver_name: str, path: str, **params: str) -> bool:
 
 
 def read_file(driver_name: str, path: str, fname: str, **kwargs: str) -> str:
-    ref = importlib.resources.files("datacube_ows").joinpath(f"sql/{driver_name}/{path}/{fname}")
+    ref = importlib.resources.files("datacube_ows").joinpath(
+        f"sql/{driver_name}/{path}/{fname}"
+    )
     sql = ""
     with ref.open("rb") as fp:
         first = True
@@ -87,7 +101,9 @@ def read_file(driver_name: str, path: str, fname: str, **kwargs: str) -> str:
     return sql
 
 
-def run_sql_statement(sql: str, fname: str, conn: sqlalchemy.Connection, env: datacube.cfg.ODCEnvironment) -> None:
+def run_sql_statement(
+    sql: str, fname: str, conn: sqlalchemy.Connection, env: datacube.cfg.ODCEnvironment
+) -> None:
     try:
         result = conn.execute(sqlalchemy.text(sql))
         click.echo(f"    ...  succeeded(?) with rowcount {result.rowcount}")
@@ -99,7 +115,7 @@ def run_sql_statement(sql: str, fname: str, conn: sqlalchemy.Connection, env: da
             )
             raise AbortRun() from None
         if isinstance(e.orig, psycopg2.errors.DuplicateObject):
-            if fname.endswith('_ignore_duplicates.sql'):
+            if fname.endswith("_ignore_duplicates.sql"):
                 click.echo("Ignoring 'already exists' error")
             else:
                 raise e from None

--- a/datacube_ows/legend_generator.py
+++ b/datacube_ows/legend_generator.py
@@ -19,15 +19,14 @@ from datacube_ows.wms_utils import GetLegendGraphicParameters
 
 # Do not use X Server backend
 
-matplotlib.use('Agg')
+matplotlib.use("Agg")
 
 _LOG: logging.Logger = logging.getLogger(__name__)
 
 
 def legend_graphic(args) -> tuple | None:
     params = GetLegendGraphicParameters(args)
-    img = create_legends_from_styles(params.styles,
-                        ndates=len(params.times))
+    img = create_legends_from_styles(params.styles, ndates=len(params.times))
     if img is None:
         raise WMSException("No legend is available for this request", http_response=404)
     return img
@@ -54,7 +53,7 @@ def create_legends_from_styles(styles, ndates: int = 0) -> tuple | None:
     imgs_comb = np.vstack([np.asarray(i.resize(min_shape)) for i in imgs])
     imgs_comb = Image.fromarray(imgs_comb)
     b = io.BytesIO()
-    imgs_comb.save(b, 'png')
+    imgs_comb.save(b, "png")
     # legend = make_response(b.getvalue())
     # legend.mimetype = 'image/png'
     # b.close()

--- a/datacube_ows/legend_utils.py
+++ b/datacube_ows/legend_utils.py
@@ -45,10 +45,14 @@ def get_image_from_url(url: str) -> Image.Image | None:
     """
     r = retrying_requests.get(url)
     if r.status_code != 200:
-        raise WMSException(f"Could not retrieve legend - external URL is failing with http code {r.status_code}")
-    if r.headers['content-type'] != 'image/png':
-        _LOG.warning("External legend has MIME type %s. OWS strongly recommends PNG format for legend images.",
-                     r.headers['content-type'])
+        raise WMSException(
+            f"Could not retrieve legend - external URL is failing with http code {r.status_code}"
+        )
+    if r.headers["content-type"] != "image/png":
+        _LOG.warning(
+            "External legend has MIME type %s. OWS strongly recommends PNG format for legend images.",
+            r.headers["content-type"],
+        )
     bytesio = io.BytesIO()
     bytesio.write(r.content)
     bytesio.seek(0)

--- a/datacube_ows/loading.py
+++ b/datacube_ows/loading.py
@@ -33,11 +33,14 @@ _LOG: logging.Logger = logging.getLogger(__name__)
 
 
 class ProductBandQuery:
-    def __init__(self,
-                 products: list[Product],
-                 bands: Iterable[str],
-                 main: bool = False, manual_merge: bool = False, ignore_time: bool = False,
-                 fuse_func: FuserFunction | None = None
+    def __init__(
+        self,
+        products: list[Product],
+        bands: Iterable[str],
+        main: bool = False,
+        manual_merge: bool = False,
+        ignore_time: bool = False,
+        fuse_func: FuserFunction | None = None,
     ) -> None:
         self.products = products
         self.bands = set(bands)
@@ -45,10 +48,7 @@ class ProductBandQuery:
         self.fuse_func = fuse_func
         self.ignore_time = ignore_time
         self.main = main
-        self.key = (
-            tuple(p.id for p in self.products),
-            tuple(bands)
-        )
+        self.key = (tuple(p.id for p in self.products), tuple(bands))
 
     @override
     def __str__(self) -> str:
@@ -59,77 +59,106 @@ class ProductBandQuery:
         return hash(self.key)
 
     @classmethod
-    def style_queries(cls, style: StyleDef, resource_limited: bool = False) -> list["ProductBandQuery"]:
+    def style_queries(
+        cls, style: StyleDef, resource_limited: bool = False
+    ) -> list["ProductBandQuery"]:
         queries = [
-            cls.simple_layer_query(style.product, style.needed_bands,
-                                   manual_merge=style.product.data_manual_merge,
-                                   fuse_func=style.product.fuse_func,
-                                   resource_limited=resource_limited)
+            cls.simple_layer_query(
+                style.product,
+                style.needed_bands,
+                manual_merge=style.product.data_manual_merge,
+                fuse_func=style.product.fuse_func,
+                resource_limited=resource_limited,
+            )
         ]
         for fp in style.flag_products:
             if fp.products_match(style.product.product_names):
                 for band in fp.bands:
-                    assert band in style.needed_bands, "Style band not in needed bands list"
+                    assert band in style.needed_bands, (
+                        "Style band not in needed bands list"
+                    )
             else:
                 pq_products = fp.low_res_products if resource_limited else fp.products
-                queries.append(cls(
-                    pq_products,
-                    list(fp.bands),
-                    manual_merge=fp.manual_merge,
-                    ignore_time=fp.ignore_time,
-                    fuse_func=fp.fuse_func
-                ))
+                queries.append(
+                    cls(
+                        pq_products,
+                        list(fp.bands),
+                        manual_merge=fp.manual_merge,
+                        ignore_time=fp.ignore_time,
+                        fuse_func=fp.fuse_func,
+                    )
+                )
         return queries
 
     @classmethod
-    def full_layer_queries(cls,
-                           layer: OWSNamedLayer,
-                           main_bands: list[str] | None = None) -> list["ProductBandQuery"]:
+    def full_layer_queries(
+        cls, layer: OWSNamedLayer, main_bands: list[str] | None = None
+    ) -> list["ProductBandQuery"]:
         if main_bands:
             needed_bands: Iterable[str] = main_bands
         else:
             needed_bands = set(layer.band_idx.band_cfg.keys())
         queries = [
-            cls.simple_layer_query(layer, needed_bands,
-                                   manual_merge=layer.data_manual_merge,
-                                   fuse_func=layer.fuse_func,
-                                   resource_limited=False)
+            cls.simple_layer_query(
+                layer,
+                needed_bands,
+                manual_merge=layer.data_manual_merge,
+                fuse_func=layer.fuse_func,
+                resource_limited=False,
+            )
         ]
         for fpb in layer.allflag_productbands:
             if fpb.products_match(layer.product_names):
                 for band in fpb.bands:
-                    assert band in needed_bands, "main product band not in needed bands list"
+                    assert band in needed_bands, (
+                        "main product band not in needed bands list"
+                    )
             else:
                 pq_products = fpb.products
-                queries.append(cls(
-                    pq_products,
-                    list(fpb.bands),
-                    manual_merge=fpb.manual_merge,
-                    ignore_time=fpb.ignore_time,
-                    fuse_func=fpb.fuse_func
-                ))
+                queries.append(
+                    cls(
+                        pq_products,
+                        list(fpb.bands),
+                        manual_merge=fpb.manual_merge,
+                        ignore_time=fpb.ignore_time,
+                        fuse_func=fpb.fuse_func,
+                    )
+                )
         return queries
 
     @classmethod
-    def simple_layer_query(cls, layer: OWSNamedLayer,
-                           bands: Iterable[str],
-                           manual_merge: bool = False,
-                           fuse_func: FuserFunction | None = None,
-                           resource_limited: bool = False) -> "ProductBandQuery":
+    def simple_layer_query(
+        cls,
+        layer: OWSNamedLayer,
+        bands: Iterable[str],
+        manual_merge: bool = False,
+        fuse_func: FuserFunction | None = None,
+        resource_limited: bool = False,
+    ) -> "ProductBandQuery":
         main_products = layer.low_res_products if resource_limited else layer.products
-        return cls(main_products, bands, manual_merge=manual_merge, main=True, fuse_func=fuse_func)
+        return cls(
+            main_products,
+            bands,
+            manual_merge=manual_merge,
+            main=True,
+            fuse_func=fuse_func,
+        )
+
 
 PerPBQReturnType = xarray.DataArray | Iterable[UUID]
 
+
 class DataStacker:
     @log_call
-    def __init__(self,
-                 layer: OWSNamedLayer,
-                 geobox: GeoBox,
-                 times: list[datetime.datetime],
-                 resampling: Resampling | None = None,
-                 style: StyleDef | None = None,
-                 bands: list[str] | None = None) -> None:
+    def __init__(
+        self,
+        layer: OWSNamedLayer,
+        geobox: GeoBox,
+        times: list[datetime.datetime],
+        resampling: Resampling | None = None,
+        style: StyleDef | None = None,
+        bands: list[str] | None = None,
+    ) -> None:
         self._layer = layer
         self.cfg = layer.global_cfg
         self._geobox = geobox
@@ -149,11 +178,7 @@ class DataStacker:
         if self._layer.mosaic_date_func:
             self._times = [self._layer.mosaic_date_func(layer.ranges.times)]
         else:
-            self._times = [
-                    self._layer.search_times(
-                            t, self._geobox)
-                    for t in times
-            ]
+            self._times = [self._layer.search_times(t, self._geobox) for t in times]
         self.group_by = self._layer.dataset_groupby()
         self.resource_limited = False
 
@@ -166,22 +191,26 @@ class DataStacker:
             queries = ProductBandQuery.style_queries(self.style)
         else:
             # Just take needed bands.
-            queries = [ProductBandQuery.simple_layer_query(self._layer, self.needed_bands())]
+            queries = [
+                ProductBandQuery.simple_layer_query(self._layer, self.needed_bands())
+            ]
         geom = self._geobox.extent
         for query in queries:
             qry_times = None if query.ignore_time else self._times
-            return self._layer.ows_index().count(self._layer, times=qry_times, geom=geom, products=query.products)
+            return self._layer.ows_index().count(
+                self._layer, times=qry_times, geom=geom, products=query.products
+            )
         return 0
 
     def extent(self, crs: CRS | None = None) -> Geometry | None:
         query = ProductBandQuery.simple_layer_query(
-                self._layer,
-                self.needed_bands(),
-                self.resource_limited
+            self._layer, self.needed_bands(), self.resource_limited
         )
         geom = self._geobox.extent
         times = None if query.ignore_time else self._times
-        return self._layer.ows_index().extent(self._layer, times=times, geom=geom, products=query.products, crs=crs)
+        return self._layer.ows_index().extent(
+            self._layer, times=times, geom=geom, products=query.products, crs=crs
+        )
 
     def dsids(self) -> dict[ProductBandQuery, Iterable[UUID]]:
         if self.style:
@@ -189,60 +218,69 @@ class DataStacker:
             queries = ProductBandQuery.style_queries(self.style)
         else:
             # Just take needed bands.
-            queries = [ProductBandQuery.simple_layer_query(self._layer, self.needed_bands())]
+            queries = [
+                ProductBandQuery.simple_layer_query(self._layer, self.needed_bands())
+            ]
         results: list[tuple[ProductBandQuery, Iterable[UUID]]] = []
         for query in queries:
             qry_times = None if query.ignore_time else self._times
-            result = self._layer.ows_index().dsid_search(self._layer, times=qry_times, geom=self._geobox.extent,
-                                                         products=query.products)
+            result = self._layer.ows_index().dsid_search(
+                self._layer,
+                times=qry_times,
+                geom=self._geobox.extent,
+                products=query.products,
+            )
             results.append((query, result))
         return OrderedDict(results)
 
     def datasets_all_time(self, point: Geometry | None = None) -> xarray.DataArray:
         query = ProductBandQuery.simple_layer_query(
-                    self._layer,
-                    self.needed_bands(),
-                    self.resource_limited)
+            self._layer, self.needed_bands(), self.resource_limited
+        )
         geom = point if point else self._geobox.extent
         result = self._layer.ows_index().ds_search(
-            layer=self._layer,
-            geom=geom,
-            products=query.products)
+            layer=self._layer, geom=geom, products=query.products
+        )
         return datacube.Datacube.group_datasets(result, self.group_by)
 
-    def datasets(self,
-                 all_flag_bands: bool = False,
-                 point: Geometry | None = None,
-                 ) -> dict[ProductBandQuery, xarray.DataArray]:
+    def datasets(
+        self, all_flag_bands: bool = False, point: Geometry | None = None
+    ) -> dict[ProductBandQuery, xarray.DataArray]:
         if self.style:
             # we have a style - lets go with that.
             queries = ProductBandQuery.style_queries(self.style)
         elif all_flag_bands:
-            queries = ProductBandQuery.full_layer_queries(self._layer, self.needed_bands())
+            queries = ProductBandQuery.full_layer_queries(
+                self._layer, self.needed_bands()
+            )
         else:
             # Just take needed bands.
-            queries = [ProductBandQuery.simple_layer_query(self._layer, self.needed_bands())]
+            queries = [
+                ProductBandQuery.simple_layer_query(self._layer, self.needed_bands())
+            ]
 
         geom = point if point else self._geobox.extent
         results: list[tuple[ProductBandQuery, xarray.DataArray]] = []
         for query in queries:
             qry_times = None if query.ignore_time else self._times
             result = self._layer.ows_index().ds_search(
-                               layer=self._layer,
-                               times=qry_times,
-                               geom=geom,
-                               products=query.products)
+                layer=self._layer, times=qry_times, geom=geom, products=query.products
+            )
             grpd_result = datacube.Datacube.group_datasets(result, self.group_by)
             results.append((query, grpd_result))
         return OrderedDict(results)
 
     @staticmethod
-    def create_nodata_filled_flag_bands(data: xarray.Dataset, pbq: ProductBandQuery) -> xarray.Dataset:
+    def create_nodata_filled_flag_bands(
+        data: xarray.Dataset, pbq: ProductBandQuery
+    ) -> xarray.Dataset:
         var = None
         for var in data.data_vars.variables:  # noqa: B007
             break
         if var is None:
-            raise WMSException("Cannot add default flag data as there is no non-flag data available")
+            raise WMSException(
+                "Cannot add default flag data as there is no non-flag data available"
+            )
         template = cast(xarray.DataArray, getattr(data, cast(str, var)))
         data_new_bands = {}
         for band in pbq.bands:
@@ -253,13 +291,17 @@ class DataStacker:
             data_new_bands[band] = qry_result
         data = data.assign(data_new_bands)
         for band in pbq.bands:
-            data[band].attrs["flags_definition"] = pbq.products[0].measurements[band].flags_definition
+            data[band].attrs["flags_definition"] = (
+                pbq.products[0].measurements[band].flags_definition
+            )
         return data
 
     @log_call
-    def data(self,
-             datasets_by_query: dict[ProductBandQuery, xarray.DataArray],
-             skip_corrections: bool = False) -> xarray.Dataset | None:
+    def data(
+        self,
+        datasets_by_query: dict[ProductBandQuery, xarray.DataArray],
+        skip_corrections: bool = False,
+    ) -> xarray.Dataset | None:
         # pylint: disable=too-many-locals, consider-using-enumerate
         # datasets is an XArray DataArray of datasets grouped by time.
         data: xarray.Dataset | None = None
@@ -270,9 +312,21 @@ class DataStacker:
             measurements = pbq.products[0].lookup_measurements(pbq.bands)
             fuse_func = pbq.fuse_func
             if pbq.manual_merge:
-                qry_result = self.manual_data_stack(datasets, measurements, pbq.bands, skip_corrections, fuse_func=fuse_func)
+                qry_result = self.manual_data_stack(
+                    datasets,
+                    measurements,
+                    pbq.bands,
+                    skip_corrections,
+                    fuse_func=fuse_func,
+                )
             else:
-                qry_result = self.read_data(datasets, measurements, self._geobox, resampling=self._resampling, fuse_func=fuse_func)
+                qry_result = self.read_data(
+                    datasets,
+                    measurements,
+                    self._geobox,
+                    resampling=self._resampling,
+                    fuse_func=fuse_func,
+                )
             if qry_result is None:
                 continue
             if data is None:
@@ -284,7 +338,9 @@ class DataStacker:
             if pbq.ignore_time:
                 # regularise time dimension:
                 if len(qry_result.time) > 1:
-                    raise WMSException("Cannot ignore time on PQ (flag) bands from a time-aware product")
+                    raise WMSException(
+                        "Cannot ignore time on PQ (flag) bands from a time-aware product"
+                    )
                 if len(qry_result.time) == len(data.time):
                     qry_result["time"] = data.time
                 else:
@@ -294,7 +350,9 @@ class DataStacker:
                     data_new_bands = {}
                     for band in pbq.bands:
                         band_data = qry_result[band]
-                        timeless_band_data = band_data.sel(time=qry_result.time.values[0])
+                        timeless_band_data = band_data.sel(
+                            time=qry_result.time.values[0]
+                        )
                         band_time_slices = []
                         for _ in data.time.values:
                             band_time_slices.append(timeless_band_data)
@@ -308,22 +366,31 @@ class DataStacker:
                 continue
             assert data is not None
             qry_result.coords["time"] = data.coords["time"]
-            data = cast(xarray.Dataset, xarray.combine_by_coords([data, qry_result], join="exact"))
+            data = cast(
+                xarray.Dataset,
+                xarray.combine_by_coords([data, qry_result], join="exact"),
+            )
 
         return data
 
     @log_call
-    def manual_data_stack(self,
-                          datasets: xarray.DataArray,
-                          measurements: Mapping[str, Measurement],
-                          bands: set[str],
-                          skip_corrections: bool,
-                          fuse_func: FuserFunction | None) -> xarray.Dataset | None:
+    def manual_data_stack(
+        self,
+        datasets: xarray.DataArray,
+        measurements: Mapping[str, Measurement],
+        bands: set[str],
+        skip_corrections: bool,
+        fuse_func: FuserFunction | None,
+    ) -> xarray.Dataset | None:
         # pylint: disable=too-many-locals, too-many-branches
         # manual merge
         if self.style:
-            flag_bands: Iterable[str] = set(filter(lambda b: b in self.style.flag_bands, bands))  # type: ignore[arg-type]
-            non_flag_bands: Iterable[str] = set(filter(lambda b: b not in self.style.flag_bands, bands))  #type: ignore[arg-type]
+            flag_bands: Iterable[str] = set(
+                filter(lambda b: b in self.style.flag_bands, bands)  # type: ignore[arg-type]
+            )
+            non_flag_bands: Iterable[str] = set(
+                filter(lambda b: b not in self.style.flag_bands, bands)  # type: ignore[arg-type]
+            )
         else:
             non_flag_bands = bands
             flag_bands = set()
@@ -332,7 +399,9 @@ class DataStacker:
             tds = datasets.sel(time=dt)
             merged = None
             for ds in cast(Iterable[Dataset], tds.values.item()):
-                d = self.read_data_for_single_dataset(ds, measurements, self._geobox, fuse_func=fuse_func)
+                d = self.read_data_for_single_dataset(
+                    ds, measurements, self._geobox, fuse_func=fuse_func
+                )
                 extent_mask = None
                 for band in non_flag_bands:
                     for f in self._layer.extent_mask_func:
@@ -350,7 +419,7 @@ class DataStacker:
                 continue
             for band in flag_bands:
                 # REVISIT: not sure about type converting one band like this?
-                merged[band] = merged[band].astype('uint16', copy=True)
+                merged[band] = merged[band].astype("uint16", copy=True)
                 merged[band].attrs = d[band].attrs
             time_slices.append(merged)
 
@@ -361,38 +430,45 @@ class DataStacker:
     # Read data for given datasets and measurements per the output_geobox
     # TODO: Make skip_broken passed in via config
     @log_call
-    def read_data(self,
-                  datasets: xarray.DataArray,
-                  measurements: Mapping[str, Measurement],
-                  geobox: GeoBox,
-                  skip_broken: bool = True,
-                  resampling: Resampling = "nearest",
-                  fuse_func: FuserFunction | None = None) -> xarray.Dataset:
+    def read_data(
+        self,
+        datasets: xarray.DataArray,
+        measurements: Mapping[str, Measurement],
+        geobox: GeoBox,
+        skip_broken: bool = True,
+        resampling: Resampling = "nearest",
+        fuse_func: FuserFunction | None = None,
+    ) -> xarray.Dataset:
         CredentialManager.check_cred()
         try:
             return datacube.Datacube.load_data(
-                    datasets,
-                    geobox,
-                    measurements=measurements,
-                    fuse_func=fuse_func,
-                    skip_broken_datasets=skip_broken,
-                    patch_url=self._layer.patch_url,
-                    resampling=resampling)
+                datasets,
+                geobox,
+                measurements=measurements,
+                fuse_func=fuse_func,
+                skip_broken_datasets=skip_broken,
+                patch_url=self._layer.patch_url,
+                resampling=resampling,
+            )
         except Exception as e:
             _LOG.error("Error (%s) in load_data: %s", e.__class__.__name__, str(e))
             raise
 
     # TODO: Make skip_broken passed in via config
     @log_call
-    def read_data_for_single_dataset(self,
-                                     dataset: Dataset,
-                                     measurements: Mapping[str, Measurement],
-                                     geobox: GeoBox,
-                                     skip_broken: bool = True,
-                                     resampling: Resampling = "nearest",
-                                     fuse_func: FuserFunction | None = None) -> xarray.Dataset:
+    def read_data_for_single_dataset(
+        self,
+        dataset: Dataset,
+        measurements: Mapping[str, Measurement],
+        geobox: GeoBox,
+        skip_broken: bool = True,
+        resampling: Resampling = "nearest",
+        fuse_func: FuserFunction | None = None,
+    ) -> xarray.Dataset:
         datasets = [dataset]
-        dc_datasets = datacube.Datacube.group_datasets(datasets, self._layer.time_resolution.dataset_groupby())
+        dc_datasets = datacube.Datacube.group_datasets(
+            datasets, self._layer.time_resolution.dataset_groupby()
+        )
         CredentialManager.check_cred()
         try:
             return datacube.Datacube.load_data(
@@ -402,7 +478,8 @@ class DataStacker:
                 fuse_func=fuse_func,
                 skip_broken_datasets=skip_broken,
                 patch_url=self._layer.patch_url,
-                resampling=resampling)
+                resampling=resampling,
+            )
         except Exception as e:
             _LOG.error("Error (%s) in load_data: %s", e.__class__.__name__, str(e))
             raise

--- a/datacube_ows/ogc.py
+++ b/datacube_ows/ogc.py
@@ -70,27 +70,28 @@ prometheus_ows_ogc_metric = metrics.histogram(
     "ows_ogc",
     "Summary by OGC request protocol, version, operation, layer, and HTTP Status",
     labels={
-        'query_request': lambda: request.args.get('request', "NONE").upper(),
-        'query_service': lambda: request.args.get('service', "NONE").upper(),
-        'query_version': lambda: request.args.get('version'),
-        'query_layer': lambda: (request.args.get('query_layers') # WMS GetFeatureInfo
-                                or request.args.get('layers')  # WMS
-                                or request.args.get('layer')  # WMTS
-                                or request.args.get('coverage')  # WCS 1.x
-                                or request.args.get('coverageid')  # WCS 2.x
-                                ),
-        'status': lambda r: r.status_code,
-    }
+        "query_request": lambda: request.args.get("request", "NONE").upper(),
+        "query_service": lambda: request.args.get("service", "NONE").upper(),
+        "query_version": lambda: request.args.get("version"),
+        "query_layer": lambda: (
+            request.args.get("query_layers")  # WMS GetFeatureInfo
+            or request.args.get("layers")  # WMS
+            or request.args.get("layer")  # WMTS
+            or request.args.get("coverage")  # WCS 1.x
+            or request.args.get("coverageid")  # WCS 2.x
+        ),
+        "status": lambda r: r.status_code,
+    },
 )
 
 
 # Flask Routes
 
 
-@app.route('/')
+@app.route("/")
 @prometheus_ows_ogc_metric
 def ogc_impl():
-    #pylint: disable=too-many-branches
+    # pylint: disable=too-many-branches
     nocase_args = lower_get_args()
     nocase_args = capture_headers(request, nocase_args)
     service = nocase_args.get("service", "").upper()
@@ -116,23 +117,26 @@ def ogc_impl():
             # Defaulting to WMS because that's what we already have.
             raise WMSException(
                 "Invalid service and/or request",
-                locator="Service and request parameters")
-        cfg = get_config()   # pylint: disable=redefined-outer-name
-        url = nocase_args.get('Host', nocase_args['url_root'])
+                locator="Service and request parameters",
+            )
+        cfg = get_config()  # pylint: disable=redefined-outer-name
+        url = nocase_args.get("Host", nocase_args["url_root"])
         base_url = get_service_base_url(cfg.allowed_urls, url)
-        return (render_template(
-                        "index.html",
-                        cfg=cfg,
-                        supported=OWS_SUPPORTED,
-                        base_url=base_url,
-                        version=__version__,
-                ),
-                200,
-                resp_headers({"Content-Type": "text/html"}))
+        return (
+            render_template(
+                "index.html",
+                cfg=cfg,
+                supported=OWS_SUPPORTED,
+                base_url=base_url,
+                version=__version__,
+            ),
+            200,
+            resp_headers({"Content-Type": "text/html"}),
+        )
     except OGCException as e:
         _LOG.error("Handled Error: %s", repr(e.errors))
         return e.exception_response()
-    except Exception as e: # pylint: disable=broad-except
+    except Exception as e:  # pylint: disable=broad-except
         tb = sys.exc_info()[2]
         ogc_e = WMSException(f"Unexpected server error: {e!s}", http_response=500)
         return ogc_e.exception_response(traceback=traceback.extract_tb(tb))
@@ -147,20 +151,27 @@ def ogc_svc_impl(svc):
     # Is service activated in config?
     try:
         if not svc_support:
-            raise WMSException(f"Invalid service: {svc}",
-                               valid_keys=[
-                                       service.service
-                                       for service in OWS_SUPPORTED.values()
-                                       if service.activated()
-                               ],
-                               code=WMSException.OPERATION_NOT_SUPPORTED,
-                               locator="service parameter")
+            raise WMSException(
+                f"Invalid service: {svc}",
+                valid_keys=[
+                    service.service
+                    for service in OWS_SUPPORTED.values()
+                    if service.activated()
+                ],
+                code=WMSException.OPERATION_NOT_SUPPORTED,
+                locator="service parameter",
+            )
         if not svc_support.activated():
-            raise svc_support.default_exception_class("Invalid service and/or request", locator="Service and request parameters")
+            raise svc_support.default_exception_class(
+                "Invalid service and/or request",
+                locator="Service and request parameters",
+            )
 
         # Does service match path (if supplied)
         if service != svc_support.service_upper:
-            raise svc_support.default_exception_class("Invalid service", locator="Service parameter")
+            raise svc_support.default_exception_class(
+                "Invalid service", locator="Service parameter"
+            )
 
         version = nocase_args.get("version")
         version_support = svc_support.negotiated_version(version)
@@ -171,31 +182,36 @@ def ogc_svc_impl(svc):
         return version_support.router(nocase_args)
     except OGCException as e:
         return e.exception_response()
-    except Exception as e: #pylint: disable=broad-except
+    except Exception as e:  # pylint: disable=broad-except
         tb = sys.exc_info()[2]
-        ogc_e = version_support.exception_class(f"Unexpected server error: {e!s}", http_response=500)
+        ogc_e = version_support.exception_class(
+            f"Unexpected server error: {e!s}", http_response=500
+        )
         return ogc_e.exception_response(traceback=traceback.extract_tb(tb))
 
 
-@app.route('/wms')
+@app.route("/wms")
 @prometheus_ows_ogc_metric
 def ogc_wms_impl():
     return ogc_svc_impl("wms")
 
 
-@app.route('/wmts')
+@app.route("/wmts")
 @prometheus_ows_ogc_metric
 def ogc_wmts_impl():
     return ogc_svc_impl("wmts")
 
 
-@app.route('/wcs')
+@app.route("/wcs")
 @prometheus_ows_ogc_metric
 def ogc_wcs_impl():
     return ogc_svc_impl("wcs")
 
-@app.route('/ping')
-@metrics.summary('ows_heartbeat_pings', "Ping durations", labels={"status": lambda r: r.status})
+
+@app.route("/ping")
+@metrics.summary(
+    "ows_heartbeat_pings", "Ping durations", labels={"status": lambda r: r.status}
+)
 def ping() -> tuple[str, int, dict[str, str]]:
     dbs_ok = {
         name: ows_index(dc).check_db_access(dc)
@@ -203,18 +219,34 @@ def ping() -> tuple[str, int, dict[str, str]]:
     }
 
     if all(dbs_ok.values()):
-        return render_template("ping.html", status="Up", statuses=dbs_ok), 200, resp_headers({"Content-Type": "text/html"})
+        return (
+            render_template("ping.html", status="Up", statuses=dbs_ok),
+            200,
+            resp_headers({"Content-Type": "text/html"}),
+        )
     if any(dbs_ok.values()):
-        return render_template("ping.html", status="Partially Up", statuses=dbs_ok), 503, resp_headers({"Content-Type": "text/html"})
-    return render_template("ping.html", status="Down", statuses=dbs_ok), 503, resp_headers({"Content-Type": "text/html"})
+        return (
+            render_template("ping.html", status="Partially Up", statuses=dbs_ok),
+            503,
+            resp_headers({"Content-Type": "text/html"}),
+        )
+    return (
+        render_template("ping.html", status="Down", statuses=dbs_ok),
+        503,
+        resp_headers({"Content-Type": "text/html"}),
+    )
 
 
 @app.route("/legend/<string:layer>/<string:style>/legend.png")
-@metrics.histogram('ows_legends', "Legend query durations", labels={
-    "layer": lambda: request.path.split("/")[2],
-    "style": lambda: request.path.split("/")[3],
-    "status": lambda r: r.status,
-})
+@metrics.histogram(
+    "ows_legends",
+    "Legend query durations",
+    labels={
+        "layer": lambda: request.path.split("/")[2],
+        "style": lambda: request.path.split("/")[3],
+        "status": lambda r: r.status,
+    },
+)
 def legend(layer, style, dates=None):
     # pylint: disable=redefined-outer-name
     cfg = get_config()
@@ -235,7 +267,9 @@ def legend(layer, style, dates=None):
         return "Unknown Style", 404, resp_headers({"Content-Type": "text/plain"})
     return img
 
+
 # Flask middleware
+
 
 @app.before_request
 def start_timer() -> None:
@@ -247,15 +281,21 @@ def start_timer() -> None:
 def log_time_and_request_response(response):
     time_taken = int((monotonic() - g.ogc_start_time) * 1000)
     # request.environ.get('HTTP_X_REAL_IP') captures requester ip on a local docker container via gunicorn
-    if request.environ.get('HTTP_X_REAL_IP'):
-        ip = request.environ.get('HTTP_X_REAL_IP')
+    if request.environ.get("HTTP_X_REAL_IP"):
+        ip = request.environ.get("HTTP_X_REAL_IP")
     # request.environ.get('HTTP_X_FORWARDED_FOR') captures request IP forwarded by ingress/loadbalancer
-    elif request.environ.get('HTTP_X_FORWARDED_FOR'):
-        ip = request.environ.get('HTTP_X_FORWARDED_FOR')
+    elif request.environ.get("HTTP_X_FORWARDED_FOR"):
+        ip = request.environ.get("HTTP_X_FORWARDED_FOR")
     # request.environ.get('REMOTE_ADDR') is standard internal IP address
-    elif request.environ.get('REMOTE_ADDR'):
-        ip = request.environ.get('REMOTE_ADDR')
+    elif request.environ.get("REMOTE_ADDR"):
+        ip = request.environ.get("REMOTE_ADDR")
     else:
-        ip = 'Not found'
-    _LOG.info("ip: %s request: %s returned status: %d and took: %d ms", ip, request.url, response.status_code, time_taken)
+        ip = "Not found"
+    _LOG.info(
+        "ip: %s request: %s returned status: %d and took: %d ms",
+        ip,
+        request.url,
+        response.status_code,
+        time_taken,
+    )
     return response

--- a/datacube_ows/ogc_exceptions.py
+++ b/datacube_ows/ogc_exceptions.py
@@ -23,29 +23,33 @@ class OGCException(Exception):
     schema_url: str | None = None
 
     # pylint: disable=super-init-not-called
-    def __init__(self, msg, code=None, locator=None, http_response: int = 400, valid_keys=None) -> None:
+    def __init__(
+        self, msg, code=None, locator=None, http_response: int = 400, valid_keys=None
+    ) -> None:
         self.http_response = http_response
         self.errors: list = []
         self.add_error(msg, code, locator, valid_keys)
 
     def add_error(self, msg, code=None, locator=None, valid_keys=None) -> None:
-        self.errors.append({
-            "msg": msg,
-            "code": code,
-            "locator": locator,
-            "valid_keys": valid_keys
-        })
+        self.errors.append(
+            {"msg": msg, "code": code, "locator": locator, "valid_keys": valid_keys}
+        )
 
     # pylint: disable=dangerous-default-value
-    def exception_response(self, traceback: list | None = None) -> tuple[str, int, dict[str, str]]:
-        return (render_template("ogc_error.xml",
-                                exception=self,
-                                traceback=[] if traceback is None else traceback,
-                                version=self.version,
-                                schema_url=self.schema_url),
-                self.http_response,
-                resp_headers({"Content-Type": "application/xml"})
-               )
+    def exception_response(
+        self, traceback: list | None = None
+    ) -> tuple[str, int, dict[str, str]]:
+        return (
+            render_template(
+                "ogc_error.xml",
+                exception=self,
+                traceback=[] if traceback is None else traceback,
+                version=self.version,
+                schema_url=self.schema_url,
+            ),
+            self.http_response,
+            resp_headers({"Content-Type": "application/xml"}),
+        )
 
 
 class WMSException(OGCException):
@@ -107,9 +111,9 @@ class WCS2Exception(OGCException):
             traceback = []
         exceptions = [
             OWSException(
-                code=error['code'],
-                locator=error['locator'],
-                text=[error['msg'], *tb.format_list(traceback)]
+                code=error["code"],
+                locator=error["locator"],
+                text=[error["msg"], *tb.format_list(traceback)],
             )
             for error in self.errors
         ]
@@ -121,5 +125,5 @@ class WCS2Exception(OGCException):
         return (
             result.value,
             self.http_response,
-            resp_headers({"Content-Type": "application/xml"})
+            resp_headers({"Content-Type": "application/xml"}),
         )

--- a/datacube_ows/ogc_utils.py
+++ b/datacube_ows/ogc_utils.py
@@ -27,17 +27,19 @@ _LOG: logging.Logger = logging.getLogger(__name__)
 
 @deprecat(
     reason="The 'rolling_windows_ndays' mosaicing function has moved to 'datacube.time_utils' - "
-           "please import it from there.",
-    version="1.9.0"
+    "please import it from there.",
+    version="1.9.0",
 )
 def rolling_window_ndays(
-        available_dates: list[datetime.datetime],
-        layer_cfg: "OWSExtensibleConfigEntry",
-        ndays: int = 6) -> tuple[datetime.datetime, datetime.datetime]:
+    available_dates: list[datetime.datetime],
+    layer_cfg: "OWSExtensibleConfigEntry",
+    ndays: int = 6,
+) -> tuple[datetime.datetime, datetime.datetime]:
     from datacube_ows.time_utils import rolling_window_ndays
-    return rolling_window_ndays(available_dates=available_dates,
-                                layer_cfg=layer_cfg,
-                                ndays=ndays)
+
+    return rolling_window_ndays(
+        available_dates=available_dates, layer_cfg=layer_cfg, ndays=ndays
+    )
 
 
 def mask_by_val(data: xarray.Dataset, band: str, val: Any = None) -> xarray.DataArray:
@@ -48,7 +50,7 @@ def mask_by_val(data: xarray.Dataset, band: str, val: Any = None) -> xarray.Data
     :param val: The value to mask by, defaults to None, which means use the 'nodata' value in ODC metadata
     """
     if val is None:
-        return data[band] != data[band].attrs['nodata']
+        return data[band] != data[band].attrs["nodata"]
     return data[band] != val
 
 
@@ -65,10 +67,12 @@ def mask_by_bitflag(data: xarray.Dataset, band: str) -> xarray.DataArray:
     """
     Mask by ODC metadata nodata value, as a bitflag
     """
-    return ~data[band] & data[band].attrs['nodata']
+    return ~data[band] & data[band].attrs["nodata"]
 
 
-def mask_by_val_in_band(data: xarray.Dataset, band: str, mask_band: str, val: Any = None) -> xarray.DataArray:
+def mask_by_val_in_band(
+    data: xarray.Dataset, band: str, mask_band: str, val: Any = None
+) -> xarray.DataArray:
     """
     Mask all bands by a value in a particular band
 
@@ -129,10 +133,13 @@ def mask_by_nan(data: xarray.Dataset, band: str) -> numpy.ndarray:
 
 
 def create_geobox(
-        crs: CRS,
-        minx: float | int, miny: float | int,
-        maxx: float | int, maxy: float | int,
-        width: int | None = None, height: int | None = None,
+    crs: CRS,
+    minx: float | int,
+    miny: float | int,
+    maxx: float | int,
+    maxy: float | int,
+    width: int | None = None,
+    height: int | None = None,
 ) -> GeoBox:
     """
     Create an ODC Geobox.
@@ -156,13 +163,18 @@ def create_geobox(
         scale_x = -scale_y  # pylint: disable=possibly-used-before-assignment
         width = round((float(maxx) - float(minx)) / scale_x)
     if height is None:
-        scale_y = - scale_x
+        scale_y = -scale_x
         height = round((float(miny) - float(maxy)) / scale_y)
     affine = Affine.translation(minx, maxy) * Affine.scale(scale_x, scale_y)
     return GeoBox((height, width), affine, crs)
 
 
-def xarray_image_as_png(img_data: xarray.Dataset, loop_over=None, animate: bool = False, frame_duration: int = 1000):
+def xarray_image_as_png(
+    img_data: xarray.Dataset,
+    loop_over=None,
+    animate: bool = False,
+    frame_duration: int = 1000,
+):
     """
     Render an Xarray image as a PNG.
 
@@ -204,7 +216,15 @@ def xarray_image_as_png(img_data: xarray.Dataset, loop_over=None, animate: bool 
         for t_slice in time_slices_array:
             im = Image.fromarray(t_slice)
             images.append(im)
-        images[0].save(img_io, "PNG", save_all=True, default_image=True, loop=0, duration=frame_duration, append_images=images)
+        images[0].save(
+            img_io,
+            "PNG",
+            save_all=True,
+            default_image=True,
+            loop=0,
+            duration=frame_duration,
+            append_images=images,
+        )
         img_io.seek(0)
         return img_io.read()
 
@@ -236,12 +256,7 @@ def render_frame(img_data: xarray.Dataset, width: int, height: int) -> numpy.nda
     masked = False
     last_band = None
     buffer = numpy.zeros((4, width, height), numpy.uint8)
-    band_index = {
-        "red": 0,
-        "green": 1,
-        "blue": 2,
-        "alpha": 3,
-    }
+    band_index = {"red": 0, "green": 1, "blue": 2, "alpha": 3}
     for band_var in img_data.data_vars:
         band = str(band_var)
         index = band_index[band]
@@ -251,8 +266,8 @@ def render_frame(img_data: xarray.Dataset, width: int, height: int) -> numpy.nda
         buffer[index, :, :] = band_data
         last_band = band_data
     if not masked:
-        assert last_band is not None # For typechecker.
-        alpha_mask = numpy.empty(last_band.shape).astype('uint8')
+        assert last_band is not None  # For typechecker.
+        alpha_mask = numpy.empty(last_band.shape).astype("uint8")
         alpha_mask.fill(255)
         buffer[3, :, :] = alpha_mask
     return buffer.transpose()

--- a/datacube_ows/ows_cfg_example.py
+++ b/datacube_ows/ows_cfg_example.py
@@ -6,7 +6,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-
 # Example configuration file for datacube_ows.
 #
 # The file was originally the only documentation for the configuration file format.
@@ -45,12 +44,11 @@ landsat8_bands = {
     "swir1": ["shortwave_infrared_1", "near_shortwave_infrared"],
     "swir2": ["shortwave_infrared_2", "far_shortwave_infrared"],
     "coastal_aerosol": ["far_blue"],
-
     # N.B. Include pixel quality bands if they are in the main data product.
 }
 
 sentinel2_bands = {
-    "nbar_coastal_aerosol": ['nbar_far_blue'],
+    "nbar_coastal_aerosol": ["nbar_far_blue"],
     "nbar_blue": [],
     "nbar_green": [],
     "nbar_red": [],
@@ -61,18 +59,17 @@ sentinel2_bands = {
     "nbar_nir_2": ["nbar_near_infrared_2"],
     "nbar_swir_2": ["nbar_shortwave_infrared_2"],
     "nbar_swir_3": ["nbar_shortwave_infrared_3"],
-    "nbart_coastal_aerosol": ['coastal_aerosol', 'nbart_far_blue', 'far_blue'],
-    "nbart_blue": ['blue'],
-    "nbart_green": ['green'],
-    "nbart_red": ['red'],
-    "nbart_red_edge_1": ['red_edge_1'],
-    "nbart_red_edge_2": ['red_edge_2'],
-    "nbart_red_edge_3": ['red_edge_3'],
+    "nbart_coastal_aerosol": ["coastal_aerosol", "nbart_far_blue", "far_blue"],
+    "nbart_blue": ["blue"],
+    "nbart_green": ["green"],
+    "nbart_red": ["red"],
+    "nbart_red_edge_1": ["red_edge_1"],
+    "nbart_red_edge_2": ["red_edge_2"],
+    "nbart_red_edge_3": ["red_edge_3"],
     "nbart_nir_1": ["nir_1", "nbart_near_infrared_1"],
     "nbart_nir_2": ["nir_2", "nbart_near_infrared_2"],
     "nbart_swir_2": ["swir_2", "nbart_shortwave_infrared_2"],
     "nbart_swir_3": ["swir_3", "nbart_shortwave_infrared_3"],
-
     # N.B. Include pixel quality bands if they are in the main data product.
     "quality": [],
 }
@@ -96,12 +93,8 @@ style_rgb = {
             # but this is not enforced.
             "red": 1.0
         },
-        "green": {
-            "green": 1.0
-        },
-        "blue": {
-            "blue": 1.0
-        }
+        "green": {"green": 1.0},
+        "blue": {"blue": 1.0},
     },
     # The raw band value range to be compressed to an 8 bit range for the output image tiles.
     # Band values outside this range are clipped to 0 or 255 as appropriate.
@@ -114,54 +107,26 @@ style_rgb = {
         # A legend cannot be auto-generated for a linear combination style, so a url pointing to
         # legend PNG image must be supplied if 'show_legend' is True.
         # Note that legend urls are proxied, not displayed directly to the user.
-        "url": "http://example.com/custom_style_image.png"
-    }
-
+        "url": "http://example.com/custom_style_image.png",
+    },
 }
 
 style_rgb_cloudmask = {
     "name": "cloud_masked_rgb",
     "title": "Simple RGB with cloud masking",
     "abstract": "Simple true-colour image, using the red, green and blue bands, with cloud masking",
-    "components": {
-        "red": {
-            "red": 1.0
-        },
-        "green": {
-            "green": 1.0
-        },
-        "blue": {
-            "blue": 1.0
-        }
-    },
+    "components": {"red": {"red": 1.0}, "green": {"green": 1.0}, "blue": {"blue": 1.0}},
     # PQ masking example
     # Pixels with any of the listed flag values are masked out (made transparent).
-    "pq_masks": [
-        {
-            "flags": {
-                "cloud_acca": "no_cloud",
-                "cloud_fmask": "no_cloud",
-            },
-        },
-    ],
-    "scale_range": [0.0, 3000.0]
+    "pq_masks": [{"flags": {"cloud_acca": "no_cloud", "cloud_fmask": "no_cloud"}}],
+    "scale_range": [0.0, 3000.0],
 }
 
 style_rgb_cloud_and_shadowmask = {
     "name": "cloud_and_shadow_masked_rgb",
     "title": "Simple RGB with cloud and cloud shadow masking",
     "abstract": "Simple true-colour image, using the red, green and blue bands, with cloud and cloud shadow masking",
-    "components": {
-        "red": {
-            "red": 1.0
-        },
-        "green": {
-            "green": 1.0
-        },
-        "blue": {
-            "blue": 1.0
-        }
-    },
+    "components": {"red": {"red": 1.0}, "green": {"green": 1.0}, "blue": {"blue": 1.0}},
     # PQ masking example
     "pq_masks": [
         {
@@ -170,10 +135,10 @@ style_rgb_cloud_and_shadowmask = {
                 "cloud_fmask": "no_cloud",
                 "cloud_shadow_acca": "no_cloud_shadow",
                 "cloud_shadow_fmask": "no_cloud_shadow",
-            },
-        },
+            }
+        }
     ],
-    "scale_range": [0.0, 3000.0]
+    "scale_range": [0.0, 3000.0],
 }
 
 style_ext_rgb = {
@@ -181,18 +146,11 @@ style_ext_rgb = {
     "title": "Extended RGB",
     "abstract": "Extended true-colour image, incorporating the coastal aerosol band",
     "components": {
-        "red": {
-            "red": 1.0
-        },
-        "green": {
-            "green": 1.0
-        },
-        "blue": {
-            "blue": 0.6,
-            "coastal_aerosol": 0.4
-        }
+        "red": {"red": 1.0},
+        "green": {"green": 1.0},
+        "blue": {"blue": 0.6, "coastal_aerosol": 0.4},
     },
-    "scale_range": [0.0, 3000.0]
+    "scale_range": [0.0, 3000.0],
 }
 
 style_ls8_allband_false_colour = {
@@ -200,23 +158,11 @@ style_ls8_allband_false_colour = {
     "title": "Wideband false-colour",
     "abstract": "False-colour image, incorporating all available LS8 spectral bands",
     "components": {
-        "red": {
-            "swir2": 0.255,
-            "swir1": 0.45,
-            "nir": 0.255,
-        },
-        "green": {
-            "nir": 0.255,
-            "red": 0.45,
-            "green": 0.255,
-        },
-        "blue": {
-            "green": 0.255,
-            "blue": 0.45,
-            "coastal_aerosol": 0.255,
-        }
+        "red": {"swir2": 0.255, "swir1": 0.45, "nir": 0.255},
+        "green": {"nir": 0.255, "red": 0.45, "green": 0.255},
+        "blue": {"green": 0.255, "blue": 0.45, "coastal_aerosol": 0.255},
     },
-    "scale_range": [0.0, 3000.0]
+    "scale_range": [0.0, 3000.0],
 }
 
 style_infrared_false_colour = {
@@ -232,14 +178,8 @@ style_infrared_false_colour = {
             # by defining a band alias.)
             "scale_range": [5.0, 4000.0],
         },
-        "green": {
-            "swir2": 1.0,
-            "scale_range": [25.0, 4000.0],
-        },
-        "blue": {
-            "nir": 1.0,
-            "scale_range": [0.0, 3000.0],
-        }
+        "green": {"swir2": 1.0, "scale_range": [25.0, 4000.0]},
+        "blue": {"nir": 1.0, "scale_range": [0.0, 3000.0]},
     },
     # The style scale_range can be omitted if all components have a component-specific scale_range defined.
     # "scale_range": [0.0, 3000.0]
@@ -269,35 +209,22 @@ style_mineral_content = {
             #
             "function": "datacube_ows.band_utils.norm_diff",
             "mapped_bands": True,
-            "kwargs": {
-                "band1": "red",
-                "band2": "blue",
-                "scale_from": [-0.1, 1.0],
-            }
+            "kwargs": {"band1": "red", "band2": "blue", "scale_from": [-0.1, 1.0]},
         },
         "green": {
             "function": "datacube_ows.band_utils.norm_diff",
             "mapped_bands": True,
-            "kwargs": {
-                "band1": "nir",
-                "band2": "swir1",
-                "scale_from": [-0.1, 1.0],
-            }
+            "kwargs": {"band1": "nir", "band2": "swir1", "scale_from": [-0.1, 1.0]},
         },
         "blue": {
             "function": "datacube_ows.band_utils.norm_diff",
             "mapped_bands": True,
-            "kwargs": {
-                "band1": "swir1",
-                "band2": "swir2",
-                "scale_from": [-0.1, 1.0],
-            }
-        }
+            "kwargs": {"band1": "swir1", "band2": "swir2", "scale_from": [-0.1, 1.0]},
+        },
     },
     # If ANY components include a function callback, the bands that need to be passed to the callback
     # MUST be declared in a "additional_bands" item:
-    "additional_bands": ["red", "blue", "nir", "swir1", "swir2"]
-
+    "additional_bands": ["red", "blue", "nir", "swir1", "swir2"],
     #
     # The style scale_range can be omitted if all components have a component-specific scale_range defined or
     # a function callback.
@@ -310,35 +237,19 @@ style_pure_ls8_coastal_aerosol = {
     "title": "Spectral band 1 - Coastal aerosol",
     "abstract": "Coastal aerosol band, approximately 435nm to 450nm",
     "components": {
-        "red": {
-            "coastal_aerosol": 1.0
-        },
-        "green": {
-            "coastal_aerosol": 1.0
-        },
-        "blue": {
-            "coastal_aerosol": 1.0
-        }
+        "red": {"coastal_aerosol": 1.0},
+        "green": {"coastal_aerosol": 1.0},
+        "blue": {"coastal_aerosol": 1.0},
     },
-    "scale_range": [0.0, 3000.0]
+    "scale_range": [0.0, 3000.0],
 }
 
 style_pure_ls8_blue = {
     "name": "blue",
     "title": "Spectral band 2 - Blue",
     "abstract": "Blue band, approximately 453nm to 511nm",
-    "components": {
-        "red": {
-            "blue": 1.0
-        },
-        "green": {
-            "blue": 1.0
-        },
-        "blue": {
-            "blue": 1.0
-        }
-    },
-    "scale_range": [0.0, 3000.0]
+    "components": {"red": {"blue": 1.0}, "green": {"blue": 1.0}, "blue": {"blue": 1.0}},
+    "scale_range": [0.0, 3000.0],
 }
 
 style_pure_ls8_green = {
@@ -346,53 +257,27 @@ style_pure_ls8_green = {
     "title": "Spectral band 3 - Green",
     "abstract": "Green band, approximately 534nm to 588nm",
     "components": {
-        "red": {
-            "green": 1.0
-        },
-        "green": {
-            "green": 1.0
-        },
-        "blue": {
-            "green": 1.0
-        }
+        "red": {"green": 1.0},
+        "green": {"green": 1.0},
+        "blue": {"green": 1.0},
     },
-    "scale_range": [0.0, 3000.0]
+    "scale_range": [0.0, 3000.0],
 }
 
 style_pure_ls8_red = {
     "name": "red",
     "title": "Spectral band 4 - Red",
     "abstract": "Red band, roughly 637nm to 672nm",
-    "components": {
-        "red": {
-            "red": 1.0
-        },
-        "green": {
-            "red": 1.0
-        },
-        "blue": {
-            "red": 1.0
-        }
-    },
-    "scale_range": [0.0, 3000.0]
+    "components": {"red": {"red": 1.0}, "green": {"red": 1.0}, "blue": {"red": 1.0}},
+    "scale_range": [0.0, 3000.0],
 }
 
 style_pure_ls8_nir = {
     "name": "nir",
     "title": "Spectral band 5 - Near infra-red",
     "abstract": "Near infra-red band, roughly 853nm to 876nm",
-    "components": {
-        "red": {
-            "nir": 1.0
-        },
-        "green": {
-            "nir": 1.0
-        },
-        "blue": {
-            "nir": 1.0
-        }
-    },
-    "scale_range": [0.0, 3000.0]
+    "components": {"red": {"nir": 1.0}, "green": {"nir": 1.0}, "blue": {"nir": 1.0}},
+    "scale_range": [0.0, 3000.0],
 }
 
 style_pure_ls8_swir1 = {
@@ -400,17 +285,11 @@ style_pure_ls8_swir1 = {
     "title": "Spectral band 6 - Short wave infra-red 1",
     "abstract": "Short wave infra-red band 1, roughly 1575nm to 1647nm",
     "components": {
-        "red": {
-            "swir1": 1.0
-        },
-        "green": {
-            "swir1": 1.0
-        },
-        "blue": {
-            "swir1": 1.0
-        }
+        "red": {"swir1": 1.0},
+        "green": {"swir1": 1.0},
+        "blue": {"swir1": 1.0},
     },
-    "scale_range": [0.0, 3000.0]
+    "scale_range": [0.0, 3000.0],
 }
 
 style_pure_ls8_swir2 = {
@@ -418,17 +297,11 @@ style_pure_ls8_swir2 = {
     "title": "Spectral band 7 - Short wave infra-red 2",
     "abstract": "Short wave infra-red band 2, roughly 2117nm to 2285nm",
     "components": {
-        "red": {
-            "swir2": 1.0
-        },
-        "green": {
-            "swir2": 1.0
-        },
-        "blue": {
-            "swir2": 1.0
-        }
+        "red": {"swir2": 1.0},
+        "green": {"swir2": 1.0},
+        "blue": {"swir2": 1.0},
     },
-    "scale_range": [0.0, 3000.0]
+    "scale_range": [0.0, 3000.0],
 }
 
 
@@ -458,10 +331,7 @@ style_ndvi = {
     "index_function": {
         "function": "datacube_ows.band_utils.norm_diff",
         "mapped_bands": True,
-        "kwargs": {
-            "band1": "nir",
-            "band2": "red"
-        }
+        "kwargs": {"band1": "nir", "band2": "red"},
     },
     # List of bands used by this style. The band may not be passed to the index function if it is not declared
     # here, resulting in an error.  Band aliases can be used here.
@@ -471,61 +341,26 @@ style_ndvi = {
     "color_ramp": [
         # Any value less than the first entry will have colour and alpha of the first entry.
         # (i.e. in this example all negative values will be fully transparent (alpha=0.0).)
-        {
-            "value": -0.0,
-            "color": "#8F3F20",
-            "alpha": 0.0
-        },
-        {
-            "value": 0.0,
-            "color": "#8F3F20",
-            "alpha": 1.0
-        },
+        {"value": -0.0, "color": "#8F3F20", "alpha": 0.0},
+        {"value": 0.0, "color": "#8F3F20", "alpha": 1.0},
         {
             # do not have to defined alpha value
             # if no alpha is specified, alpha will default to 1.0 (fully opaque)
             "value": 0.1,
-            "color": "#A35F18"
+            "color": "#A35F18",
         },
-        {
-            "value": 0.2,
-            "color": "#B88512"
-        },
-        {
-            "value": 0.3,
-            "color": "#CEAC0E"
-        },
-        {
-            "value": 0.4,
-            "color": "#E5D609"
-        },
-        {
-            "value": 0.5,
-            "color": "#FFFF0C"
-        },
-        {
-            "value": 0.6,
-            "color": "#C3DE09"
-        },
-        {
-            "value": 0.7,
-            "color": "#88B808"
-        },
-        {
-            "value": 0.8,
-            "color": "#529400"
-        },
-        {
-            "value": 0.9,
-            "color": "#237100"
-        },
+        {"value": 0.2, "color": "#B88512"},
+        {"value": 0.3, "color": "#CEAC0E"},
+        {"value": 0.4, "color": "#E5D609"},
+        {"value": 0.5, "color": "#FFFF0C"},
+        {"value": 0.6, "color": "#C3DE09"},
+        {"value": 0.7, "color": "#88B808"},
+        {"value": 0.8, "color": "#529400"},
+        {"value": 0.9, "color": "#237100"},
         # Values greater than the last entry will use the colour and alpha of the last entry.
         # (N.B. This will not happen for this example because it is normalised so that 1.0 is
         # maximum possible value.)
-        {
-            "value": 1.0,
-            "color": "#114D04"
-        }
+        {"value": 1.0, "color": "#114D04"},
     ],
     # If true, the calculated index value for the pixel will be included in GetFeatureInfo responses.
     # Defaults to True.
@@ -538,8 +373,8 @@ style_ndvi = {
         "show_legend": True,
         # Instead of using the generated color ramp legend for the style, a URL to an PNG file can
         # be used instead.  If 'url' is not supplied, the generated legend is used.
-        "url": "http://example.com/custom_style_image.png"
-    }
+        "url": "http://example.com/custom_style_image.png",
+    },
 }
 
 # Examples of non-linear colour-ramped style with multi-date support.
@@ -550,71 +385,29 @@ style_ndvi_delta = {
     "index_function": {
         "function": "datacube_ows.band_utils.norm_diff",
         "mapped_bands": True,
-        "kwargs": {
-            "band1": "nir",
-            "band2": "red"
-        }
+        "kwargs": {"band1": "nir", "band2": "red"},
     },
     "needed_bands": ["red", "nir"],
     # The color ramp for single-date requests - same as ndvi style example above
     "color_ramp": [
-        {
-            "value": -0.0,
-            "color": "#8F3F20",
-            "alpha": 0.0
-        },
-        {
-            "value": 0.0,
-            "color": "#8F3F20",
-            "alpha": 1.0
-        },
-        {
-            "value": 0.1,
-            "color": "#A35F18"
-        },
-        {
-            "value": 0.2,
-            "color": "#B88512"
-        },
-        {
-            "value": 0.3,
-            "color": "#CEAC0E"
-        },
-        {
-            "value": 0.4,
-            "color": "#E5D609"
-        },
-        {
-            "value": 0.5,
-            "color": "#FFFF0C"
-        },
-        {
-            "value": 0.6,
-            "color": "#C3DE09"
-        },
-        {
-            "value": 0.7,
-            "color": "#88B808"
-        },
-        {
-            "value": 0.8,
-            "color": "#529400"
-        },
-        {
-            "value": 0.9,
-            "color": "#237100"
-        },
-        {
-            "value": 1.0,
-            "color": "#114D04"
-        }
+        {"value": -0.0, "color": "#8F3F20", "alpha": 0.0},
+        {"value": 0.0, "color": "#8F3F20", "alpha": 1.0},
+        {"value": 0.1, "color": "#A35F18"},
+        {"value": 0.2, "color": "#B88512"},
+        {"value": 0.3, "color": "#CEAC0E"},
+        {"value": 0.4, "color": "#E5D609"},
+        {"value": 0.5, "color": "#FFFF0C"},
+        {"value": 0.6, "color": "#C3DE09"},
+        {"value": 0.7, "color": "#88B808"},
+        {"value": 0.8, "color": "#529400"},
+        {"value": 0.9, "color": "#237100"},
+        {"value": 1.0, "color": "#114D04"},
     ],
     "include_in_feature_info": True,
     "legend": {
         # Show the legend (default True for colour ramp styles)
         "show_legend": True,
         # Example config for colour ramp style auto-legend generation.
-
         # The range covered by the legend.
         # Defaults to the first and last non transparent (alpha != 0.0)
         # entry in the explicit colour ramp, or the values in the range parameter.
@@ -635,16 +428,13 @@ style_ndvi_delta = {
         # Default is a tick_count of 1, which means only the begin and end ticks.
         # Legend title.  Defaults to the style name.
         "title": "This is not a legend",
-
         # Units
         # added to title of legend in parenthesis, default is to not display units.  To emulate
         # the previous default behaviour use:
         "units": "unitless",
-
         # decimal_places. 1 for "1.0" style labels, 2 for "1.00" and 0 for "1", etc.
         # (default 1)
         "decimal_places": 1,
-
         # tick_labels
         # Labels for individual ticks can be customised"
         "tick_labels": {
@@ -671,32 +461,24 @@ style_ndvi_delta = {
             # Or the label can changed.  Note that the default prefix and suffix
             # are still applied unless explicitly over-ridden.
             # E.g. To display "(max)" for the 1.0 tick:
-            "1.0": {
-                "label": "max"
-            }
+            "1.0": {"label": "max"},
         },
-
         # MatPlotLib rcparams options.
         # Defaults to {} (i.e. matplotlib defaults)
         # See https://matplotlib.org/3.2.2/tutorials/introductory/customizing.html
-        "rcParams": {
-                 "lines.linewidth": 2,
-                 "font.weight": "bold",
-        },
-
+        "rcParams": {"lines.linewidth": 2, "font.weight": "bold"},
         # Image size (in "inches").
         # Matplotlib's default dpi is 100, so measured in hundreds of pixels unless the dpi
         # is over-ridden by the rcParams above.
         # Default is 4x1.25, i.e. 400x125 pixels
         "width": 4,
         "height": 1.25,
-
         # strip_location
         # The location and size of the coloured strip, in format:
         #  [ left, bottom, width, height ], as passed to Matplotlib Figure.add_axes function.
         # All values as fractions of the width and height.  (i.e. between 0.0 and 1.0)
         # The default is:
-        "strip_location": [0.05, 0.5, 0.9, 0.15]
+        "strip_location": [0.05, 0.5, 0.9, 0.15],
     },
     # Define behaviour(s) for multi-date requests. If not declared, style only supports single-date requests.
     "multi_date": [
@@ -730,12 +512,12 @@ style_ndvi_delta = {
             "legend": {
                 # Legend only covers positive part of ramp.
                 "begin": "0.0",
-                "end": "1.0"
+                "end": "1.0",
             },
             # The feature info label for the multi-date index value.
-            "feature_info_label": "ndvi_delta"
+            "feature_info_label": "ndvi_delta",
         }
-    ]
+    ],
 }
 
 # Examples of non-linear colour-ramped style with multi-date animation support.
@@ -746,71 +528,29 @@ style_ndvi_anim = {
     "index_function": {
         "function": "datacube_ows.band_utils.norm_diff",
         "mapped_bands": True,
-        "kwargs": {
-            "band1": "nir",
-            "band2": "red"
-        }
+        "kwargs": {"band1": "nir", "band2": "red"},
     },
     "needed_bands": ["red", "nir"],
     # The color ramp for single-date requests - same as ndvi style example above
     "color_ramp": [
-        {
-            "value": -0.0,
-            "color": "#8F3F20",
-            "alpha": 0.0
-        },
-        {
-            "value": 0.0,
-            "color": "#8F3F20",
-            "alpha": 1.0
-        },
-        {
-            "value": 0.1,
-            "color": "#A35F18"
-        },
-        {
-            "value": 0.2,
-            "color": "#B88512"
-        },
-        {
-            "value": 0.3,
-            "color": "#CEAC0E"
-        },
-        {
-            "value": 0.4,
-            "color": "#E5D609"
-        },
-        {
-            "value": 0.5,
-            "color": "#FFFF0C"
-        },
-        {
-            "value": 0.6,
-            "color": "#C3DE09"
-        },
-        {
-            "value": 0.7,
-            "color": "#88B808"
-        },
-        {
-            "value": 0.8,
-            "color": "#529400"
-        },
-        {
-            "value": 0.9,
-            "color": "#237100"
-        },
-        {
-            "value": 1.0,
-            "color": "#114D04"
-        }
+        {"value": -0.0, "color": "#8F3F20", "alpha": 0.0},
+        {"value": 0.0, "color": "#8F3F20", "alpha": 1.0},
+        {"value": 0.1, "color": "#A35F18"},
+        {"value": 0.2, "color": "#B88512"},
+        {"value": 0.3, "color": "#CEAC0E"},
+        {"value": 0.4, "color": "#E5D609"},
+        {"value": 0.5, "color": "#FFFF0C"},
+        {"value": 0.6, "color": "#C3DE09"},
+        {"value": 0.7, "color": "#88B808"},
+        {"value": 0.8, "color": "#529400"},
+        {"value": 0.9, "color": "#237100"},
+        {"value": 1.0, "color": "#114D04"},
     ],
     "include_in_feature_info": True,
     "legend": {
         # Show the legend (default True for colour ramp styles)
         "show_legend": True,
         # Example config for colour ramp style auto-legend generation.
-
         # The range covered by the legend.
         # Defaults to the first and last non transparent (alpha != 0.0)
         # entry in the explicit colour ramp, or the values in the range parameter.
@@ -831,16 +571,13 @@ style_ndvi_anim = {
         # Default is a tick_count of 1, which means only the begin and end ticks.
         # Legend title.  Defaults to the style name.
         "title": "This is not a legend",
-
         # Units
         # added to title of legend in parenthesis, default is to not display units.  To emulate
         # the previous default behaviour use:
         "units": "unitless",
-
         # decimal_places. 1 for "1.0" style labels, 2 for "1.00" and 0 for "1", etc.
         # (default 1)
         "decimal_places": 1,
-
         # tick_labels
         # Labels for individual ticks can be customised"
         "tick_labels": {
@@ -867,32 +604,24 @@ style_ndvi_anim = {
             # Or the label can changed.  Note that the default prefix and suffix
             # are still applied unless explicitly over-ridden.
             # E.g. To display "(max)" for the 1.0 tick:
-            "1.0": {
-                "label": "max"
-            }
+            "1.0": {"label": "max"},
         },
-
         # MatPlotLib rcparams options.
         # Defaults to {} (i.e. matplotlib defaults)
         # See https://matplotlib.org/3.2.2/tutorials/introductory/customizing.html
-        "rcParams": {
-                 "lines.linewidth": 2,
-                 "font.weight": "bold",
-        },
-
+        "rcParams": {"lines.linewidth": 2, "font.weight": "bold"},
         # Image size (in "inches").
         # Matplotlib's default dpi is 100, so measured in hundreds of pixels unless the dpi
         # is over-ridden by the rcParams above.
         # Default is 4x1.25, i.e. 400x125 pixels
         "width": 4,
         "height": 1.25,
-
         # strip_location
         # The location and size of the coloured strip, in format:
         #  [ left, bottom, width, height ], as passed to Matplotlib Figure.add_axes function.
         # All values as fractions of the width and height.  (i.e. between 0.0 and 1.0)
         # The default is:
-        "strip_location": [0.05, 0.5, 0.9, 0.15]
+        "strip_location": [0.05, 0.5, 0.9, 0.15],
     },
     # Define behaviour(s) for multi-date requests. If not declared, style only supports single-date requests.
     "multi_date": [
@@ -917,66 +646,28 @@ style_ndvi_anim = {
             },
             # The color ramp for single-date requests - same as ndvi style example above
             "color_ramp": [
-                {
-                    "value": -0.0,
-                    "color": "#8F3F20",
-                    "alpha": 0.0
-                },
-                {
-                    "value": 0.0,
-                    "color": "#8F3F20",
-                    "alpha": 1.0
-                },
-                {
-                    "value": 0.1,
-                    "color": "#A35F18"
-                },
-                {
-                    "value": 0.2,
-                    "color": "#B88512"
-                },
-                {
-                    "value": 0.3,
-                    "color": "#CEAC0E"
-                },
-                {
-                    "value": 0.4,
-                    "color": "#E5D609"
-                },
-                {
-                    "value": 0.5,
-                    "color": "#FFFF0C"
-                },
-                {
-                    "value": 0.6,
-                    "color": "#C3DE09"
-                },
-                {
-                    "value": 0.7,
-                    "color": "#88B808"
-                },
-                {
-                    "value": 0.8,
-                    "color": "#529400"
-                },
-                {
-                    "value": 0.9,
-                    "color": "#237100"
-                },
-                {
-                    "value": 1.0,
-                    "color": "#114D04"
-                }
+                {"value": -0.0, "color": "#8F3F20", "alpha": 0.0},
+                {"value": 0.0, "color": "#8F3F20", "alpha": 1.0},
+                {"value": 0.1, "color": "#A35F18"},
+                {"value": 0.2, "color": "#B88512"},
+                {"value": 0.3, "color": "#CEAC0E"},
+                {"value": 0.4, "color": "#E5D609"},
+                {"value": 0.5, "color": "#FFFF0C"},
+                {"value": 0.6, "color": "#C3DE09"},
+                {"value": 0.7, "color": "#88B808"},
+                {"value": 0.8, "color": "#529400"},
+                {"value": 0.9, "color": "#237100"},
+                {"value": 1.0, "color": "#114D04"},
             ],
             "legend": {
                 # Legend only covers positive part of ramp.
                 "begin": "0.0",
-                "end": "1.0"
+                "end": "1.0",
             },
             # The feature info label for the multi-date animation performs a pixel drill.
-            "feature_info_label": "ndvi_anim"
+            "feature_info_label": "ndvi_anim",
         }
-    ]
+    ],
 }
 
 # Examples of Matplotlib Color-Ramp styles
@@ -1008,7 +699,7 @@ style_deform = {
         # decimal places for tick labels
         # set to 0 for ints
         "decimal_places": 0,
-    }
+    },
 }
 
 style_ndvi_cloudmask = {
@@ -1018,10 +709,7 @@ style_ndvi_cloudmask = {
     "index_function": {
         "function": "datacube_ows.band_utils.norm_diff",
         "mapped_bands": True,
-        "kwargs": {
-            "band1": "nir",
-            "band2": "red"
-        }
+        "kwargs": {"band1": "nir", "band2": "red"},
     },
     "needed_bands": ["red", "nir"],
     # If a "range" is supplied instead of a "color_ramp", a default color ramp is used.
@@ -1031,14 +719,7 @@ style_ndvi_cloudmask = {
     # Areas where the index_function returns greater than the upper range limit are displayed as dark red.
     "range": [0.0, 1.0],
     # Cloud masks work the same as for linear combination styles.
-    "pq_masks": [
-        {
-            "flags": {
-                "cloud_acca": "no_cloud",
-                "cloud_fmask": "no_cloud",
-            },
-        },
-    ],
+    "pq_masks": [{"flags": {"cloud_acca": "no_cloud", "cloud_fmask": "no_cloud"}}],
     # Already have NDVI in GetFeatureInfo.
     "include_in_feature_info": False,
 }
@@ -1050,10 +731,7 @@ style_ndwi = {
     "index_function": {
         "function": "datacube_ows.band_utils.norm_diff",
         "mapped_bands": True,
-        "kwargs": {
-            "band1": "green",
-            "band2": "nir"
-        }
+        "kwargs": {"band1": "green", "band2": "nir"},
     },
     "needed_bands": ["green", "nir"],
     "range": [0.0, 1.0],
@@ -1066,10 +744,7 @@ style_ndbi = {
     "index_function": {
         "function": "datacube_ows.band_utils.norm_diff",
         "mapped_bands": True,
-        "kwargs": {
-            "band1": "swir2",
-            "band2": "nir"
-        }
+        "kwargs": {"band1": "swir2", "band2": "nir"},
     },
     "needed_bands": ["swir2", "nir"],
     "range": [0.0, 1.0],
@@ -1083,77 +758,27 @@ style_wofs_frequency = {
     "index_function": {
         "function": "datacube_ows.band_utils.single_band",
         "mapped_bands": True,
-        "kwargs": {
-            "band": "frequency",
-        }
+        "kwargs": {"band": "frequency"},
     },
     # Should the index_function value be shown as a derived band in GetFeatureInfo responses.
     # Defaults to true for style types with an index function.
     "include_in_feature_info": False,
     "color_ramp": [
-        {
-            "value": 0.002,
-            "color": "#000000",
-            "alpha": 0.0
-        },
-        {
-            "value": 0.005,
-            "color": "#8e0101",
-            "alpha": 0.25
-        },
-        {
-            "value": 0.01,
-            "color": "#cf2200",
-            "alpha": 0.75
-        },
-        {
-            "value": 0.02,
-            "color": "#e38400"
-        },
-        {
-            "value": 0.05,
-            "color": "#e3df00"
-        },
-        {
-            "value": 0.1,
-            "color": "#a6e300"
-        },
-        {
-            "value": 0.2,
-            "color": "#62e300"
-        },
-        {
-            "value": 0.3,
-            "color": "#00e32d"
-        },
-        {
-            "value": 0.4,
-            "color": "#00e384"
-        },
-        {
-            "value": 0.5,
-            "color": "#00e3c8"
-        },
-        {
-            "value": 0.6,
-            "color": "#00c5e3"
-        },
-        {
-            "value": 0.7,
-            "color": "#0097e3"
-        },
-        {
-            "value": 0.8,
-            "color": "#005fe3"
-        },
-        {
-            "value": 0.9,
-            "color": "#000fe3"
-        },
-        {
-            "value": 1.0,
-            "color": "#5700e3",
-        }
+        {"value": 0.002, "color": "#000000", "alpha": 0.0},
+        {"value": 0.005, "color": "#8e0101", "alpha": 0.25},
+        {"value": 0.01, "color": "#cf2200", "alpha": 0.75},
+        {"value": 0.02, "color": "#e38400"},
+        {"value": 0.05, "color": "#e3df00"},
+        {"value": 0.1, "color": "#a6e300"},
+        {"value": 0.2, "color": "#62e300"},
+        {"value": 0.3, "color": "#00e32d"},
+        {"value": 0.4, "color": "#00e384"},
+        {"value": 0.5, "color": "#00e3c8"},
+        {"value": 0.6, "color": "#00c5e3"},
+        {"value": 0.7, "color": "#0097e3"},
+        {"value": 0.8, "color": "#005fe3"},
+        {"value": 0.9, "color": "#000fe3"},
+        {"value": 1.0, "color": "#5700e3"},
     ],
     # defines the format of the legend generated
     # for this style
@@ -1172,8 +797,8 @@ style_wofs_frequency = {
             "0.50": {"label": "50"},
             "0.75": {"label": "75"},
             "1.00": {"label": "100"},
-        }
-    }
+        },
+    },
 }
 
 # Mask layers - examples of how to display raw pixel quality data.
@@ -1187,10 +812,7 @@ style_cloud_mask = {
     "index_function": {
         "function": "datacube_ows.band_utils.constant",
         "mapped_bands": True,
-        "kwargs": {
-            "band": "red",
-            "const": "0.1"
-        }
+        "kwargs": {"band": "red", "const": "0.1"},
     },
     "needed_bands": ["red"],
     "range": [0.0, 1.0],
@@ -1203,13 +825,7 @@ style_cloud_mask = {
     #      Specifying "cloud"for both flags and setting the "pq_mask_invert" to False would
     #      show pixels which are not clouds in both metrics.
     "pq_masks": [
-        {
-            "invert": True,
-            "flags": {
-                "cloud_acca": "no_cloud",
-                "cloud_fmask": "no_cloud",
-            },
-        },
+        {"invert": True, "flags": {"cloud_acca": "no_cloud", "cloud_fmask": "no_cloud"}}
     ],
     "legend": {
         # Default legend won't work well with mask layers, so set 'show_legend' to False or provide a url to
@@ -1232,25 +848,12 @@ style_rgb_ndvi = {
     "index_function": {
         "function": "datacube_ows.band_utils.norm_diff",
         "mapped_bands": True,
-        "kwargs": {
-            "band1": "nir",
-            "band2": "red"
-        }
+        "kwargs": {"band1": "nir", "band2": "red"},
     },
     "needed_bands": ["red", "nir"],
     "range": [0.0, 1.0],
-    "components": {
-        "red": {
-            "red": 1.0
-        },
-        "green": {
-            "green": 1.0
-        },
-        "blue": {
-            "blue": 1.0
-        }
-    },
-    "scale_range": [0.0, 3000.0]
+    "components": {"red": {"red": 1.0}, "green": {"green": 1.0}, "blue": {"blue": 1.0}},
+    "scale_range": [0.0, 3000.0],
     # N.B. The "pq_mask" section works the same as for the style types above.
 }
 
@@ -1270,17 +873,13 @@ style_mangrove = {
                 # flags that all must match
                 # in order for this style color to apply
                 # "and" and "or" flags cannot be mixed
-                "flags": {
-                    "and": {
-                        "woodland": True
-                    }
-                },
+                "flags": {"and": {"woodland": True}},
                 "color": "#9FFF4C",
                 # If specified as True (defaults to False)
                 # Any areas which match this flag set
                 # will be masked out completely, similar to using an extent
                 # mask function or pq masking
-                "mask": True
+                "mask": True,
             },
             {
                 "title": "Open Forest",
@@ -1288,26 +887,20 @@ style_mangrove = {
                 # flags that any may match
                 # in order for this style color to apply
                 # "and" and "or" flags cannot be mixed
-                "flags": {
-                    "or": {
-                        "open_forest": True
-                    }
-                },
+                "flags": {"or": {"open_forest": True}},
                 "color": "#5ECC00",
                 # Can set an optional alpha value (0.0 - 1.0) for these colors
                 # will default to 1.0 (fully opaque)
-                "alpha": 0.5
+                "alpha": 0.5,
             },
             {
                 "title": "Closed Forest",
                 "abstract": "(>80% cover)",
-                "flags": {
-                    "closed_forest": True
-                },
-                "color": "#3B7F00"
+                "flags": {"closed_forest": True},
+                "color": "#3B7F00",
             },
         ]
-    }
+    },
     # NB: You can also do additional masking using the "pq_mask" section as described above for other
     #     style types.
 }
@@ -1330,7 +923,6 @@ standard_resource_limits = {
         #
         # Defaults to [150, 180, 200, 160]
         "zoomed_out_fill_colour": [150, 180, 200, 160],
-
         # WMS/WMTS Resource Limit 1: Min zoom factor
         #
         # The zoom factor is a dimensionless number calculated from the request in a way that is independent
@@ -1341,7 +933,6 @@ standard_resource_limits = {
         #
         # Defaults to 300.0
         "min_zoom_factor": 500.0,
-
         # Min zoom factor (above) works well for small-tiled requests, (e.g. 256x256 as sent by Terria).
         # However, for large-tiled requests (e.g. as sent by QGIS), large and intensive queries can still
         # go through to the datacube.
@@ -1374,7 +965,7 @@ standard_resource_limits = {
             {
                 # Where number of datasets greater than or equal to the min_datasets value for this rule AND
                 # less than the min_datasets of the next rule (4-7 in this example)
-                "min_datasets": 4, # Must be greater than zero.  Blank tiles (0 datasets) are NEVER cached
+                "min_datasets": 4,  # Must be greater than zero.  Blank tiles (0 datasets) are NEVER cached
                 # The cache-control max-age for this rule, in seconds.
                 "max_age": 86400,  # 86400 seconds = 24 hours
             },
@@ -1389,17 +980,17 @@ standard_resource_limits = {
             # 4-7 datasets: max-age: 86400
             # 8-10 datasets: max-age: 604800
             # 11+ datasets:  no-cache (over-limit behaviour.  Low-resolution summary product or shaded polygons.)
-        ]
+        ],
     },
     "wcs": {
         # wcs::max_datasets is the WCS equivalent of wms::max_datasets.  The main requirement for setting this
         # value is to avoid gateway timeouts on overly large WCS requests (and reduce server load).
         #
         # Defaults to zero, which is interpreted as no dataset limit.
-        "max_datasets": 16,
+        "max_datasets": 16
         # dataset_cache_rules can be set independently for WCS requests.  This example omits it, so
         # WCS GetCoverage requests will always return no cache-control header.
-    }
+    },
 }
 
 
@@ -1408,28 +999,25 @@ standard_resource_limits = {
 ows_cfg = {
     # Config entries in the "global" section apply to all services and all layers/coverages
     "global": {
-
         # These HTML headers are added to all responses
         # Optional, default {} - no added headers
         "response_headers": {
-            "Access-Control-Allow-Origin": "*",  # CORS header (strongly recommended)
+            "Access-Control-Allow-Origin": "*"  # CORS header (strongly recommended)
         },
         # Which web service(s) should be implemented by this instance
         # Optional, defaults: wms,wmts: True, wcs: False
-        "services": {
-            "wms": True,
-            "wmts": True,
-            "wcs": True
-        },
+        "services": {"wms": True, "wmts": True, "wcs": True},
         # Service title - appears e.g. in Terria catalog (required)
         "title": "Open web-services for the Open Data Cube",
         # Service URL.
         # A list of fully qualified URLs that the service can return
         # in the GetCapabilities documents based on the requesting url
-        "allowed_urls": ["http://localhost/odc_ows",
-                          "https://localhost/odc_ows",
-                          "https://alternateurl.domain.org/odc_ows",
-                          "http://127.0.0.1:8000/"],
+        "allowed_urls": [
+            "http://localhost/odc_ows",
+            "https://localhost/odc_ows",
+            "https://alternateurl.domain.org/odc_ows",
+            "http://127.0.0.1:8000/",
+        ],
         # URL that humans can visit to learn more about the service(s) or organization
         # should be fully qualified
         "info_url": "http://opendatacube.org",
@@ -1438,11 +1026,7 @@ ows_cfg = {
         "abstract": """This web-service serves georectified raster data from our very own special Open Data Cube instance.""",
         # Keywords included for all services and products
         # Optional - defaults to empty list.
-        "keywords": [
-            "satellite",
-            "australia",
-            "time-series",
-        ],
+        "keywords": ["satellite", "australia", "time-series"],
         # Contact info.
         # Optional but strongly recommended - defaults to blank.
         "contact_info": {
@@ -1482,7 +1066,7 @@ ows_cfg = {
                 "url": "https://www.acme.com/satellites/images/acme-370x73.png",
                 # Image MIME type for the logo - should match type referenced in the logo url (required if logo specified.)
                 "format": "image/png",
-            }
+            },
         },
         # If fees are charged for the use of the service, these can be described here in free text.
         # If blank or not included, defaults to "none".
@@ -1502,10 +1086,10 @@ ows_cfg = {
             },
             "EPSG:4326": {  # WGS-84
                 "geographic": True,
-                "vertical_coord_first": True
+                "vertical_coord_first": True,
             },
             "EPSG:3111": {  # VicGrid94 for delwp.vic.gov.au
-               "geographic": False,
+                "geographic": False,
                 "horizontal_coord": "x",
                 "vertical_coord": "y",
             },
@@ -1515,8 +1099,7 @@ ows_cfg = {
                 "vertical_coord": "y",
             },
         },
-    },   #### End of "global" section.
-
+    },  #### End of "global" section.
     # Config items in the "wms" section apply to the WMS service (and WMTS, which is implemented as a
     # thin wrapper to the WMS code unless stated otherwise) to all WMS/WMTS layers (unless over-ridden).
     "wms": {
@@ -1531,7 +1114,6 @@ ows_cfg = {
         # Optional, defaults to 256x256
         "max_width": 512,
         "max_height": 512,
-
         # These define the AuthorityURLs.
         # They represent the authorities that define the "Identifiers" defined layer by layer below.
         # The spec allows AuthorityURLs to be defined anywhere on the Layer heirarchy, but datacube_ows treats them
@@ -1541,9 +1123,8 @@ ows_cfg = {
             # The authorities dictionary maps names to authority urls.
             "auth": "https://authoritative-authority.com",
             "idsrus": "https://www.identifiers-r-us.com",
-        }
-    }, ####  End of "wms" section.
-
+        },
+    },  ####  End of "wms" section.
     # Config items in the "wmts" section apply to the WMTS service only.
     # Note that most items in the "wms" section apply to the WMTS service
     # as well as the WMS service.
@@ -1593,10 +1174,9 @@ ows_cfg = {
                 # is 2**1 = 2
                 # So tiles side by side (2x1) (then 4x2, 8x4, 16x8, etc.)
                 "matrix_exponent_initial_offsets": (1, 0),
-            },
+            }
         }
     },
-
     # Config items in the "wcs" section apply to the WCS service to all WCS coverages
     # (unless over-ridden).
     "wcs": {
@@ -1616,7 +1196,7 @@ ows_cfg = {
                 # The file extension to add to the filename.
                 "extension": "tif",
                 # Whether or not the file format supports multiple time slices.
-                "multi-time": False
+                "multi-time": False,
             },
             "netCDF": {
                 "renderers": {
@@ -1626,14 +1206,13 @@ ows_cfg = {
                 "mime": "application/x-netcdf",
                 "extension": "nc",
                 "multi-time": True,
-            }
+            },
         },
         # The wcs:native_format must be declared in wcs:formats dict above.
         # Maybe over-ridden at the named layer (i.e. coverage)
         # level.
         "native_format": "GeoTIFF",
-    }, ###### End of "wcs" section
-
+    },  ###### End of "wcs" section
     # Products published by this datacube_ows instance.
     # The layers section is a list of layer definitions.  Each layer may be either:
     # 1) A folder-layer.  Folder-layers are not named and can contain a list of child layers.  Folder-layers are
@@ -1649,15 +1228,11 @@ ows_cfg = {
             # to that of the parent layer.
             "abstract": "Images from the Landsat 8 satellite",
             # NOTE: Folder-layers do not have a layer "name".
-
             # Keywords are optional, but can be added at any folder level and are cumulative.
             # A layer combines its own keywords, the keywords of it's parent (and grandparent, etc) layers,
             # and any keywords defined in the global section above.
             #
-            "keywords": [
-                "landsat",
-                "landsat8",
-            ],
+            "keywords": ["landsat", "landsat8"],
             # Attribution.  This entire section is optional.  If provided, it overrides any
             #               attribution defined in the wms section above or any higher layers, and
             #               applies to this layer and all child layers under this layer unless itself
@@ -1678,7 +1253,7 @@ ows_cfg = {
                     "url": "https://www.ga.gov.au/__data/assets/image/0011/61589/GA-DEA-Logo-Inline-370x73.png",
                     # Image MIME type for the logo - should match type referenced in the logo url (required if logo specified.)
                     "format": "image/png",
-                }
+                },
             },
             # Folder-type layers include a list of sub-layers
             "layers": [
@@ -1693,7 +1268,6 @@ ows_cfg = {
                     "name": "ls8_nbart_albers",
                     # The ODC product name for the associated data product
                     "product_name": "ls8_nbart_albers",
-
                     # Supported bands, mapping native band names to a list of possible aliases.
                     # See reusable band alias maps above for documentation.
                     "bands": landsat8_bands,
@@ -1809,7 +1383,6 @@ ows_cfg = {
                     # If the WCS section is not supplied, then this named layer will NOT appear as a WCS
                     # coverage (but will still be a layer in WMS and WMTS).
                     "wcs": {
-
                         # The default bands for a WCS request.
                         # 1. Must be provided if WCS is activated.
                         # 2. Must contain at least one band.
@@ -1821,14 +1394,14 @@ ows_cfg = {
                         # in the global wcs formats section.
                         # Optional: if not supplied defaults to the
                         # globally defined native_format.
-                        "native_format": "NetCDF"
+                        "native_format": "NetCDF",
                     },
                     # Each key of the identifiers dictionary must match a name from the authorities dictionary
                     # in the global section.  The values are the identifiers defined for this layer by that
                     # authority.
                     "identifiers": {
                         "auth": "ls8_ard",
-                        "idsrus": "12345435::0054234::GHW::24356-splunge"
+                        "idsrus": "12345435::0054234::GHW::24356-splunge",
                     },
                     # The urls section provides the values that are included in the FeatureListURLs and
                     # DataURLs sections of a WMS GetCapabilities document.
@@ -1845,19 +1418,19 @@ ows_cfg = {
                         "features": [
                             {
                                 "url": "http://domain.tld/path/to/page.html",
-                                "format": "text/html"
+                                "format": "text/html",
                             },
                             {
                                 "url": "http://another-domain.tld/path/to/image.png",
-                                "format": "image/png"
-                            }
+                                "format": "image/png",
+                            },
                         ],
                         "data": [
                             {
                                 "url": "http://abc.xyz/data-link.xml",
-                                "format": "application/xml"
+                                "format": "application/xml",
                             }
-                        ]
+                        ],
                     },
                     # The feature_info section is optional.
                     "feature_info": {
@@ -1876,9 +1449,9 @@ ows_cfg = {
                                 "mapped_bands": False,
                                 "kwargs": {
                                     "template": "https://host.domain/path/{data['f_id']:06}.csv"
-                                }
+                                },
                             }
-                        }
+                        },
                     },
                     # The sub_products section is optional.
                     "sub_products": {
@@ -1904,18 +1477,28 @@ ows_cfg = {
                         # style.  See reusable style definitions above for more documentation on
                         # defining styles.
                         "styles": [
-                            style_rgb, style_rgb_cloudmask, style_rgb_cloud_and_shadowmask,
-                            style_ext_rgb, style_ls8_allband_false_colour, style_infrared_false_colour,
-                            style_pure_ls8_coastal_aerosol, style_pure_ls8_blue,
-                            style_pure_ls8_green, style_pure_ls8_red,
-                            style_pure_ls8_nir, style_pure_ls8_swir1, style_pure_ls8_swir2,
-                            style_ndvi, style_ndvi_cloudmask,
-                            style_ndwi, style_ndbi,
+                            style_rgb,
+                            style_rgb_cloudmask,
+                            style_rgb_cloud_and_shadowmask,
+                            style_ext_rgb,
+                            style_ls8_allband_false_colour,
+                            style_infrared_false_colour,
+                            style_pure_ls8_coastal_aerosol,
+                            style_pure_ls8_blue,
+                            style_pure_ls8_green,
+                            style_pure_ls8_red,
+                            style_pure_ls8_nir,
+                            style_pure_ls8_swir1,
+                            style_pure_ls8_swir2,
+                            style_ndvi,
+                            style_ndvi_cloudmask,
+                            style_ndwi,
+                            style_ndbi,
                             style_cloud_mask,
-                            style_rgb_ndvi
-                        ]
-                    }
-                }, #### End of ls8_nbart_albers product
+                            style_rgb_ndvi,
+                        ],
+                    },
+                },  #### End of ls8_nbart_albers product
                 {
                     # NOTE: This layer IS a mappable "named layer" that can be selected in GetMap requests
                     "title": "Level 1 USGS Landsat-8 Public Data Set",
@@ -1947,26 +1530,30 @@ ows_cfg = {
                         "manual_merge": True,
                         # Apply corrections for solar angle, for "Level 1" products.
                         # (Defaults to false - should not be used for NBAR/NBAR-T or other Analysis Ready products
-                        "apply_solar_corrections": True
+                        "apply_solar_corrections": True,
                     },
-                    "wcs": {
-                        "default_bands": ["red", "green", "blue"],
-                    },
+                    "wcs": {"default_bands": ["red", "green", "blue"]},
                     "styling": {
                         "default_style": "simple_rgb",
                         "styles": [
-                            style_rgb, style_ext_rgb,
-                            style_ls8_allband_false_colour, style_infrared_false_colour,
-                            style_pure_ls8_coastal_aerosol, style_pure_ls8_blue,
-                            style_pure_ls8_green, style_pure_ls8_red,
-                            style_pure_ls8_nir, style_pure_ls8_swir1, style_pure_ls8_swir2,
-                            style_ndvi, style_ndwi, style_ndbi,
-                            style_rgb_ndvi
-                        ]
-                    }
-                }, ##### End of ls8_level1_pds product definition.
-
-
+                            style_rgb,
+                            style_ext_rgb,
+                            style_ls8_allband_false_colour,
+                            style_infrared_false_colour,
+                            style_pure_ls8_coastal_aerosol,
+                            style_pure_ls8_blue,
+                            style_pure_ls8_green,
+                            style_pure_ls8_red,
+                            style_pure_ls8_nir,
+                            style_pure_ls8_swir1,
+                            style_pure_ls8_swir2,
+                            style_ndvi,
+                            style_ndwi,
+                            style_ndbi,
+                            style_rgb_ndvi,
+                        ],
+                    },
+                },  ##### End of ls8_level1_pds product definition.
                 {
                     # NOTE: This layer IS a mappable "named layer" that can be selected in GetMap requests
                     "title": "WOfS Summary",
@@ -1982,25 +1569,16 @@ ows_cfg = {
                         "extent_mask_func": "datacube_ows.ogc_utils.mask_by_val",
                         "fuse_func": "datacube_ows.wms_utils.wofls_fuser",
                     },
-                    "wcs": {
-                        "default_bands": ["frequency"],
-                    },
-                    "styling": {
-                        "styles": [
-                            style_wofs_frequency
-                        ]
-                    }
-                }, ##### End of wofs_summary product definition.
-
-            ]
+                    "wcs": {"default_bands": ["frequency"]},
+                    "styling": {"styles": [style_wofs_frequency]},
+                },  ##### End of wofs_summary product definition.
+            ],
         },  ### End of Landsat 8 folder.
         {
             # NOTE: This layer is a folder - it is NOT "named layer" that can be selected in GetMap requests
             "title": "Sentinel-2 Products",
             "abstract": "Products containing data ultimately derived from ESA's Sentinel-2 satellite.",
-            "keywords": [
-                "sentinel2",
-            ],
+            "keywords": ["sentinel2"],
             "layers": [
                 {
                     # NOTE: This layer IS a mappable "named layer" that can be selected in GetMap requests
@@ -2031,33 +1609,26 @@ ows_cfg = {
                         "manual_merge": False,
                         "apply_solar_corrections": False,
                     },
-                    "wcs": {
-                        "default_bands": ["red", "green", "blue"],
-                    },
-                    "identifiers": {
-                        "auth": "s2_nrt_multi",
-                    },
+                    "wcs": {"default_bands": ["red", "green", "blue"]},
+                    "identifiers": {"auth": "s2_nrt_multi"},
                     "urls": {
                         "features": [
                             {
                                 "url": "http://domain.tld/path/to/page.html",
-                                "format": "text/html"
+                                "format": "text/html",
                             }
                         ],
                         "data": [
                             {
                                 "url": "http://abc.xyz/data-link.xml",
-                                "format": "application/xml"
+                                "format": "application/xml",
                             }
-                        ]
+                        ],
                     },
-                    "styling": {
-                        "default_style": "simple_rgb",
-                        "styles": [style_rgb],
-                    }
-                } ##### End of sentinel2_nrt multi-product definition
+                    "styling": {"default_style": "simple_rgb", "styles": [style_rgb]},
+                }  ##### End of sentinel2_nrt multi-product definition
             ],
-        },   #### End of Sentinel-2 folder
+        },  #### End of Sentinel-2 folder
         {
             # NOTE: This layer IS a mappable "named layer" that can be selected in GetMap requests
             # NOTE: Named layers can sit at the same heirarchical level as folder layers.
@@ -2075,30 +1646,20 @@ ows_cfg = {
                 "manual_merge": False,
                 "apply_solar_corrections": False,
             },
-            "wcs": {
-                "default_bands": ["canopy_cover_class"],
-            },
-            "identifiers": {
-                "auth": "mangrove_canopy_cover",
-            },
+            "wcs": {"default_bands": ["canopy_cover_class"]},
+            "identifiers": {"auth": "mangrove_canopy_cover"},
             "urls": {
                 "features": [
                     {
                         "url": "http://domain.tld/path/to/page.html",
-                        "format": "text/html"
+                        "format": "text/html",
                     }
                 ],
                 "data": [
-                    {
-                        "url": "http://abc.xyz/data-link.xml",
-                        "format": "application/xml"
-                    }
-                ]
+                    {"url": "http://abc.xyz/data-link.xml", "format": "application/xml"}
+                ],
             },
-            "styling": {
-                "default_style": "mangrove",
-                "styles": [style_mangrove],
-            }
-        } ##### End of mangrove_cover definition
-    ]  ##### End of "layers" list.
-} #### End of example configuration object
+            "styling": {"default_style": "mangrove", "styles": [style_mangrove]},
+        },  ##### End of mangrove_cover definition
+    ],  ##### End of "layers" list.
+}  #### End of example configuration object

--- a/datacube_ows/ows_configuration.py
+++ b/datacube_ows/ows_configuration.py
@@ -92,7 +92,8 @@ def read_config(path: str | None = None) -> CFG_DICT:
     if isinstance(expansion, dict):
         return expansion
     raise ConfigException(
-        f"Top level config must be a dict: {expansion!r} ({expansion.__class__.__name__})")
+        f"Top level config must be a dict: {expansion!r} ({expansion.__class__.__name__})"
+    )
 
 
 class BandIndex(OWSMetadataConfig):
@@ -125,11 +126,15 @@ class BandIndex(OWSMetadataConfig):
     def add_aliases(self, cfg: dict[str, list[str]]) -> None:
         for b, aliases in cfg.items():
             if b in self._idx:
-                raise ConfigException(f"Duplicate band name/alias: {b} in layer {self.layer_name}")
+                raise ConfigException(
+                    f"Duplicate band name/alias: {b} in layer {self.layer_name}"
+                )
             self._idx[b] = b
             for a in aliases:
                 if a != b and a in self._idx:
-                    raise ConfigException(f"Duplicate band name/alias: {a} in layer {self.layer_name}")
+                    raise ConfigException(
+                        f"Duplicate band name/alias: {a} in layer {self.layer_name}"
+                    )
                 self._idx[a] = b
 
     @override
@@ -140,6 +145,7 @@ class BandIndex(OWSMetadataConfig):
             if isinstance(inp, str):
                 raise ValueError("Invalid nodata value: {inp}")
             return inp
+
         default_to_all = not bool(self._raw_cfg)
         # pylint: disable=attribute-defined-outside-init
         self.measurements: dict[str, Measurement] = {}
@@ -154,22 +160,38 @@ class BandIndex(OWSMetadataConfig):
                 self.add_aliases(self.band_cfg)
             try:
                 prod_measurements = cast(
-                    dict[str, Measurement], product.lookup_measurements(list(self.band_cfg.keys()))
+                    dict[str, Measurement],
+                    product.lookup_measurements(list(self.band_cfg.keys())),
                 )
                 if first_product:
                     self.measurements = prod_measurements
-                    self._nodata_vals = {name: floatify_nans(model.nodata) for name, model in self.measurements.items()}
-                    self._dtypes = {name: numpy.dtype(model.dtype) for name, model in self.measurements.items()}
+                    self._nodata_vals = {
+                        name: floatify_nans(model.nodata)
+                        for name, model in self.measurements.items()
+                    }
+                    self._dtypes = {
+                        name: numpy.dtype(model.dtype)
+                        for name, model in self.measurements.items()
+                    }
                 else:
                     for k in prod_measurements:
                         nodata = self._nodata_vals[k]
-                        if ((numpy.isnan(nodata) and not numpy.isnan(floatify_nans(prod_measurements[k].nodata)))
-                                or (not numpy.isnan(nodata) and prod_measurements[k].nodata != nodata)):
+                        if (
+                            numpy.isnan(nodata)
+                            and not numpy.isnan(
+                                floatify_nans(prod_measurements[k].nodata)
+                            )
+                        ) or (
+                            not numpy.isnan(nodata)
+                            and prod_measurements[k].nodata != nodata
+                        ):
                             raise ConfigException(
-                                f"Nodata value mismatch between products for band {k} in multiproduct layer {self.layer_name}")
+                                f"Nodata value mismatch between products for band {k} in multiproduct layer {self.layer_name}"
+                            )
                         if prod_measurements[k].dtype != self._dtypes[k]:
                             raise ConfigException(
-                                f"Data type mismatch between products for band {k} in multiproduct layer {self.layer_name}")
+                                f"Data type mismatch between products for band {k} in multiproduct layer {self.layer_name}"
+                            )
             except KeyError as e:
                 raise ConfigException(
                     f"Product {product.name} in layer {self.layer_name} is missing band {e}"
@@ -180,7 +202,9 @@ class BandIndex(OWSMetadataConfig):
     def band(self, name_alias: str) -> str:
         if name_alias in self._idx:
             return self._idx[name_alias]
-        raise ConfigException(f"Unknown band name/alias: {name_alias} in layer {self.layer_name}")
+        raise ConfigException(
+            f"Unknown band name/alias: {name_alias} in layer {self.layer_name}"
+        )
 
     def locale_band(self, name_alias: str) -> str:
         try:
@@ -221,7 +245,9 @@ class AttributionCfg(OWSConfigEntry):
         self.url = cast(str | None, cfg.get("url"))
         logo = cast(dict[str, str] | None, cfg.get("logo"))
         if not self.title and not self.url and not logo:
-            raise ConfigException("At least one of title, url and logo is required in an attribution definition")
+            raise ConfigException(
+                "At least one of title, url and logo is required in an attribution definition"
+            )
         if not logo:
             self.logo_width: int | None = None
             self.logo_height: int | None = None
@@ -229,18 +255,24 @@ class AttributionCfg(OWSConfigEntry):
             self.logo_fmt: str | None = None
         else:
             self.logo_width = None if logo.get("width") is None else int(logo["width"])
-            self.logo_height = None if logo.get("height") is None else int(logo["height"])
+            self.logo_height = (
+                None if logo.get("height") is None else int(logo["height"])
+            )
             self.logo_url = logo.get("url")
             self.logo_fmt = logo.get("format")
             if not self.logo_url or not self.logo_fmt:
-                raise ConfigException("url and format must both be specified in an attribution logo.")
+                raise ConfigException(
+                    "url and format must both be specified in an attribution logo."
+                )
 
     @property
     def title(self) -> str:
         return self.owner.attribution_title  # ????
 
     @classmethod
-    def parse(cls, cfg: CFG_DICT | None, owner: Union["OWSConfig", "OWSLayer"]) -> Optional["AttributionCfg"]:
+    def parse(
+        cls, cfg: CFG_DICT | None, owner: Union["OWSConfig", "OWSLayer"]
+    ) -> Optional["AttributionCfg"]:
         if not cfg:
             return None
         return cls(cfg, owner)
@@ -264,7 +296,14 @@ class OWSLayer(OWSMetadataConfig):
     METADATA_ATTRIBUTION = True
 
     named = False
-    def __init__(self, cfg: CFG_DICT, object_label: str, parent_layer: Optional["OWSLayer"]=None, **kwargs) -> None:
+
+    def __init__(
+        self,
+        cfg: CFG_DICT,
+        object_label: str,
+        parent_layer: Optional["OWSLayer"] = None,
+        **kwargs,
+    ) -> None:
         super().__init__(cfg, **kwargs)
         self.object_label = object_label
         self.global_cfg: OWSConfig = kwargs["global_cfg"]
@@ -279,8 +318,7 @@ class OWSLayer(OWSMetadataConfig):
         # Inherit or override attribution
         if "attribution" in cfg:
             self.attribution = AttributionCfg.parse(
-                cast(CFG_DICT | None, cfg.get("attribution")),
-                self
+                cast(CFG_DICT | None, cfg.get("attribution")), self
             )
         elif parent_layer:
             self.attribution = cast(OWSLayer, self.parent_layer).attribution
@@ -367,9 +405,14 @@ class OWSLayer(OWSMetadataConfig):
 
 
 class OWSFolder(OWSLayer):
-    def __init__(self, cfg: CFG_DICT, global_cfg: "OWSConfig",
-                 parent_layer: Optional["OWSFolder"] = None,
-                 sibling: int = 0, **kwargs) -> None:
+    def __init__(
+        self,
+        cfg: CFG_DICT,
+        global_cfg: "OWSConfig",
+        parent_layer: Optional["OWSFolder"] = None,
+        sibling: int = 0,
+        **kwargs,
+    ) -> None:
         if "label" in cfg:
             obj_lbl = f"folder.{cfg['label']}"
         elif parent_layer:
@@ -378,7 +421,13 @@ class OWSFolder(OWSLayer):
             obj_lbl = f"folder.{sibling}"
         if obj_lbl in global_cfg.folder_index:
             raise ConfigException(f"Duplicate folder label: {obj_lbl}")
-        super().__init__(cfg, parent_layer=parent_layer, object_label=obj_lbl, global_cfg=global_cfg, **kwargs)
+        super().__init__(
+            cfg,
+            parent_layer=parent_layer,
+            object_label=obj_lbl,
+            global_cfg=global_cfg,
+            **kwargs,
+        )
         self.slug_name = slugify(self.title, separator="_")
         self.unready_layers: list[OWSLayer] = []
         self.child_layers: list[OWSLayer] = []
@@ -388,15 +437,22 @@ class OWSFolder(OWSLayer):
         for lyr_cfg in cast(list[RAW_CFG], cfg["layers"]):
             if isinstance(lyr_cfg, dict):
                 try:
-                    lyr = parse_ows_layer(lyr_cfg, global_cfg=global_cfg, parent_layer=self, sibling=child)
+                    lyr = parse_ows_layer(
+                        lyr_cfg, global_cfg=global_cfg, parent_layer=self, sibling=child
+                    )
                     self.unready_layers.append(lyr)
                 except ConfigException as e:
-                    _LOG.error("Could not parse layer (%s): %s",
-                               lyr_cfg.get("name", lyr_cfg.get("title", "??")),
-                               str(e))
+                    _LOG.error(
+                        "Could not parse layer (%s): %s",
+                        lyr_cfg.get("name", lyr_cfg.get("title", "??")),
+                        str(e),
+                    )
                 child += 1
             else:
-                _LOG.error("Non-dictionary where dictionary expected - check for trailing comma? %s...", repr(lyr_cfg)[0:50])
+                _LOG.error(
+                    "Non-dictionary where dictionary expected - check for trailing comma? %s...",
+                    repr(lyr_cfg)[0:50],
+                )
         global_cfg.folder_index[obj_lbl] = self
 
     @override
@@ -434,7 +490,7 @@ class TimeRes(Enum):
         return self == self.SUBDAY
 
     def is_solar(self) -> bool:
-        return self  == self.SOLAR
+        return self == self.SOLAR
 
     def is_summary(self) -> bool:
         return not self.is_solar() and not self.is_subday()
@@ -447,23 +503,32 @@ class TimeRes(Enum):
         if cfg is None:
             cfg = "solar"
         elif cfg == "raw":
-            _LOG.warning("The 'raw' time resolution type is deprecated.  Please use 'solar'.")
+            _LOG.warning(
+                "The 'raw' time resolution type is deprecated.  Please use 'solar'."
+            )
             cfg = "solar"
         elif cfg in ("day", "month", "year"):
-            _LOG.warning("The '%s' time resolution type is deprecated.  Please use 'summary'.", cfg)
+            _LOG.warning(
+                "The '%s' time resolution type is deprecated.  Please use 'summary'.",
+                cfg,
+            )
             cfg = "summary"
         try:
             return cls(cfg)
         except ValueError:
             return None
 
-    def search_times(self,
-                     t: datetime.datetime,
-                     geobox: GeoBox | None = None) -> datetime.datetime | tuple[datetime.datetime, datetime.datetime]:
+    def search_times(
+        self, t: datetime.datetime, geobox: GeoBox | None = None
+    ) -> datetime.datetime | tuple[datetime.datetime, datetime.datetime]:
         if self.is_solar():
             if geobox is None:
-                raise ValueError("Solar time resolution search_times requires a geobox.")
-            times: datetime.datetime | tuple[datetime.datetime, datetime.datetime] = local_solar_date_range(geobox, t)
+                raise ValueError(
+                    "Solar time resolution search_times requires a geobox."
+                )
+            times: datetime.datetime | tuple[datetime.datetime, datetime.datetime] = (
+                local_solar_date_range(geobox, t)
+            )
         elif self.is_subday():
             # For subday products, return a single start datetime instead of a range.
             # mv_index will expand this to a one-second search range.
@@ -477,7 +542,9 @@ class TimeRes(Enum):
 
         return times
 
-    def dataset_groupby(self, product_names: list[str] | None = None, is_mosaic: bool = False) -> GroupBy:
+    def dataset_groupby(
+        self, product_names: list[str] | None = None, is_mosaic: bool = False
+    ) -> GroupBy:
         if self.is_subday():
             return group_by_begin_datetime(product_names, truncate_dates=False)
         if is_mosaic:
@@ -485,6 +552,7 @@ class TimeRes(Enum):
         if self.is_solar():
             return group_by_solar(product_names)
         return group_by_begin_datetime(product_names)
+
 
 DEF_TIME_LATEST = "latest"
 DEF_TIME_EARLIEST = "earliest"
@@ -495,26 +563,45 @@ class OWSNamedLayer(OWSExtensibleConfigEntry, OWSLayer):
     named = True
     multi_product: bool = False
 
-    def __init__(self, cfg: CFG_DICT, global_cfg: "OWSConfig", parent_layer: OWSFolder | None = None, **kwargs) -> None:
+    def __init__(
+        self,
+        cfg: CFG_DICT,
+        global_cfg: "OWSConfig",
+        parent_layer: OWSFolder | None = None,
+        **kwargs,
+    ) -> None:
         name = cast(str, cfg["name"])
-        super().__init__(cfg, object_label=f"layer.{name}", global_cfg=global_cfg, parent_layer=parent_layer,
-                         keyvals={"layer": name},
-                         **kwargs)
+        super().__init__(
+            cfg,
+            object_label=f"layer.{name}",
+            global_cfg=global_cfg,
+            parent_layer=parent_layer,
+            keyvals={"layer": name},
+            **kwargs,
+        )
         self.name = name
         cfg = cast(CFG_DICT, self._raw_cfg)
         self.hide = False
         try:
             self.parse_product_names(cfg)
             if len(self.low_res_product_names) not in (0, len(self.product_names)):
-                raise ConfigException(f"Lengths of product_names and low_res_product_names do not match in layer {self.name}")
+                raise ConfigException(
+                    f"Lengths of product_names and low_res_product_names do not match in layer {self.name}"
+                )
             for prod_name in self.product_names:
                 if "__" in prod_name:
                     # I think this was for subproducts which are currently broken
-                    raise ConfigException("Product names cannot contain a double underscore '__'.")
+                    raise ConfigException(
+                        "Product names cannot contain a double underscore '__'."
+                    )
         except IndexError:
-            raise ConfigException(f"No products declared in layer {self.name}") from None
+            raise ConfigException(
+                f"No products declared in layer {self.name}"
+            ) from None
         except KeyError as e:
-            raise ConfigException(f"Required product names entry ({e!s}) missing in named layer {self.name}") from None
+            raise ConfigException(
+                f"Required product names entry ({e!s}) missing in named layer {self.name}"
+            ) from None
         self.declare_unready("products")
         self.declare_unready("low_res_products")
         self.declare_unready("product")
@@ -526,13 +613,19 @@ class OWSNamedLayer(OWSExtensibleConfigEntry, OWSLayer):
             self.user_band_math = False
         tr = TimeRes.parse(cast(str | None, cfg.get("time_resolution")))
         if not tr:
-            raise ConfigException(f"Invalid time resolution value {cfg['time_resolution']} in named layer {self.name}")
+            raise ConfigException(
+                f"Invalid time resolution value {cfg['time_resolution']} in named layer {self.name}"
+            )
         self.time_resolution: TimeRes = tr
         self.mosaic_date_func: FunctionWrapper | None = None
         if "mosaic_date_func" in cfg:
-            self.mosaic_date_func = FunctionWrapper(self, cast(CFG_DICT, cfg["mosaic_date_func"]))
+            self.mosaic_date_func = FunctionWrapper(
+                self, cast(CFG_DICT, cfg["mosaic_date_func"])
+            )
         if self.mosaic_date_func and not self.time_resolution.allow_mosaic():
-            raise ConfigException(f"Mosaic date function not supported for {self.time_resolution} time resolution.")
+            raise ConfigException(
+                f"Mosaic date function not supported for {self.time_resolution} time resolution."
+            )
         dtr: str = cast(str, cfg.get("default_time", DEF_TIME_LATEST))
         if dtr in (DEF_TIME_LATEST, DEF_TIME_EARLIEST):
             self.default_time_rule: str | datetime.datetime | datetime.date = dtr
@@ -549,7 +642,9 @@ class OWSNamedLayer(OWSExtensibleConfigEntry, OWSLayer):
         self.time_axis = cast(CFG_DICT | None, cfg.get("time_axis"))
         if self.time_axis:
             if self.time_resolution.is_subday():
-                raise ConfigException("Regular time axis is not supported for sub-day time resolutions")
+                raise ConfigException(
+                    "Regular time axis is not supported for sub-day time resolutions"
+                )
             self.regular_time_axis = True
             if "time_interval" not in self.time_axis:
                 raise ConfigException("No time_interval supplied in time_axis")
@@ -568,18 +663,26 @@ class OWSNamedLayer(OWSExtensibleConfigEntry, OWSLayer):
                 try:
                     self.time_axis_start = datetime.date.fromisoformat(time_axis_start)
                 except ValueError:
-                    raise ConfigException("time_axis start_date is not a valid ISO format date string") from None
+                    raise ConfigException(
+                        "time_axis start_date is not a valid ISO format date string"
+                    ) from None
             if time_axis_end is None:
                 self.time_axis_end: datetime.date | None = None
             else:
                 try:
                     self.time_axis_end = datetime.date.fromisoformat(time_axis_end)
                 except ValueError:
-                    raise ConfigException("time_axis end_date is not a valid ISO format date string") from None
-            if (self.time_axis_end is not None
-                    and self.time_axis_start is not None
-                    and self.time_axis_end < self.time_axis_start):
-                raise ConfigException("time_axis end_date must be greater than or equal to the start_date if both are provided")
+                    raise ConfigException(
+                        "time_axis end_date is not a valid ISO format date string"
+                    ) from None
+            if (
+                self.time_axis_end is not None
+                and self.time_axis_start is not None
+                and self.time_axis_end < self.time_axis_start
+            ):
+                raise ConfigException(
+                    "time_axis end_date must be greater than or equal to the start_date if both are provided"
+                )
         else:
             self.regular_time_axis = False
             self.time_axis_interval = 0
@@ -596,9 +699,11 @@ class OWSNamedLayer(OWSExtensibleConfigEntry, OWSLayer):
         self.cfg_native_crs = cfg.get("native_crs")
         self.declare_unready("resolution_x")
         self.declare_unready("resolution_y")
-        self.resource_limits = OWSResourceManagementRules(self.global_cfg,
-                                                          cast(CFG_DICT, cfg.get("resource_limits", {})),
-                                                          f"Layer {self.name}")
+        self.resource_limits = OWSResourceManagementRules(
+            self.global_cfg,
+            cast(CFG_DICT, cfg.get("resource_limits", {})),
+            f"Layer {self.name}",
+        )
         try:
             self.parse_flags(cast(CFG_DICT, cfg.get("flags", {})))
             self.declare_unready("all_flag_band_names")
@@ -615,12 +720,16 @@ class OWSNamedLayer(OWSExtensibleConfigEntry, OWSLayer):
         self.identifiers = cast(dict[str, str], cfg.get("identifiers", {}))
         for auth in self.identifiers:
             if auth not in self.global_cfg.authorities:
-                raise ConfigException(f"Identifier with non-declared authority: {auth} in layer {self.name}")
+                raise ConfigException(
+                    f"Identifier with non-declared authority: {auth} in layer {self.name}"
+                )
         self.parse_urls(cast(CFG_DICT, cfg.get("urls", {})))
         self.parse_feature_info(cast(CFG_DICT, cfg.get("feature_info", {})))
         self.feature_info_include_utc_dates = cfg.get("feature_info_url_dates", False)
         if "patch_url_function" in cfg:
-            self.patch_url: FunctionWrapper | None = FunctionWrapper(self, cast(CFG_DICT, cfg["patch_url_function"]))
+            self.patch_url: FunctionWrapper | None = FunctionWrapper(
+                self, cast(CFG_DICT, cfg["patch_url_function"])
+            )
         else:
             self.patch_url = None
         try:
@@ -638,13 +747,13 @@ class OWSNamedLayer(OWSExtensibleConfigEntry, OWSLayer):
                     f"Missing required config item {e} in wcs section for layer {self.name}"
                 ) from None
 
-#       Sub-products have been broken for some time.
-#        sub_prod_cfg = cfg.get("sub_products", {})
-#        self.sub_product_label = sub_prod_cfg.get("label")
-#        if "extractor" in sub_prod_cfg:
-#            self.sub_product_extractor = FunctionWrapper(self, sub_prod_cfg["extractor"])
-#        else:
-#            self.sub_product_extractor = None
+        #       Sub-products have been broken for some time.
+        #        sub_prod_cfg = cfg.get("sub_products", {})
+        #        self.sub_product_label = sub_prod_cfg.get("label")
+        #        if "extractor" in sub_prod_cfg:
+        #            self.sub_product_extractor = FunctionWrapper(self, sub_prod_cfg["extractor"])
+        #        else:
+        #            self.sub_product_extractor = None
         # And finally, add to the global product index.
         existing = self.global_cfg.layer_index.get(self.name)
         if existing and existing != self:
@@ -663,10 +772,14 @@ class OWSNamedLayer(OWSExtensibleConfigEntry, OWSLayer):
         self.products: list[Product] = []
         self.low_res_products: list[Product] = []
         for i, prod_name in enumerate(self.product_names):
-            low_res_prod_name = self.low_res_product_names[i] if self.low_res_product_names else None
+            low_res_prod_name = (
+                self.low_res_product_names[i] if self.low_res_product_names else None
+            )
             product = self.dc.index.products.get_by_name(prod_name)
             if not product:
-                raise ConfigException(f"Could not find product {prod_name} in datacube for layer {self.name}")
+                raise ConfigException(
+                    f"Could not find product {prod_name} in datacube for layer {self.name}"
+                )
             self.products.append(product)
             if low_res_prod_name:
                 product = self.dc.index.products.get_by_name(low_res_prod_name)
@@ -707,7 +820,8 @@ class OWSNamedLayer(OWSExtensibleConfigEntry, OWSLayer):
             self.extent_mask_func = [FunctionWrapper(self, emf_cfg)]
         else:
             self.extent_mask_func = [
-                FunctionWrapper(self, emf) for emf in cast(list[CFG_DICT | str], emf_cfg)
+                FunctionWrapper(self, emf)
+                for emf in cast(list[CFG_DICT | str], emf_cfg)
             ]
         self.raw_afb = cfg.get("always_fetch_bands", [])
         self.declare_unready("always_fetch_bands")
@@ -715,32 +829,46 @@ class OWSNamedLayer(OWSExtensibleConfigEntry, OWSLayer):
         self.data_manual_merge = bool(cfg.get("manual_merge", False))
         if self.solar_correction and not self.data_manual_merge:
             raise ConfigException("Solar correction requires manual_merge.")
-        if self.data_manual_merge and not self.solar_correction and not self.multi_product:
-            _LOG.warning("Manual merge is only recommended where solar correction is required and for multi-product layers.")
+        if (
+            self.data_manual_merge
+            and not self.solar_correction
+            and not self.multi_product
+        ):
+            _LOG.warning(
+                "Manual merge is only recommended where solar correction is required and for multi-product layers."
+            )
 
         if cfg.get("fuse_func"):
             self.fuse_func: FunctionWrapper | None = FunctionWrapper(
-                self,
-                cast(str | CFG_DICT, cfg["fuse_func"])
+                self, cast(str | CFG_DICT, cfg["fuse_func"])
             )
         else:
             self.fuse_func = None
 
     # pylint: disable=attribute-defined-outside-init
     def ready_image_processing(self) -> None:
-        self.always_fetch_bands = [self.band_idx.band(b) for b in cast(list[str], self.raw_afb)]
+        self.always_fetch_bands = [
+            self.band_idx.band(b) for b in cast(list[str], self.raw_afb)
+        ]
 
     # pylint: disable=attribute-defined-outside-init
     def parse_feature_info(self, cfg: CFG_DICT) -> None:
         self.feature_info_include_utc_dates = bool(cfg.get("include_utc_dates", False))
         custom = cast(dict[str, CFG_DICT | str], cfg.get("include_custom", {}))
-        self.legacy_feature_info_custom_includes = {k: FunctionWrapper(self, v) for k, v in custom.items()}
+        self.legacy_feature_info_custom_includes = {
+            k: FunctionWrapper(self, v) for k, v in custom.items()
+        }
         if self.legacy_feature_info_custom_includes:
-            _LOG.warning("In layer %s: The 'include_custom' directive is deprecated and will be removed in version 1.9. "
-                         "Please refer to the documentation for information on how to migrate your configuration "
-                         "to the new 'custom_includes' directive.", self.name)
+            _LOG.warning(
+                "In layer %s: The 'include_custom' directive is deprecated and will be removed in version 1.9. "
+                "Please refer to the documentation for information on how to migrate your configuration "
+                "to the new 'custom_includes' directive.",
+                self.name,
+            )
         custom = cast(dict[str, CFG_DICT | str | F], cfg.get("custom_includes", {}))
-        self.feature_info_custom_includes = {k: FunctionWrapper(self, v) for k, v in custom.items()}
+        self.feature_info_custom_includes = {
+            k: FunctionWrapper(self, v) for k, v in custom.items()
+        }
 
     # pylint: disable=attribute-defined-outside-init
     def parse_flags(self, cfg: CFG_DICT) -> None:
@@ -749,7 +877,10 @@ class OWSNamedLayer(OWSExtensibleConfigEntry, OWSLayer):
             if isinstance(cfg, dict):
                 fb = OWSFlagBand(cfg, self)
                 self.flag_bands[fb.pq_band] = fb
-                _LOG.warning("Single flag bands not in a list is deprecated. Please refer to the documentation for the new format (layer %s)", self.name)
+                _LOG.warning(
+                    "Single flag bands not in a list is deprecated. Please refer to the documentation for the new format (layer %s)",
+                    self.name,
+                )
             else:
                 for fb_cfg in cfg:
                     fb = OWSFlagBand(fb_cfg, self)
@@ -758,16 +889,27 @@ class OWSNamedLayer(OWSExtensibleConfigEntry, OWSLayer):
         for fb in self.flag_bands.values():
             pns = fb.pq_names
             lrpns = fb.pq_low_res_names
-            if pns in pq_names_to_lowres_names and pq_names_to_lowres_names[pns] != lrpns:
-                raise ConfigException(f"Product name mismatch in flags section for layer {self.name}: product_names {pns} has multiple distinct low-res product names")
+            if (
+                pns in pq_names_to_lowres_names
+                and pq_names_to_lowres_names[pns] != lrpns
+            ):
+                raise ConfigException(
+                    f"Product name mismatch in flags section for layer {self.name}: product_names {pns} has multiple distinct low-res product names"
+                )
             pq_names_to_lowres_names[pns] = lrpns
         # pylint: disable=dict-values-not-iterating
-        self.allflag_productbands = FlagProductBands.build_list_from_flagbands(self.flag_bands.values(), self)
+        self.allflag_productbands = FlagProductBands.build_list_from_flagbands(
+            self.flag_bands.values(), self
+        )
 
     # pylint: disable=attribute-defined-outside-init
     def parse_urls(self, cfg: CFG_DICT) -> None:
-        self.feature_list_urls = SuppURL.parse_list(cast(list[dict[str, str]], cfg.get("features", [])))
-        self.data_urls = SuppURL.parse_list(cast(list[dict[str, str]], cfg.get("data", [])))
+        self.feature_list_urls = SuppURL.parse_list(
+            cast(list[dict[str, str]], cfg.get("features", []))
+        )
+        self.data_urls = SuppURL.parse_list(
+            cast(list[dict[str, str]], cfg.get("data", []))
+        )
 
     # pylint: disable=attribute-defined-outside-init
     def parse_styling(self, cfg: CFG_DICT) -> None:
@@ -779,7 +921,9 @@ class OWSNamedLayer(OWSExtensibleConfigEntry, OWSLayer):
             self.style_index[style.name] = style
         if "default_style" in cfg:
             if cfg["default_style"] not in self.style_index:
-                raise ConfigException(f"Default style {cfg['default_style']} is not in the 'styles' for layer {self.name}")
+                raise ConfigException(
+                    f"Default style {cfg['default_style']} is not in the 'styles' for layer {self.name}"
+                )
             self.default_style = self.style_index[cast(str, cfg["default_style"])]
         else:
             self.default_style = self.styles[0]
@@ -797,23 +941,32 @@ class OWSNamedLayer(OWSExtensibleConfigEntry, OWSLayer):
             if not self.cfg_native_resolution:
                 _LOG.warning(
                     "Specifying native_resolution in wcs section of layer %s is now deprecated, please move to "
-                    "main layer section if required.", self.name)
+                    "main layer section if required.",
+                    self.name,
+                )
                 self.cfg_native_resolution = cfg.get("native_resolution")
             else:
                 _LOG.warning(
                     "Native_resolution in wcs section of layer %s ignored in favour of value in "
-                    "main layer section.", self.name)
+                    "main layer section.",
+                    self.name,
+                )
 
         # Native CRS
         if "native_crs" in cfg:
             if not self.cfg_native_crs:
-                _LOG.warning("Specifying native_crs in wcs section of layer %s is now deprecated, pleas move to "
-                             "main layer section if required", self.name)
+                _LOG.warning(
+                    "Specifying native_crs in wcs section of layer %s is now deprecated, pleas move to "
+                    "main layer section if required",
+                    self.name,
+                )
                 self.cfg_native_crs = cfg["native_crs"]
             else:
                 _LOG.warning(
                     "native_crs in wcs section of layer %s ignored in favour of value in "
-                    "main layer section.", self.name)
+                    "main layer section.",
+                    self.name,
+                )
 
         self.declare_unready("native_CRS")
         self.declare_unready("native_CRS_def")
@@ -836,23 +989,32 @@ class OWSNamedLayer(OWSExtensibleConfigEntry, OWSLayer):
         if "native_format" in cfg:
             self.native_format = cfg["native_format"]
             if self.native_format not in self.global_cfg.wcs_formats_by_name:
-                raise ConfigException(f"WCS native format {self.native_format} for layer {self.name} is not in supported formats list")
+                raise ConfigException(
+                    f"WCS native format {self.native_format} for layer {self.name} is not in supported formats list"
+                )
         else:
             self.native_format = self.global_cfg.native_wcs_format
 
     # pylint: disable=attribute-defined-outside-init
     def ready_native_specs(self) -> None:
-        product_native_specs = self.product.definition.get("load", self.product.definition.get("storage"))
+        product_native_specs = self.product.definition.get(
+            "load", self.product.definition.get("storage")
+        )
         # Native CRS
         if product_native_specs is not None and "crs" in product_native_specs:
             self.native_CRS = product_native_specs["crs"]
             if self.cfg_native_crs == self.native_CRS:
                 _LOG.debug(
                     "Native crs for layer %s is specified in ODC metadata and does not need to be specified in configuration",
-                    self.name)
+                    self.name,
+                )
             else:
-                _LOG.warning("Native crs for layer %s is specified in config as %s - overridden to %s by ODC metadata",
-                             self.name, self.cfg_native_crs, self.native_CRS)
+                _LOG.warning(
+                    "Native crs for layer %s is specified in config as %s - overridden to %s by ODC metadata",
+                    self.name,
+                    self.cfg_native_crs,
+                    self.native_CRS,
+                )
         else:
             self.native_CRS = self.cfg_native_crs
 
@@ -860,7 +1022,8 @@ class OWSNamedLayer(OWSExtensibleConfigEntry, OWSLayer):
             raise ConfigException(f"No native CRS could be found for layer {self.name}")
         if self.native_CRS not in self.global_cfg.published_CRSs:
             raise ConfigException(
-                f"Native CRS for product {self.product_name} in layer {self.name} ({self.native_CRS}) not in published CRSs")
+                f"Native CRS for product {self.product_name} in layer {self.name} ({self.native_CRS}) not in published CRSs"
+            )
         self.native_CRS_def = self.global_cfg.published_CRSs[self.native_CRS]
 
         if product_native_specs is not None and "resolution" in product_native_specs:
@@ -885,22 +1048,30 @@ class OWSNamedLayer(OWSExtensibleConfigEntry, OWSLayer):
                     f"No native resolution supplied for layer {self.name} with no product-native resolution defined in ODC."
                 ) from None
             except ValueError:
-                raise ConfigException(f"Invalid native resolution supplied for layer {self.name}") from None
+                raise ConfigException(
+                    f"Invalid native resolution supplied for layer {self.name}"
+                ) from None
             except TypeError:
-                raise ConfigException(f"Invalid native resolution supplied for layer {self.name}") from None
+                raise ConfigException(
+                    f"Invalid native resolution supplied for layer {self.name}"
+                ) from None
         elif self.cfg_native_resolution:
             config_x, config_y = (float(r) for r in self.cfg_native_resolution)  # type: ignore[arg-type, union-attr]
-            if (
-                    math.isclose(config_x, float(self.resolution_x), rel_tol=1e-8)
-                    and math.isclose(config_y, float(self.resolution_y), rel_tol=1e-8)
-            ):
+            if math.isclose(
+                config_x, float(self.resolution_x), rel_tol=1e-8
+            ) and math.isclose(config_y, float(self.resolution_y), rel_tol=1e-8):
                 _LOG.debug(
                     "Native resolution for layer %s is specified in ODC metadata and does not need to be specified in configuration",
-                    self.name)
+                    self.name,
+                )
             else:
                 _LOG.warning(
                     "Native resolution for layer %s is specified in config as %s - overridden to (%.15f, %.15f) by ODC metadata",
-                    self.name, repr(self.cfg_native_resolution), self.resolution_x, self.resolution_y)
+                    self.name,
+                    repr(self.cfg_native_resolution),
+                    self.resolution_x,
+                    self.resolution_y,
+                )
 
     # pylint: disable=attribute-defined-outside-init
     def ready_wcs(self) -> None:
@@ -910,23 +1081,32 @@ class OWSNamedLayer(OWSExtensibleConfigEntry, OWSLayer):
                 native_bounding_box = self.bboxes[self.native_CRS]
             except KeyError:
                 if not self.global_cfg.called_from_update_ranges:
-                    _LOG.warning("Layer: %s No bounding box in ranges for native CRS %s - rerun datacube-ows-update",
-                                 self.name,
-                                 self.native_CRS)
+                    _LOG.warning(
+                        "Layer: %s No bounding box in ranges for native CRS %s - rerun datacube-ows-update",
+                        self.name,
+                        self.native_CRS,
+                    )
                 self.hide = True
                 return
             self.origin_x = native_bounding_box["left"]
             self.origin_y = native_bounding_box["bottom"]
 
-
-            if abs(native_bounding_box["right"] - native_bounding_box["left"]) < abs(self.resolution_x):
+            if abs(native_bounding_box["right"] - native_bounding_box["left"]) < abs(
+                self.resolution_x
+            ):
                 raise ConfigException(
                     f"Native ({self.native_CRS}) bounding box on layer {self.name} has "
-                    + ("left {:.8f}, right {:.8f} ".format(native_bounding_box["left"], native_bounding_box["right"]))
+                    + (
+                        "left {:.8f}, right {:.8f} ".format(
+                            native_bounding_box["left"], native_bounding_box["right"]
+                        )
+                    )
                     + f"(diff {native_bounding_box['right'] - native_bounding_box['left']})"
                     + f", but horizontal resolution is {self.resolution_x:.8f}"
                 )
-            if abs(native_bounding_box["top"] - native_bounding_box["bottom"]) < abs(self.resolution_y):
+            if abs(native_bounding_box["top"] - native_bounding_box["bottom"]) < abs(
+                self.resolution_y
+            ):
                 raise ConfigException(
                     f"Native ({self.native_CRS}) bounding box on layer {self.name} has "
                     f"bottom {native_bounding_box['bottom']}, top "
@@ -934,8 +1114,16 @@ class OWSNamedLayer(OWSExtensibleConfigEntry, OWSLayer):
                     f"{native_bounding_box['top'] - native_bounding_box['bottom']}), "
                     f"but vertical resolution is {self.resolution_y}"
                 )
-            self.grid_high_x = abs(int((native_bounding_box["right"] - native_bounding_box["left"]) / self.resolution_x))
-            self.grid_high_y = int((native_bounding_box["bottom"] - native_bounding_box["top"]) / self.resolution_y)
+            self.grid_high_x = abs(
+                int(
+                    (native_bounding_box["right"] - native_bounding_box["left"])
+                    / self.resolution_x
+                )
+            )
+            self.grid_high_y = int(
+                (native_bounding_box["bottom"] - native_bounding_box["top"])
+                / self.resolution_y
+            )
 
             if self.grid_high_x <= 0:
                 err_str = f"Grid High x is non-positive on layer {self.name}: native ({self.native_CRS}) extent: {native_bounding_box['left']},{native_bounding_box['right']}: x_res={self.resolution_x}"
@@ -959,8 +1147,8 @@ class OWSNamedLayer(OWSExtensibleConfigEntry, OWSLayer):
                         "origin": (bbox["left"], bbox["bottom"]),
                         "resolution": (
                             (bbox["right"] - bbox["left"]) / self.grid_high_x,
-                            (bbox["top"] - bbox["bottom"]) / self.grid_high_y
-                        )
+                            (bbox["top"] - bbox["bottom"]) / self.grid_high_y,
+                        ),
                     }
 
     def parse_product_names(self, cfg: CFG_DICT):
@@ -978,14 +1166,17 @@ class OWSNamedLayer(OWSExtensibleConfigEntry, OWSLayer):
             self.bboxes = self.extract_bboxes()
             if self.default_time_rule == DEF_TIME_EARLIEST:
                 self.default_time = self._ranges.start_time
-            elif isinstance(self.default_time_rule,
-                            datetime.date) and self.default_time_rule in self._ranges.time_set:
+            elif (
+                isinstance(self.default_time_rule, datetime.date)
+                and self.default_time_rule in self._ranges.time_set
+            ):
                 self.default_time = self.default_time_rule
             elif isinstance(self.default_time_rule, datetime.date):
-                _LOG.warning("default_time for named_layer %s is explicit date (%s) that is "
-                             " not available for the layer. Using most recent available date instead.",
-                                    self.name,
-                                    self.default_time_rule.isoformat()
+                _LOG.warning(
+                    "default_time for named_layer %s is explicit date (%s) that is "
+                    " not available for the layer. Using most recent available date instead.",
+                    self.name,
+                    self.default_time_rule.isoformat(),
                 )
                 self.default_time = self._ranges.end_time
             else:
@@ -998,13 +1189,21 @@ class OWSNamedLayer(OWSExtensibleConfigEntry, OWSLayer):
             self.hide = True
             self.bboxes = {}
 
-    def time_range(self,
-                   ranges: Optional["LayerExtent"] = None
-                   ) -> tuple[datetime.datetime | datetime.date, datetime.datetime | datetime.date]:
+    def time_range(
+        self, ranges: Optional["LayerExtent"] = None
+    ) -> tuple[datetime.datetime | datetime.date, datetime.datetime | datetime.date]:
         if ranges is None:
             ranges = self.ranges
-        start = self.time_axis_start if self.regular_time_axis and self.time_axis_start else ranges.start_time
-        end = self.time_axis_end if self.regular_time_axis and self.time_axis_end else ranges.end_time
+        start = (
+            self.time_axis_start
+            if self.regular_time_axis and self.time_axis_start
+            else ranges.start_time
+        )
+        end = (
+            self.time_axis_end
+            if self.regular_time_axis and self.time_axis_end
+            else ranges.end_time
+        )
         return start, end
 
     @property
@@ -1018,7 +1217,9 @@ class OWSNamedLayer(OWSExtensibleConfigEntry, OWSLayer):
         if self._ranges is None:
             return {}
         bboxes = {}
-        for crs_id, bbox in cast(dict[str, dict[str, float]], self._ranges.bboxes).items():
+        for crs_id, bbox in cast(
+            dict[str, dict[str, float]], self._ranges.bboxes
+        ).items():
             if crs_id in self.global_cfg.published_CRSs:
                 # Assume we've already handled coordinate swapping for
                 # Vertical-coord first CRSs.   Top is top, left is left.
@@ -1027,7 +1228,9 @@ class OWSNamedLayer(OWSExtensibleConfigEntry, OWSLayer):
                     "left": bbox["left"],
                     "top": bbox["top"],
                     "bottom": bbox["bottom"],
-                    "vertical_coord_first": self.global_cfg.published_CRSs[crs_id]["vertical_coord_first"]
+                    "vertical_coord_first": self.global_cfg.published_CRSs[crs_id][
+                        "vertical_coord_first"
+                    ],
                 }
         return bboxes
 
@@ -1035,19 +1238,26 @@ class OWSNamedLayer(OWSExtensibleConfigEntry, OWSLayer):
     def layer_count(self) -> int:
         return 1
 
-    def search_times(self, t: datetime.datetime,
-                     geobox=None) -> datetime.datetime | tuple[datetime.datetime, datetime.datetime]:
+    def search_times(
+        self, t: datetime.datetime, geobox=None
+    ) -> datetime.datetime | tuple[datetime.datetime, datetime.datetime]:
         if not geobox:
             bbox = self.ranges.bboxes[self.native_CRS]
             geobox = create_geobox(
                 self.native_CRS,
-                bbox["left"], bbox["bottom"], bbox["right"], bbox["top"],
-                1, 1
+                bbox["left"],
+                bbox["bottom"],
+                bbox["right"],
+                bbox["top"],
+                1,
+                1,
             )
         return self.time_resolution.search_times(t, geobox)
 
     def dataset_groupby(self) -> GroupBy:
-        return self.time_resolution.dataset_groupby(is_mosaic=self.mosaic_date_func is not None)
+        return self.time_resolution.dataset_groupby(
+            is_mosaic=self.mosaic_date_func is not None
+        )
 
     @override
     def __str__(self) -> str:
@@ -1055,7 +1265,9 @@ class OWSNamedLayer(OWSExtensibleConfigEntry, OWSLayer):
 
     @classmethod
     @override
-    def lookup_impl(cls, cfg: "OWSConfig", keyvals: dict[str, str], subs: CFG_DICT | None = None) -> "OWSNamedLayer":
+    def lookup_impl(
+        cls, cfg: "OWSConfig", keyvals: dict[str, str], subs: CFG_DICT | None = None
+    ) -> "OWSNamedLayer":
         try:
             return cfg.layer_index[keyvals["layer"]]
         except KeyError:
@@ -1080,20 +1292,26 @@ class OWSProductLayer(OWSNamedLayer):
         else:
             self.low_res_product_names = ()
         if "product_names" in cfg:
-            raise ConfigException(f"'product_names' entry in non-multi-product layer {self.name} - use 'product_name' only")
+            raise ConfigException(
+                f"'product_names' entry in non-multi-product layer {self.name} - use 'product_name' only"
+            )
         if "low_res_product_names" in cfg:
-            raise ConfigException(f"'low_res_product_names' entry in non-multi-product layer {self.name} - use 'low_res_product_name' only")
+            raise ConfigException(
+                f"'low_res_product_names' entry in non-multi-product layer {self.name} - use 'low_res_product_name' only"
+            )
 
     @override
     def parse_pq_names(self, cfg: CFG_DICT) -> dict[str, tuple | bool]:
         main_product = False
         if "dataset" in cfg:
-            raise ConfigException(f"The 'dataset' entry in the flags section is no longer supported.  Please refer to the documentation for the correct format (layer {self.name})")
+            raise ConfigException(
+                f"The 'dataset' entry in the flags section is no longer supported.  Please refer to the documentation for the correct format (layer {self.name})"
+            )
         if "product" in cfg:
             pq_names: tuple[str, ...] = (cast(str, cfg["product"]),)
         else:
             pq_names = (self.product_name,)
-            main_product = (pq_names[0] == self.product_name)
+            main_product = pq_names[0] == self.product_name
 
         if "low_res_product" in cfg:
             pq_low_res_names: tuple[str, ...] = (cast(str, cfg.get("low_res_product")),)
@@ -1103,13 +1321,17 @@ class OWSProductLayer(OWSNamedLayer):
             pq_low_res_names = pq_names
 
         if "products" in cfg:
-            raise ConfigException(f"'products' entry in flags section of non-multi-product layer {self.name} - use 'product' only")
+            raise ConfigException(
+                f"'products' entry in flags section of non-multi-product layer {self.name} - use 'product' only"
+            )
         if "low_res_products" in cfg:
-            raise ConfigException(f"'low_res_products' entry in flags section of non-multi-product layer {self.name}- use 'low_res_product' only")
+            raise ConfigException(
+                f"'low_res_products' entry in flags section of non-multi-product layer {self.name}- use 'low_res_product' only"
+            )
         return {
             "pq_names": pq_names,
             "pq_low_res_names": pq_low_res_names,
-            "main_products": main_product
+            "main_products": main_product,
         }
 
 
@@ -1120,20 +1342,28 @@ class OWSMultiProductLayer(OWSNamedLayer):
     def parse_product_names(self, cfg: CFG_DICT) -> None:
         self.product_names = tuple(cast(list[str], cfg["product_names"]))
         self.product_name = self.product_names[0]
-        self.low_res_product_names = tuple(cast(list[str], cfg.get("low_res_product_names", [])))
+        self.low_res_product_names = tuple(
+            cast(list[str], cfg.get("low_res_product_names", []))
+        )
         if self.low_res_product_names:
             self.low_res_product_name: str | None = self.low_res_product_names[0]
         else:
             self.low_res_product_name = None
         if "product_name" in cfg:
-            raise ConfigException(f"'product_name' entry in multi-product layer {self.name} - use 'product_names' only")
+            raise ConfigException(
+                f"'product_name' entry in multi-product layer {self.name} - use 'product_names' only"
+            )
         if "low_res_product_name" in cfg:
-            raise ConfigException(f"'low_res_product_name' entry in multi-product layer {self.name} - use 'low_res_product_names' only")
+            raise ConfigException(
+                f"'low_res_product_name' entry in multi-product layer {self.name} - use 'low_res_product_names' only"
+            )
 
     @override
     def parse_pq_names(self, cfg: CFG_DICT) -> dict[str, tuple | bool]:
         if "datasets" in cfg:
-            raise ConfigException(f"The 'datasets' entry in the flags section is no longer supported. Please refer to the documentation for the correct format (layer {self.name})")
+            raise ConfigException(
+                f"The 'datasets' entry in the flags section is no longer supported. Please refer to the documentation for the correct format (layer {self.name})"
+            )
         if "products" in cfg:
             pq_names = tuple(cast(list[str], cfg["products"]))
             main_products = pq_names == self.product_names
@@ -1146,9 +1376,13 @@ class OWSMultiProductLayer(OWSNamedLayer):
         else:
             pq_low_res_names = self.low_res_product_names
         if "product" in cfg:
-            raise ConfigException(f"'product' entry in flags section of multi-product layer {self.name} - use 'products' only")
+            raise ConfigException(
+                f"'product' entry in flags section of multi-product layer {self.name} - use 'products' only"
+            )
         if "low_res_product" in cfg:
-            raise ConfigException(f"'low_res_product' entry in flags section of multi-product layer {self.name} - use 'low_res_products' only")
+            raise ConfigException(
+                f"'low_res_product' entry in flags section of multi-product layer {self.name} - use 'low_res_products' only"
+            )
         return {
             "pq_names": pq_names,
             "pq_low_res_names": pq_low_res_names,
@@ -1158,14 +1392,16 @@ class OWSMultiProductLayer(OWSNamedLayer):
     @override
     def dataset_groupby(self) -> GroupBy:
         return self.time_resolution.dataset_groupby(
-            list(self.product_names),
-            is_mosaic=self.mosaic_date_func is not None)
+            list(self.product_names), is_mosaic=self.mosaic_date_func is not None
+        )
 
 
-def parse_ows_layer(cfg: CFG_DICT,
-                    global_cfg: "OWSConfig",
-                    parent_layer: OWSFolder | None = None,
-                    sibling: int = 0) -> OWSLayer:
+def parse_ows_layer(
+    cfg: CFG_DICT,
+    global_cfg: "OWSConfig",
+    parent_layer: OWSFolder | None = None,
+    sibling: int = 0,
+) -> OWSLayer:
     if cfg.get("name", None):
         if cfg.get("multi_product", False):
             return OWSMultiProductLayer(cfg, global_cfg, parent_layer)
@@ -1185,12 +1421,19 @@ class WCSFormat:
                         cast(str, fmt["mime"]),
                         cast(str, fmt["extension"]),
                         cast(dict[int, CFG_DICT], fmt["renderers"]),
-                        bool(fmt.get("multi-time", False))
+                        bool(fmt.get("multi-time", False)),
                     )
                 )
         return renderers
 
-    def __init__(self, name: str, mime: str, extension: str, renderers: dict[int, CFG_DICT], multi_time: bool) -> None:
+    def __init__(
+        self,
+        name: str,
+        mime: str,
+        extension: str,
+        renderers: dict[int, CFG_DICT],
+        multi_time: bool,
+    ) -> None:
         self.name = name
         self.mime = mime
         self.extension = extension
@@ -1202,7 +1445,9 @@ class WCSFormat:
         if 1 not in self.renderers:
             _LOG.warning("No renderer supplied for WCS 1.x for format %s", self.name)
         if 2 not in self.renderers:
-            _LOG.warning("Warning: No renderer supplied for WCS 2.x for format %s", self.name)
+            _LOG.warning(
+                "Warning: No renderer supplied for WCS 2.x for format %s", self.name
+            )
 
     def renderer(self, version: str | int | Version) -> FunctionWrapper:
         if isinstance(version, str):
@@ -1282,8 +1527,13 @@ class OWSConfig(OWSMetadataConfig):
     def active_product_index(self) -> dict[str, OWSNamedLayer]:
         return {prod.name: prod for prod in self.active_products}
 
-    def __init__(self, refresh: bool = False, cfg: CFG_DICT | None = None,
-                 ignore_msgfile: bool = False, called_from_update_ranges: bool = False) -> None:
+    def __init__(
+        self,
+        refresh: bool = False,
+        cfg: CFG_DICT | None = None,
+        ignore_msgfile: bool = False,
+        called_from_update_ranges: bool = False,
+    ) -> None:
         self.called_from_update_ranges = called_from_update_ranges
         if not self.initialised or refresh:
             self.msgfile = None
@@ -1314,7 +1564,9 @@ class OWSConfig(OWSMetadataConfig):
             try:
                 self.parse_layers(cast(list[CFG_DICT], cfg["layers"]))
             except KeyError:
-                raise ConfigException("Missing required config entry in 'layers' section") from None
+                raise ConfigException(
+                    "Missing required config entry in 'layers' section"
+                ) from None
 
             try:
                 if self.wmts:
@@ -1332,20 +1584,31 @@ class OWSConfig(OWSMetadataConfig):
             self.declare_unready("native_product_index")
             self.declare_unready("all_dcs")
 
-    #pylint: disable=attribute-defined-outside-init
+    # pylint: disable=attribute-defined-outside-init
     @override
     def make_ready(self, *args: Any, **kwargs: Any) -> None:
         try:
             self.dc: Datacube = Datacube(env=self.default_env, app=self.odc_app)
         except Exception as e:
-            _LOG.error("ODC initialisation of env %s failed: %s", self.default_env._name, str(e))
+            _LOG.error(
+                "ODC initialisation of env %s failed: %s",
+                self.default_env._name,
+                str(e),
+            )
             raise ODCInitException(e) from None
         if self.msg_file_name:
             try:
                 with open(self.msg_file_name, "rb") as fp:
-                    self.set_msg_src(read_po(fp, locale=self.default_locale, domain=self.message_domain))
+                    self.set_msg_src(
+                        read_po(
+                            fp, locale=self.default_locale, domain=self.message_domain
+                        )
+                    )
             except FileNotFoundError:
-                _LOG.warning("Message file %s does not exist - using metadata from config file", self.msg_file_name)
+                _LOG.warning(
+                    "Message file %s does not exist - using metadata from config file",
+                    self.msg_file_name,
+                )
         else:
             self.set_msg_src(None)
         self.crses = {s: self.crs(s) for s in self.published_CRSs}
@@ -1371,23 +1634,29 @@ class OWSConfig(OWSMetadataConfig):
             else:
                 header += """# {now.isoformat()}
             #"""
-            self.catalog = Catalog(locale=self.default_locale,
-                                   domain=self.message_domain,
-                                   header_comment=header,
-                                   project=self.title,
-                                   version=f"{now.isoformat()}",
-                                   copyright_holder=self.contact_info.organisation if self.contact_info else None,
-                                   msgid_bugs_address=self.contact_info.email if self.contact_info else None,
-                                   creation_date=now,
-                                   revision_date=now,
-                                   fuzzy=False)
+            self.catalog = Catalog(
+                locale=self.default_locale,
+                domain=self.message_domain,
+                header_comment=header,
+                project=self.title,
+                version=f"{now.isoformat()}",
+                copyright_holder=self.contact_info.organisation
+                if self.contact_info
+                else None,
+                msgid_bugs_address=self.contact_info.email
+                if self.contact_info
+                else None,
+                creation_date=now,
+                revision_date=now,
+                fuzzy=False,
+            )
             for k, v in self._metadata_registry.items():
                 if self._inheritance_registry[k]:
                     continue
                 if k in [
-                        "folder.ows_root_hidden.title",
-                        "folder.ows_root_hidden.abstract",
-                        "folder.ows_root_hidden.local_keywords",
+                    "folder.ows_root_hidden.title",
+                    "folder.ows_root_hidden.abstract",
+                    "folder.ows_root_hidden.local_keywords",
                 ]:
                     continue
                 self.catalog.add(id=k, string=v, auto_comments=[v])
@@ -1421,7 +1690,9 @@ class OWSConfig(OWSMetadataConfig):
         self.allowed_urls = cast(str | list[str], cfg["allowed_urls"])
         self.info_url = cfg["info_url"]
         self.contact_info = ContactInfo.parse(cfg.get("contact_info"), self)
-        self.attribution = AttributionCfg.parse(cast(CFG_DICT | None, cfg.get("attribution")), self)
+        self.attribution = AttributionCfg.parse(
+            cast(CFG_DICT | None, cfg.get("attribution")), self
+        )
 
         def make_gml_name(name: str) -> str:
             if name.startswith("EPSG:"):
@@ -1442,18 +1713,22 @@ class OWSConfig(OWSMetadataConfig):
                 "vertical_coord": crsdef.get("vertical_coord", "latitude"),
                 "vertical_coord_first": crsdef.get("vertical_coord_first", False),
                 "gml_name": make_gml_name(crs_str),
-                "alias_of": None
+                "alias_of": None,
             }
             if crsdef["geographic"]:
                 geographic_CRSs.append(crs_str)
             self.published_CRSs[crs_str] = self.internal_CRSs[crs_str]
             if self.published_CRSs[crs_str]["geographic"]:
                 if self.published_CRSs[crs_str]["horizontal_coord"] != "longitude":
-                    raise ConfigException(f"Published CRS {crs_str} is geographic"
-                                    "but has a horizontal coordinate that is not 'longitude'")
+                    raise ConfigException(
+                        f"Published CRS {crs_str} is geographic"
+                        "but has a horizontal coordinate that is not 'longitude'"
+                    )
                 if self.published_CRSs[crs_str]["vertical_coord"] != "latitude":
-                    raise ConfigException(f"Published CRS {crs_str} is geographic"
-                                    "but has a vertical coordinate that is not 'latitude'")
+                    raise ConfigException(
+                        f"Published CRS {crs_str} is geographic"
+                        "but has a vertical coordinate that is not 'latitude'"
+                    )
         # default_geographic_CRS is used by WCS1
         if not self.wcs:
             self.default_geographic_CRS = ""
@@ -1474,14 +1749,17 @@ class OWSConfig(OWSMetadataConfig):
                 "vertical_coord": "y",
                 "vertical_coord_first": False,
                 "gml_name": make_gml_name("EPSG:3832"),
-                "alias_of": None
+                "alias_of": None,
             }
 
         for alias, alias_def in CRS_aliases.items():
             target_crs = cast(str, alias_def["alias"])
             if target_crs not in self.published_CRSs:
-                _LOG.warning("CRS %s defined as alias for %s, which is not a published CRS - skipping",
-                             alias, target_crs)
+                _LOG.warning(
+                    "CRS %s defined as alias for %s, which is not a published CRS - skipping",
+                    alias,
+                    target_crs,
+                )
                 continue
             target_def = self.published_CRSs[target_crs]
             self.published_CRSs[alias] = target_def.copy()
@@ -1509,30 +1787,34 @@ class OWSConfig(OWSMetadataConfig):
         self.user_band_math_extension = cfg.get("user_band_math_extension", False)
         self.wms_cap_cache_age = parse_cache_age(cfg, "caps_cache_maxage", "wms")
         if "attribution" in cfg:
-            _LOG.warning("Attribution entry in top level 'wms' section will be ignored. Attribution should be moved to the 'global' section")
+            _LOG.warning(
+                "Attribution entry in top level 'wms' section will be ignored. Attribution should be moved to the 'global' section"
+            )
 
     def parse_wcs(self, cfg: CFG_DICT | None) -> None:
         if self.wcs:
             if not isinstance(cfg, Mapping):
                 raise ConfigException("WCS section missing (and WCS is enabled)")
-            self.wcs_formats = WCSFormat.from_cfg(cast(dict[str, CFG_DICT], cfg["formats"]))
-            self.wcs_formats_by_name = {
-                fmt.name: fmt
-                for fmt in self.wcs_formats
-            }
-            self.wcs_formats_by_mime = {
-                fmt.mime: fmt
-                for fmt in self.wcs_formats
-            }
+            self.wcs_formats = WCSFormat.from_cfg(
+                cast(dict[str, CFG_DICT], cfg["formats"])
+            )
+            self.wcs_formats_by_name = {fmt.name: fmt for fmt in self.wcs_formats}
+            self.wcs_formats_by_mime = {fmt.mime: fmt for fmt in self.wcs_formats}
             if not self.wcs_formats:
-                raise ConfigException("Must configure at least one wcs format to support WCS.")
+                raise ConfigException(
+                    "Must configure at least one wcs format to support WCS."
+                )
 
             self.native_wcs_format = cfg["native_format"]
             if self.native_wcs_format not in self.wcs_formats_by_name:
-                raise ConfigException(f"Configured native WCS format ({self.native_wcs_format}) not a supported format.")
+                raise ConfigException(
+                    f"Configured native WCS format ({self.native_wcs_format}) not a supported format."
+                )
             self.wcs_tiff_statistics = cfg.get("calculate_tiff_statistics", True)
             self.wcs_cap_cache_age = parse_cache_age(cfg, "caps_cache_maxage", "wcs")
-            self.wcs_default_descov_age = parse_cache_age(cfg, "default_desc_cache_maxage", "wcs")
+            self.wcs_default_descov_age = parse_cache_age(
+                cfg, "default_desc_cache_maxage", "wcs"
+            )
         else:
             self.wcs_formats = []
             self.wcs_formats_by_name = {}
@@ -1545,26 +1827,37 @@ class OWSConfig(OWSMetadataConfig):
     def parse_wmts(self, cfg: CFG_DICT) -> None:
         tms_cfgs = cast(dict[str, CFG_DICT], TileMatrixSet.default_tm_sets.copy())
         if "tile_matrix_sets" in cfg:
-            for identifier, tms in cast(dict[str, CFG_DICT], cfg["tile_matrix_sets"]).items():
+            for identifier, tms in cast(
+                dict[str, CFG_DICT], cfg["tile_matrix_sets"]
+            ).items():
                 tms_cfgs[identifier] = tms
         self.tile_matrix_sets: dict[str, TileMatrixSet] = {}
         for identifier, tms in tms_cfgs.items():
             if len(identifier.split()) != 1:
                 raise ConfigException(f"Invalid identifier: {identifier}")
             if identifier in self.tile_matrix_sets:
-                raise ConfigException(f"Tile matrix set identifiers must be unique: {identifier}")
+                raise ConfigException(
+                    f"Tile matrix set identifiers must be unique: {identifier}"
+                )
             self.tile_matrix_sets[identifier] = TileMatrixSet(identifier, tms, self)
 
     def parse_layers(self, cfg: list[CFG_DICT]) -> None:
         self.folder_index: dict[str, OWSFolder] = {}
         self.layer_index: dict[str, OWSNamedLayer] = {}
         self.declare_unready("native_product_index")
-        self.root_layer_folder = OWSFolder(cast(CFG_DICT, {
-            "title": self.title,
-            "abstract": self.abstract,
-            "label": "ows_root",
-            "layers": cfg
-        }), global_cfg=self, parent_layer=None)
+        self.root_layer_folder = OWSFolder(
+            cast(
+                CFG_DICT,
+                {
+                    "title": self.title,
+                    "abstract": self.abstract,
+                    "label": "ows_root",
+                    "layers": cfg,
+                },
+            ),
+            global_cfg=self,
+            parent_layer=None,
+        )
 
     @property
     def layers(self) -> list[OWSLayer]:
@@ -1599,8 +1892,13 @@ class OWSConfig(OWSMetadataConfig):
         hdrs.update(d)
         return hdrs
 
-def get_config(refresh: bool = False, called_from_update_ranges: bool = False) -> OWSConfig:
-    cfg = OWSConfig(refresh=refresh, called_from_update_ranges=called_from_update_ranges)
+
+def get_config(
+    refresh: bool = False, called_from_update_ranges: bool = False
+) -> OWSConfig:
+    cfg = OWSConfig(
+        refresh=refresh, called_from_update_ranges=called_from_update_ranges
+    )
     if not cfg.ready:
         with contextlib.suppress(ODCInitException):
             cfg.make_ready()

--- a/datacube_ows/protocol_versions.py
+++ b/datacube_ows/protocol_versions.py
@@ -27,7 +27,9 @@ FlaskHandler = Callable[[Mapping[str, str]], FlaskResponse]
 
 
 class SupportedSvcVersion:
-    def __init__(self, service: str, version: str, router, exception_class: type[OGCException]) -> None:
+    def __init__(
+        self, service: str, version: str, router, exception_class: type[OGCException]
+    ) -> None:
         self.service = service.lower()
         self.service_upper = service.upper()
         self.version = version
@@ -38,7 +40,11 @@ class SupportedSvcVersion:
 
 
 class SupportedSvc:
-    def __init__(self, versions: Sequence[SupportedSvcVersion], default_exception_class: type[OGCException] | None = None) -> None:
+    def __init__(
+        self,
+        versions: Sequence[SupportedSvcVersion],
+        default_exception_class: type[OGCException] | None = None,
+    ) -> None:
         self.versions = sorted(versions, key=lambda x: x.version_parts)
         assert len(self.versions) > 0
         self.service = self.versions[0].service
@@ -78,7 +84,7 @@ class SupportedSvc:
             if rv_parts >= v.version_parts:
                 return v
         # The constructor asserted that self.versions is not empty, so this is safe.
-        #pylint: disable=undefined-loop-variable
+        # pylint: disable=undefined-loop-variable
         return v
 
     def activated(self) -> bool:
@@ -87,17 +93,19 @@ class SupportedSvc:
 
 
 OWS_SUPPORTED = {
-    "wms": SupportedSvc([
-        SupportedSvcVersion("wms", "1.3.0", handle_wms, WMSException),
-    ]),
-    "wmts": SupportedSvc([
-        SupportedSvcVersion("wmts", "1.0.0", handle_wmts, WMTSException),
-    ]),
-    "wcs": SupportedSvc([
-        SupportedSvcVersion("wcs", "1.0.0", handle_wcs1, WCS1Exception),
-        SupportedSvcVersion("wcs", "2.0.0", handle_wcs2, WCS2Exception),
-        SupportedSvcVersion("wcs", "2.1.0", handle_wcs2, WCS2Exception),
-    ]),
+    "wms": SupportedSvc(
+        [SupportedSvcVersion("wms", "1.3.0", handle_wms, WMSException)]
+    ),
+    "wmts": SupportedSvc(
+        [SupportedSvcVersion("wmts", "1.0.0", handle_wmts, WMTSException)]
+    ),
+    "wcs": SupportedSvc(
+        [
+            SupportedSvcVersion("wcs", "1.0.0", handle_wcs1, WCS1Exception),
+            SupportedSvcVersion("wcs", "2.0.0", handle_wcs2, WCS2Exception),
+            SupportedSvcVersion("wcs", "2.1.0", handle_wcs2, WCS2Exception),
+        ]
+    ),
 }
 
 

--- a/datacube_ows/resource_limits.py
+++ b/datacube_ows/resource_limits.py
@@ -41,13 +41,15 @@ def parse_cache_age(cfg: dict, entry, section, default: int = 0) -> int:
 class RequestScale:
     standard_scale: "RequestScale"
 
-    def __init__(self,
-                 native_crs: CRS,
-                 native_resolution: tuple[float | int, float | int],
-                 geobox: GeoBox,
-                 n_dates: int,
-                 request_bands: Iterable[Mapping[str, Any]] | None = None,
-                 total_band_size: int | None = None) -> None:
+    def __init__(
+        self,
+        native_crs: CRS,
+        native_resolution: tuple[float | int, float | int],
+        geobox: GeoBox,
+        n_dates: int,
+        request_bands: Iterable[Mapping[str, Any]] | None = None,
+        total_band_size: int | None = None,
+    ) -> None:
         self.resolution = self._metre_resolution(native_crs, native_resolution)
         self.crs = native_crs
         self.geobox = self._standardise_geobox(geobox)
@@ -59,27 +61,34 @@ class RequestScale:
             self.total_band_size: int = total_band_size
         else:
             self.total_band_size = sum(
-                np.dtype(band['dtype']).itemsize
+                np.dtype(band["dtype"]).itemsize
                 for band in cast(Iterable[Mapping[str, Any]], request_bands)
             )
 
     def _standardise_geobox(self, geobox: GeoBox) -> GeoBox:
-        if geobox.crs == 'EPSG:3857':
+        if geobox.crs == "EPSG:3857":
             return geobox
-        bbox = geobox.extent.to_crs('EPSG:3857').boundingbox
-        return create_geobox(CRS('EPSG:3857'),
-                             bbox.left, bbox.bottom,
-                             bbox.right, bbox.top,
-                             width=geobox.width, height=geobox.height
-                             )
+        bbox = geobox.extent.to_crs("EPSG:3857").boundingbox
+        return create_geobox(
+            CRS("EPSG:3857"),
+            bbox.left,
+            bbox.bottom,
+            bbox.right,
+            bbox.top,
+            width=geobox.width,
+            height=geobox.height,
+        )
 
-    def _metre_resolution(self, crs: CRS, resolution: tuple[float | int, float | int]) -> tuple[float, float]:
+    def _metre_resolution(
+        self, crs: CRS, resolution: tuple[float | int, float | int]
+    ) -> tuple[float, float]:
         # Convert native resolution to metres for ready comparison.
-        if crs.units == ('metre', 'metre'):
+        if crs.units == ("metre", "metre"):
             return cast(tuple[float, float], tuple(abs(r) for r in resolution))
         resolution_rectangle = polygon(
-                            ((0, 0), (0, resolution[1]), resolution, (0, resolution[0]), (0, 0)),
-                            crs=crs)
+            ((0, 0), (0, resolution[1]), resolution, (0, resolution[0]), (0, 0)),
+            crs=crs,
+        )
         proj_bbox = resolution_rectangle.to_crs("EPSG:3857").boundingbox
         return (
             abs(proj_bbox.right - proj_bbox.left),
@@ -90,15 +99,12 @@ class RequestScale:
         bbox = self.geobox.extent.boundingbox
         return (
             (bbox.right - bbox.left) / self.geobox.width,
-            (bbox.bottom - bbox.top) / self.geobox.height
+            (bbox.bottom - bbox.top) / self.geobox.height,
         )
 
     @property
     def scale_denominator(self) -> float:
-        xy_denoms = [
-            abs(ps / 0.00028)
-            for ps in self.pixel_span()
-        ]
+        xy_denoms = [abs(ps / 0.00028) for ps in self.pixel_span()]
         return sum(xy_denoms) / 2.0
 
     @property
@@ -129,10 +135,13 @@ class RequestScale:
         return math.log(self.load_factor, 4)
 
 
-RequestScale.standard_scale = RequestScale(CRS("EPSG:3857"), (25.0, 25.0),
-                                           GeoBox((256, 256), affine=affine.identity, crs="EPSG:3857"),
-                                           1, total_band_size=(3 * 2))
-
+RequestScale.standard_scale = RequestScale(
+    CRS("EPSG:3857"),
+    (25.0, 25.0),
+    GeoBox((256, 256), affine=affine.identity, crs="EPSG:3857"),
+    1,
+    total_band_size=(3 * 2),
+)
 
 
 class CacheControlRules(OWSConfigEntry):
@@ -156,26 +165,44 @@ class CacheControlRules(OWSConfigEntry):
         max_max_age_so_far: int = 0
         for rule in cast(list[CFG_DICT], self.rules):
             if "min_datasets" not in rule:
-                raise ConfigException(f"Dataset cache rule does not contain a 'min_datasets' element in {context}")
+                raise ConfigException(
+                    f"Dataset cache rule does not contain a 'min_datasets' element in {context}"
+                )
             if "max_age" not in rule:
-                raise ConfigException(f"Dataset cache rule does not contain a 'max_age' element in {context}")
+                raise ConfigException(
+                    f"Dataset cache rule does not contain a 'max_age' element in {context}"
+                )
             if not isinstance(rule["min_datasets"], int):
-                raise ConfigException(f"Dataset cache rule has non-integer 'min_datasets' element in {context}")
+                raise ConfigException(
+                    f"Dataset cache rule has non-integer 'min_datasets' element in {context}"
+                )
             min_datasets = rule["min_datasets"]
             if not isinstance(rule["max_age"], int):
-                raise ConfigException(f"Dataset cache rule has non-integer 'max_age' element in {context}")
+                raise ConfigException(
+                    f"Dataset cache rule has non-integer 'max_age' element in {context}"
+                )
             max_age = rule["max_age"]
             if min_datasets <= 0:
-                raise ConfigException(f"Invalid dataset cache rule in {context}: min_datasets must be greater than zero.")
+                raise ConfigException(
+                    f"Invalid dataset cache rule in {context}: min_datasets must be greater than zero."
+                )
             if min_datasets <= min_so_far:
-                raise ConfigException(f"Dataset cache rules must be sorted by ascending min_datasets values.  In layer {context}.")
+                raise ConfigException(
+                    f"Dataset cache rules must be sorted by ascending min_datasets values.  In layer {context}."
+                )
             if max_datasets > 0 and min_datasets > max_datasets:
-                raise ConfigException(f"Dataset cache rule min_datasets value exceeds the max_datasets limit in layer {context}.")
+                raise ConfigException(
+                    f"Dataset cache rule min_datasets value exceeds the max_datasets limit in layer {context}."
+                )
             min_so_far = min_datasets
             if max_age <= 0:
-                raise ConfigException(f"Dataset cache rule max_age value must be greater than zero in layer {context}.")
+                raise ConfigException(
+                    f"Dataset cache rule max_age value must be greater than zero in layer {context}."
+                )
             if max_age <= max_max_age_so_far:
-                raise ConfigException(f"max_age values in dataset cache rules must increase monotonically in layer {context}.")
+                raise ConfigException(
+                    f"max_age values in dataset cache rules must increase monotonically in layer {context}."
+                )
             max_max_age_so_far = max_age
 
     def cache_headers(self, n_datasets: int) -> Mapping[str, str]:
@@ -190,7 +217,9 @@ class CacheControlRules(OWSConfigEntry):
         assert n_datasets >= 0
         # If there are no datasets, don't cache. But if the max_datasets isn't 0, check
         # we're not exceeding it, and in that case, don't cache either.
-        if n_datasets == 0 or (self.max_datasets > 0 and n_datasets > self.max_datasets):
+        if n_datasets == 0 or (
+            self.max_datasets > 0 and n_datasets > self.max_datasets
+        ):
             return cache_control_headers(0)
         rule = None
         for r in cast(list[CFG_DICT], self.rules):
@@ -198,7 +227,7 @@ class CacheControlRules(OWSConfigEntry):
                 break
             rule = r
         if rule:
-            return cache_control_headers(cast(int, rule['max_age']))
+            return cache_control_headers(cast(int, rule["max_age"]))
         return cache_control_headers(0)
 
 
@@ -211,11 +240,12 @@ class ResourceLimited(Exception):
 
 class OWSResourceManagementRules(OWSConfigEntry):
     # pylint: disable=attribute-defined-outside-init
-    def __init__(self,
-                 global_cfg: "datacube_ows.ows_configuration.OWSConfig",
-                 cfg: CFG_DICT,
-                 context: str
-                 ) -> None:
+    def __init__(
+        self,
+        global_cfg: "datacube_ows.ows_configuration.OWSConfig",
+        cfg: CFG_DICT,
+        context: str,
+    ) -> None:
         """
         Class constructor.
 
@@ -226,26 +256,36 @@ class OWSResourceManagementRules(OWSConfigEntry):
         cfg = cast(CFG_DICT, self._raw_cfg)
         wms_cfg = cast(CFG_DICT, cfg.get("wms", {}))
         wcs_cfg = cast(CFG_DICT, cfg.get("wcs", {}))
-        self.zoom_fill = cast(list[int], wms_cfg.get("zoomed_out_fill_colour", [150, 180, 200, 160]))
+        self.zoom_fill = cast(
+            list[int], wms_cfg.get("zoomed_out_fill_colour", [150, 180, 200, 160])
+        )
         if len(self.zoom_fill) == 3:
             self.zoom_fill += [255]
         if len(self.zoom_fill) != 4:
-            raise ConfigException(f"zoomed_out_fill_colour must have 3 or 4 elements in {context}")
+            raise ConfigException(
+                f"zoomed_out_fill_colour must have 3 or 4 elements in {context}"
+            )
         self.min_zoom = cast(float | None, wms_cfg.get("min_zoom_factor"))
         self.min_zoom_lvl = cast(int | float | None, wms_cfg.get("min_zoom_level"))
         self.max_datasets_wms = cast(int, wms_cfg.get("max_datasets", 0))
         self.max_datasets_wcs = cast(int, wcs_cfg.get("max_datasets", 0))
         self.max_image_size_wcs = cast(int, wcs_cfg.get("max_image_size", 0))
-        self.wms_cache_rules = CacheControlRules(wms_cfg.get("dataset_cache_rules"), context, self.max_datasets_wms)
-        self.wcs_cache_rules = CacheControlRules(wcs_cfg.get("dataset_cache_rules"), context, self.max_datasets_wcs)
+        self.wms_cache_rules = CacheControlRules(
+            wms_cfg.get("dataset_cache_rules"), context, self.max_datasets_wms
+        )
+        self.wcs_cache_rules = CacheControlRules(
+            wcs_cfg.get("dataset_cache_rules"), context, self.max_datasets_wcs
+        )
         self.wcs_desc_cache_rule = parse_cache_age(
             cfg,
             "describe_cache_max_age",
             f"resource_limits for {context}",
-            default=global_cfg.wcs_default_descov_age
+            default=global_cfg.wcs_default_descov_age,
         )
 
-    def check_wms(self, n_datasets: int, zoom_factor: float, request_scale: RequestScale) -> None:
+    def check_wms(
+        self, n_datasets: int, zoom_factor: float, request_scale: RequestScale
+    ) -> None:
         """
         Check whether a WMS requests exceeds the configured resource limits.
 
@@ -266,11 +306,9 @@ class OWSResourceManagementRules(OWSConfigEntry):
         if limits_exceeded:
             raise ResourceLimited(limits_exceeded)
 
-    def check_wcs(self, n_datasets: int,
-                  height: int, width: int,
-                  pixel_size: int,
-                  n_dates: int
-                 ) -> None:
+    def check_wcs(
+        self, n_datasets: int, height: int, width: int, pixel_size: int, n_dates: int
+    ) -> None:
         """
         Check whether a WCS requests exceeds the configured resource limits.
 
@@ -280,10 +318,17 @@ class OWSResourceManagementRules(OWSConfigEntry):
         limits_exceeded: list[str] = []
         hard = False
         if self.max_datasets_wcs > 0 and n_datasets > self.max_datasets_wcs:
-            limits_exceeded.append(f"too many datasets ({n_datasets}: maximum={self.max_datasets_wcs}")
+            limits_exceeded.append(
+                f"too many datasets ({n_datasets}: maximum={self.max_datasets_wcs}"
+            )
         pixel_count = height * width
-        if self.max_image_size_wcs > 0 and n_dates * pixel_count * pixel_size > self.max_image_size_wcs:
-            limits_exceeded.append("too much data for a single request - try selecting fewer pixels or bands")
+        if (
+            self.max_image_size_wcs > 0
+            and n_dates * pixel_count * pixel_size > self.max_image_size_wcs
+        ):
+            limits_exceeded.append(
+                "too much data for a single request - try selecting fewer pixels or bands"
+            )
             hard = True
         if limits_exceeded:
             raise ResourceLimited(limits_exceeded, wcs_hard=hard)

--- a/datacube_ows/startup_utils.py
+++ b/datacube_ows/startup_utils.py
@@ -19,28 +19,29 @@ from rasterio.errors import NotGeoreferencedWarning
 from datacube_ows.ows_configuration import OWSConfig, get_config
 
 __all__ = [
-    'initialise_babel',
-    'initialise_logger',
-    'initialise_ignorable_warnings',
-    'initialise_debugging',
-    'initialise_sentry',
-    'initialise_aws_credentials',
-    'parse_config_file',
-    'initialise_flask',
-    'initialise_prometheus',
-    'CredentialManager',
+    "initialise_babel",
+    "initialise_logger",
+    "initialise_ignorable_warnings",
+    "initialise_debugging",
+    "initialise_sentry",
+    "initialise_aws_credentials",
+    "parse_config_file",
+    "initialise_flask",
+    "initialise_prometheus",
+    "CredentialManager",
 ]
+
 
 def initialise_logger(name: str | None = None) -> Logger:
     handler = logging.StreamHandler()
-    handler.setFormatter(logging.Formatter('[%(asctime)s] [%(levelname)s] %(message)s'))
+    handler.setFormatter(logging.Formatter("[%(asctime)s] [%(levelname)s] %(message)s"))
     _LOG = logging.getLogger(name)
     _LOG.addHandler(handler)
     # If invoked using Gunicorn, link our root logger to the gunicorn logger
     # this will mean the root logs will be captured and managed by the gunicorn logger
     # allowing you to set the gunicorn log directories and levels for logs
     # produced by this application
-    _LOG.setLevel(logging.getLogger('gunicorn.error').getEffectiveLevel())
+    _LOG.setLevel(logging.getLogger("gunicorn.error").getEffectiveLevel())
     return _LOG
 
 
@@ -54,32 +55,46 @@ def initialise_debugging(log: Logger | None = None) -> None:
     dbg = os.environ.get("PYDEV_DEBUG")
     if dbg and dbg.lower() not in ("no", "false", "f", "n"):
         import pydevd_pycharm
-        pydevd_pycharm.settrace('172.17.0.1', port=12321, stdoutToServer=True, stderrToServer=True)
+
+        pydevd_pycharm.settrace(
+            "172.17.0.1", port=12321, stdoutToServer=True, stderrToServer=True
+        )
         if log:
             log.info("PyCharm Debugging enabled")
 
+
 SentryEvent = TypeVar("SentryEvent")
 
+
 def before_send(event: SentryEvent, hint: dict[str, Any]) -> SentryEvent | None:
-    if 'exc_info' in hint:
-        exc_type, exc_value, tb = hint['exc_info']
-        if isinstance(exc_value, AttributeError) and "object has no attribute 'GEOSGeom_destroy'" in str(exc_value):
+    if "exc_info" in hint:
+        exc_type, exc_value, tb = hint["exc_info"]
+        if isinstance(
+            exc_value, AttributeError
+        ) and "object has no attribute 'GEOSGeom_destroy'" in str(exc_value):
             return None
     return event
+
 
 def initialise_sentry(log: Logger | None = None) -> None:
     if os.environ.get("SENTRY_DSN"):
         import sentry_sdk
         from sentry_sdk.integrations.flask import FlaskIntegration
-        SENTRY_ENV_TAG = os.environ.get("SENTRY_ENV_TAG") if os.environ.get("SENTRY_ENV_TAG") else "dev"
+
+        SENTRY_ENV_TAG = (
+            os.environ.get("SENTRY_ENV_TAG")
+            if os.environ.get("SENTRY_ENV_TAG")
+            else "dev"
+        )
         sentry_sdk.init(
             dsn=os.environ["SENTRY_DSN"],
             environment=SENTRY_ENV_TAG,
-            integrations = [FlaskIntegration()],
+            integrations=[FlaskIntegration()],
             before_send=before_send,
         )
         if log:
             log.info("Sentry initialised")
+
 
 class CredentialManager:
     _instance = None
@@ -117,9 +132,11 @@ class CredentialManager:
             else:
                 unsigned = False
                 if log:
-                    log.warning("AWS_NO_SIGN_REQUEST is not set. " +
-                                "The default behaviour has recently changed to False (i.e. signed requests) " +
-                                "Please explicitly set $AWS_NO_SIGN_REQUEST to 'no' for unsigned requests.")
+                    log.warning(
+                        "AWS_NO_SIGN_REQUEST is not set. "
+                        + "The default behaviour has recently changed to False (i.e. signed requests) "
+                        + "Please explicitly set $AWS_NO_SIGN_REQUEST to 'no' for unsigned requests."
+                    )
             env_requester_pays = os.environ.get("AWS_REQUEST_PAYER", "")
             requester_pays = False
             if env_requester_pays.lower() == "requester":
@@ -138,7 +155,8 @@ class CredentialManager:
                 del os.environ["AWS_S3_ENDPOINT"]
         elif log:
             log.warning(
-                "Environment variable $AWS_DEFAULT_REGION not set.  (This warning can be ignored if all data is stored locally.)")
+                "Environment variable $AWS_DEFAULT_REGION not set.  (This warning can be ignored if all data is stored locally.)"
+            )
 
     def _check_cred(self) -> None:
         if self.credentials and isinstance(self.credentials, RefreshableCredentials):
@@ -146,9 +164,15 @@ class CredentialManager:
                 self.renew_creds()
             elif self.log:
                 # pylint: disable=protected-access
-                self.log.info("Credentials look OK: %s seconds remaining", str(self.credentials._seconds_remaining()))
+                self.log.info(
+                    "Credentials look OK: %s seconds remaining",
+                    str(self.credentials._seconds_remaining()),
+                )
         elif self.log:
-            self.log.debug("Credentials of type %s - NOT RENEWING", self.credentials.__class__.__name__)
+            self.log.debug(
+                "Credentials of type %s - NOT RENEWING",
+                self.credentials.__class__.__name__,
+            )
 
     @classmethod
     def check_cred(cls) -> None:
@@ -160,11 +184,14 @@ class CredentialManager:
         if self.use_aws:
             if self.log:
                 self.log.info("Establishing/renewing credentials")
-            self.credentials = configure_s3_access(aws_unsigned=self.unsigned,
-                                                            requester_pays=self.requester_pays)
+            self.credentials = configure_s3_access(
+                aws_unsigned=self.unsigned, requester_pays=self.requester_pays
+            )
             if self.log and isinstance(self.credentials, RefreshableCredentials):
                 # pylint: disable=protected-access
-                self.log.debug("%s seconds remaining", str(self.credentials._seconds_remaining()))
+                self.log.debug(
+                    "%s seconds remaining", str(self.credentials._seconds_remaining())
+                )
 
 
 def initialise_aws_credentials(log: Logger | None = None) -> None:
@@ -184,23 +211,32 @@ def parse_config_file(log: Logger | None = None) -> OWSConfig | None:
 
 def initialise_flask(name: str) -> Flask:
     app_path = os.path.dirname(os.path.abspath(__file__))
-    return Flask(name.split('.')[0], template_folder=os.path.join(app_path, 'templates'))
+    return Flask(
+        name.split(".")[0], template_folder=os.path.join(app_path, "templates")
+    )
+
 
 def pass_through(undecorated: Callable) -> Callable:
     def decorator(*args, **kwargs):
         return undecorated(*args, **kwargs)
+
     decorator.__name__ = undecorated.__name__
     return decorator
+
 
 class FakeMetrics:
     def do_not_track(self) -> Callable:
         return pass_through
+
     def counter(self, *args, **kwargs) -> Callable:
         return pass_through
+
     def histogram(self, *args, **kwargs) -> Callable:
         return pass_through
+
     def gauge(self, *args, **kwargs) -> Callable:
         return pass_through
+
     def summary(self, *args, **kwargs) -> Callable:
         return pass_through
 
@@ -211,35 +247,44 @@ def initialise_prometheus(app: Flask, log: Logger | None = None):
         from prometheus_flask_exporter.multiprocess import (
             GunicornInternalPrometheusMetrics,
         )
+
         metrics = GunicornInternalPrometheusMetrics(app, group_by="endpoint")
         if log:
             log.info("Prometheus metrics enabled")
         return metrics
     return FakeMetrics()
 
+
 def proxy_fix(app: Flask, log: Logger | None = None):
     # Proxy Fix, to respect X-Forwarded-For headers
     if os.environ.get("PROXY_FIX", False):
         from werkzeug.middleware.proxy_fix import ProxyFix
+
         app.wsgi_app = ProxyFix(app.wsgi_app, x_for=1, x_proto=1, x_host=1, x_port=1)  # type: ignore[method-assign]
         if log is not None:
             log.info("ProxyFix was enabled")
     return app
 
+
 def request_extractor() -> str | None:
-    return request.args.get('request')
+    return request.args.get("request")
+
 
 def initialise_babel(cfg, app: Flask) -> object | None:
     if cfg and cfg.internationalised:
         from flask_babel import Babel
+
         app.config["BABEL_TRANSLATION_DIRECTORIES"] = cfg.translations_dir
 
         def get_locale() -> str | None:
-            return request.accept_languages.best_match(cfg.locales, default=cfg.locales[0])
+            return request.accept_languages.best_match(
+                cfg.locales, default=cfg.locales[0]
+            )
 
-        return Babel(app,
-                      locale_selector=get_locale,
-                      default_domain=cfg.message_domain,
-                      configure_jinja=False
-                      )
+        return Babel(
+            app,
+            locale_selector=get_locale,
+            default_domain=cfg.message_domain,
+            configure_jinja=False,
+        )
     return None

--- a/datacube_ows/styles/api/__init__.py
+++ b/datacube_ows/styles/api/__init__.py
@@ -6,9 +6,15 @@
 
 
 from datacube_ows.styles.api.base import (  # noqa: F401 isort:skip
-    StandaloneStyle, apply_ows_style, apply_ows_style_cfg,
-    generate_ows_legend_style, generate_ows_legend_style_cfg,
-    plot_image, plot_image_with_style, plot_image_with_style_cfg)
+    StandaloneStyle,
+    apply_ows_style,
+    apply_ows_style_cfg,
+    generate_ows_legend_style,
+    generate_ows_legend_style_cfg,
+    plot_image,
+    plot_image_with_style,
+    plot_image_with_style_cfg,
+)
 
-from datacube_ows.ogc_utils import create_geobox, xarray_image_as_png       # noqa: F401 isort:skip
-from datacube_ows.band_utils import scale_data, scalable, band_modulator    # noqa: F401 isort:skip
+from datacube_ows.ogc_utils import create_geobox, xarray_image_as_png  # noqa: F401 isort:skip
+from datacube_ows.band_utils import scale_data, scalable, band_modulator  # noqa: F401 isort:skip

--- a/datacube_ows/styles/api/base.py
+++ b/datacube_ows/styles/api/base.py
@@ -31,7 +31,9 @@ def StandaloneStyle(cfg: CFG_DICT) -> StyleDefBase:
     return style
 
 
-def apply_ows_style(style, data, loop_over=None, valid_data_mask=None) -> xarray.Dataset:
+def apply_ows_style(
+    style, data, loop_over=None, valid_data_mask=None
+) -> xarray.Dataset:
     """
     Apply an OWS style to an ODC XArray to generate a styled image.
 
@@ -52,29 +54,19 @@ def apply_ows_style(style, data, loop_over=None, valid_data_mask=None) -> xarray
             8 bit signed integer data named red, green, blue and alpha, representing an 24bit RGBA image.
     """
     if loop_over is None:
-        return style.transform_data(
-                data,
-                style.to_mask(
-                        data,
-                        valid_data_mask
-                )
-        )
+        return style.transform_data(data, style.to_mask(data, valid_data_mask))
     image_slices = []
     for coord in data[loop_over].values:
         d_slice = data.sel(**{loop_over: coord})
         image_slices.append(
-            style.transform_data(
-                d_slice,
-                style.to_mask(
-                    d_slice,
-                    valid_data_mask
-                )
-            )
+            style.transform_data(d_slice, style.to_mask(d_slice, valid_data_mask))
         )
     return xarray.concat(image_slices, data[loop_over])
 
 
-def apply_ows_style_cfg(cfg, data, loop_over=None, valid_data_mask=None) ->  xarray.Dataset:
+def apply_ows_style_cfg(
+    cfg, data, loop_over=None, valid_data_mask=None
+) -> xarray.Dataset:
     """
     Apply an OWS style configuration to an ODC XArray to generate a styled image.
 
@@ -99,10 +91,7 @@ def apply_ows_style_cfg(cfg, data, loop_over=None, valid_data_mask=None) ->  xar
             8 bit signed integer data named red, green, blue and alpha, representing an 24bit RGBA image.
     """
     return apply_ows_style(
-        StandaloneStyle(cfg),
-        data,
-        loop_over=loop_over,
-        valid_data_mask=valid_data_mask
+        StandaloneStyle(cfg), data, loop_over=loop_over, valid_data_mask=valid_data_mask
     )
 
 
@@ -132,7 +121,13 @@ def generate_ows_legend_style_cfg(cfg, ndates: int = 0) -> Image.Image | None:
     return generate_ows_legend_style(StandaloneStyle(cfg), ndates)
 
 
-def plot_image(xr_image: xarray.Dataset, x: str = "x", y: str = "y", size: float = 10, aspect: float | None = None) -> None:
+def plot_image(
+    xr_image: xarray.Dataset,
+    x: str = "x",
+    y: str = "y",
+    size: float = 10,
+    aspect: float | None = None,
+) -> None:
     """
     Plot an Xarray image with matplotlib. (e.g. for display in JupyterHub)
 
@@ -153,8 +148,15 @@ def plot_image(xr_image: xarray.Dataset, x: str = "x", y: str = "y", size: float
     rgb.plot.imshow(x=x, y=y, size=size, aspect=aspect)
 
 
-def plot_image_with_style(style, data, x: str = "x", y: str = "y", size: float = 10,
-                          aspect: float | None = None, valid_data_mask=None) -> None:
+def plot_image_with_style(
+    style,
+    data,
+    x: str = "x",
+    y: str = "y",
+    size: float = 10,
+    aspect: float | None = None,
+    valid_data_mask=None,
+) -> None:
     """
     Apply an OWS style to some data, and display with matplotlib. (e.g. for display in JupyterHub)
 
@@ -173,11 +175,24 @@ def plot_image_with_style(style, data, x: str = "x", y: str = "y", size: float =
                 (defaults to None, which means use the aspect ratio of the data.)
     :param valid_data_mask: (optional) An xarray DataArray mask, with dimensions and coordinates matching data.
     """
-    plot_image(apply_ows_style(style, data, valid_data_mask=valid_data_mask), x=x, y=y, size=size, aspect=aspect)
+    plot_image(
+        apply_ows_style(style, data, valid_data_mask=valid_data_mask),
+        x=x,
+        y=y,
+        size=size,
+        aspect=aspect,
+    )
 
 
-def plot_image_with_style_cfg(cfg, data, x: str = "x", y: str = "y", size: float = 10,
-                              aspect: float | None = None, valid_data_mask=None) -> None:
+def plot_image_with_style_cfg(
+    cfg,
+    data,
+    x: str = "x",
+    y: str = "y",
+    size: float = 10,
+    aspect: float | None = None,
+    valid_data_mask=None,
+) -> None:
     """
     Apply an OWS style to some data, and display with matplotlib. (e.g. for display in JupyterHub)
 
@@ -200,4 +215,10 @@ def plot_image_with_style_cfg(cfg, data, x: str = "x", y: str = "y", size: float
                 (defaults to None, which means use the aspect ratio of the data.)
     :param valid_data_mask: (optional) An xarray DataArray mask, with dimensions and coordinates matching data.
     """
-    plot_image(apply_ows_style_cfg(cfg, data, valid_data_mask=valid_data_mask), x=x, y=y, size=size, aspect=aspect)
+    plot_image(
+        apply_ows_style_cfg(cfg, data, valid_data_mask=valid_data_mask),
+        x=x,
+        y=y,
+        size=size,
+        aspect=aspect,
+    )

--- a/datacube_ows/styles/base.py
+++ b/datacube_ows/styles/base.py
@@ -43,9 +43,14 @@ class LegendBase(OWSConfigEntry):
     """
     Legend base class.
     """
-    def __init__(self,
-                 style_or_mdh: Union["StyleDefBase", "StyleDefBase.Legend", "StyleDefBase.MultiDateHandler"],
-                 cfg: CFG_DICT) -> None:
+
+    def __init__(
+        self,
+        style_or_mdh: Union[
+            "StyleDefBase", "StyleDefBase.Legend", "StyleDefBase.MultiDateHandler"
+        ],
+        cfg: CFG_DICT,
+    ) -> None:
         super().__init__(cfg)
         raw_cfg = cast(CFG_DICT, self._raw_cfg)
         self.style_or_mdh = style_or_mdh
@@ -53,7 +58,9 @@ class LegendBase(OWSConfigEntry):
             self.style: StyleDefBase = self.style_or_mdh
         else:
             self.style = self.style_or_mdh.style
-        self.show_legend = cast(bool, raw_cfg.get("show_legend", self.style_or_mdh.auto_legend))
+        self.show_legend = cast(
+            bool, raw_cfg.get("show_legend", self.style_or_mdh.auto_legend)
+        )
         self.legend_urls: MutableMapping[str, str] = self.parse_urls(raw_cfg.get("url"))
 
         self.width: float = 0.0
@@ -67,9 +74,7 @@ class LegendBase(OWSConfigEntry):
             return {}
         def_loc = self.global_config().default_locale
         if isinstance(cfg, str):
-            cfg_d: CFG_DICT = {
-                def_loc: cfg
-            }
+            cfg_d: CFG_DICT = {def_loc: cfg}
         else:
             cfg_d = cast(CFG_DICT, cfg)
         if def_loc not in cfg_d:
@@ -115,6 +120,7 @@ class StyleDefBase(OWSExtensibleConfigEntry, OWSMetadataConfig):
 
     Style config entries can be extended with inheritance, and support Title and Abstract metadata
     """
+
     # For OWSExtensibleConfigEntry
     INDEX_KEYS = ["layer", "style"]
 
@@ -134,36 +140,44 @@ class StyleDefBase(OWSExtensibleConfigEntry, OWSMetadataConfig):
     # Used by Ramp subclass to expose index values to GetFeatureInfo
     include_in_feature_info: bool = False
 
-    def __new__(cls, product: Optional["datacube_ows.ows_configuration.OWSNamedLayer"] = None,
-                style_cfg: CFG_DICT | None = None,
-                stand_alone: bool = False,
-                defer_multi_date: bool = False,
-                user_defined: bool = False) -> "StyleDefBase":
+    def __new__(
+        cls,
+        product: Optional["datacube_ows.ows_configuration.OWSNamedLayer"] = None,
+        style_cfg: CFG_DICT | None = None,
+        stand_alone: bool = False,
+        defer_multi_date: bool = False,
+        user_defined: bool = False,
+    ) -> "StyleDefBase":
         """
         Determine appropriate subclass to instantiate and initialise.
         """
         if product and style_cfg:
-            expanded_cfg = cast(CFG_DICT,
-                                cls.expand_inherit(style_cfg,
-                               global_cfg=product.global_cfg,
-                               keyval_subs={
-                                   "layer": {
-                                       product.name: product
-                                   }
-                               },
-                               keyval_defaults={"layer": product.name}))
+            expanded_cfg = cast(
+                CFG_DICT,
+                cls.expand_inherit(
+                    style_cfg,
+                    global_cfg=product.global_cfg,
+                    keyval_subs={"layer": {product.name: product}},
+                    keyval_defaults={"layer": product.name},
+                ),
+            )
             subclass = cls.determine_subclass(expanded_cfg)
             if not subclass:
-                raise ConfigException(f"Invalid style in layer {product.name} - could not determine style type")
+                raise ConfigException(
+                    f"Invalid style in layer {product.name} - could not determine style type"
+                )
             return super().__new__(subclass)
         return super().__new__(cls)
 
     # FIXME: product type should also include StandaloneProductProxy.
-    def __init__(self, product: "datacube_ows.ows_configuration.OWSNamedLayer",
-                 style_cfg: CFG_DICT,
-                 stand_alone: bool = False,
-                 defer_multi_date: bool = False,
-                 user_defined: bool = False) -> None:
+    def __init__(
+        self,
+        product: "datacube_ows.ows_configuration.OWSNamedLayer",
+        style_cfg: CFG_DICT,
+        stand_alone: bool = False,
+        defer_multi_date: bool = False,
+        user_defined: bool = False,
+    ) -> None:
         """
         Handle first stage initialisation of elements common to all style subclasses.
 
@@ -173,26 +187,24 @@ class StyleDefBase(OWSExtensibleConfigEntry, OWSMetadataConfig):
         :param defer_multi_date: If True, defer certain aspects of configuration - mostly used for testing.
         :param user_defined: True if elements of the style were provided by the user in an extended request.
         """
-        super().__init__(style_cfg,
-                         global_cfg=product.global_cfg,
-                         keyvals={
-                                "layer": product.name,
-                                "style": str(style_cfg.get("name", "stand_alone"))
-                         },
-                         keyval_subs={
-                             "layer": {
-                                 product.name: product
-                             }
-                         },
-                         keyval_defaults={
-                             "layer": product.name
-                         })
+        super().__init__(
+            style_cfg,
+            global_cfg=product.global_cfg,
+            keyvals={
+                "layer": product.name,
+                "style": str(style_cfg.get("name", "stand_alone")),
+            },
+            keyval_subs={"layer": {product.name: product}},
+            keyval_defaults={"layer": product.name},
+        )
         raw_cfg = cast(CFG_DICT, self._raw_cfg)
         self.stand_alone: bool = stand_alone
         if self.stand_alone:
             self._metadata_registry: dict[str, str] = {}
         self.user_defined: bool = user_defined
-        self.local_band_map = cast(MutableMapping[str, str], raw_cfg.get("band_map", {}))
+        self.local_band_map = cast(
+            MutableMapping[str, str], raw_cfg.get("band_map", {})
+        )
         if self.local_band_map:
             pass
         self.product: datacube_ows.ows_configuration.OWSNamedLayer = product
@@ -208,18 +220,20 @@ class StyleDefBase(OWSExtensibleConfigEntry, OWSMetadataConfig):
         if self.stand_alone:
             self.flag_products: list[FlagProductBands] = []
         else:
-            self.flag_products = FlagProductBands.build_list_from_masks(self.masks,
-                                                                        self.product)
+            self.flag_products = FlagProductBands.build_list_from_masks(
+                self.masks, self.product
+            )
 
         self.raw_needed_bands: set[str] = set()
         self.raw_flag_bands: set[str] = set()
         self.declare_unready("needed_bands")
         self.declare_unready("flag_bands")
 
-        custom_includes = cast(dict[str, CFG_DICT | str | F], style_cfg.get("custom_includes", {}))
+        custom_includes = cast(
+            dict[str, CFG_DICT | str | F], style_cfg.get("custom_includes", {})
+        )
         self.feature_info_includes = {
-            k: FunctionWrapper(self, v)
-            for k, v in custom_includes.items()
+            k: FunctionWrapper(self, v) for k, v in custom_includes.items()
         }
         self.legend_cfg = self.Legend(self, cast(CFG_DICT, raw_cfg.get("legend", {})))
         if not defer_multi_date:
@@ -272,13 +286,13 @@ class StyleDefBase(OWSExtensibleConfigEntry, OWSMetadataConfig):
                         handled = True
                         continue
                 if not handled:
-                    self.pq_product_bands.append(
-                        (fb.pq_names, {fb.pq_band})
-                    )
+                    self.pq_product_bands.append((fb.pq_names, {fb.pq_band}))
         for _, pq_bands in self.pq_product_bands:
             for band in pq_bands:
                 if band in self.flag_bands:
-                    raise ConfigException(f"Same flag band name {band} appears in different PQ product (sets)")
+                    raise ConfigException(
+                        f"Same flag band name {band} appears in different PQ product (sets)"
+                    )
                 self.flag_bands.add(band)
         for fp in self.flag_products:
             fp.make_ready()
@@ -314,7 +328,9 @@ class StyleDefBase(OWSExtensibleConfigEntry, OWSMetadataConfig):
         for mb_cfg in cast(list[CFG_DICT], cfg.get("multi_date", [])):
             self.multi_date_handlers.append(self.MultiDateHandler(self, mb_cfg))
 
-    def to_mask(self, data: xr.Dataset, extra_mask: xr.DataArray | None = None) -> xr.DataArray | None:
+    def to_mask(
+        self, data: xr.Dataset, extra_mask: xr.DataArray | None = None
+    ) -> xr.DataArray | None:
         """
         Generate a mask for some data.
 
@@ -342,8 +358,13 @@ class StyleDefBase(OWSExtensibleConfigEntry, OWSMetadataConfig):
                 result = result & mask_data
         return result
 
-    def apply_mask_to_image(self, img_data: xr.Dataset, mask: xr.DataArray | None,
-                            input_date_count: int, output_date_count: int) -> xr.Dataset:
+    def apply_mask_to_image(
+        self,
+        img_data: xr.Dataset,
+        mask: xr.DataArray | None,
+        input_date_count: int,
+        output_date_count: int,
+    ) -> xr.Dataset:
         """
         Apply a mask to an image xarray.
 
@@ -355,12 +376,13 @@ class StyleDefBase(OWSExtensibleConfigEntry, OWSMetadataConfig):
         """
 
         if "alpha" not in img_data.data_vars:
-            nda_alpha: np.ndarray = np.ndarray(img_data["red"].shape, dtype='uint8')
+            nda_alpha: np.ndarray = np.ndarray(img_data["red"].shape, dtype="uint8")
             nda_alpha.fill(255)
-            alpha = xr.DataArray(nda_alpha,
-                                coords=img_data["red"].coords,
-                                dims=img_data["red"].dims,
-                                name="alpha"
+            alpha = xr.DataArray(
+                nda_alpha,
+                coords=img_data["red"].coords,
+                dims=img_data["red"].dims,
+                name="alpha",
             )
         else:
             alpha = img_data.alpha
@@ -387,14 +409,20 @@ class StyleDefBase(OWSExtensibleConfigEntry, OWSMetadataConfig):
         """
         input_date_count = self.count_dates(data)
         mdh = self.get_multi_date_handler(input_date_count)
-        img_data = self.transform_single_date_data(data) if mdh is None else mdh.transform_data(data)
+        img_data = (
+            self.transform_single_date_data(data)
+            if mdh is None
+            else mdh.transform_data(data)
+        )
         if "time" not in img_data.coords or not img_data.time.shape:
             output_date_count = 1
         else:
             output_date_count = len(data.coords["time"])
             if output_date_count == 1:
                 img_data = img_data.squeeze(dim="time", drop=True)
-        return self.apply_mask_to_image(img_data, mask, input_date_count, output_date_count)
+        return self.apply_mask_to_image(
+            img_data, mask, input_date_count, output_date_count
+        )
 
     def transform_single_date_data(self, data: xr.Dataset) -> xr.Dataset:
         """
@@ -442,14 +470,17 @@ class StyleDefBase(OWSExtensibleConfigEntry, OWSMetadataConfig):
             return len(data.coords["time"])
         return len(count_or_sized_or_ds)
 
-    def get_legend_cfg(self, count_or_sized_or_ds: int | Sized | xr.Dataset) -> LegendBase:
+    def get_legend_cfg(
+        self, count_or_sized_or_ds: int | Sized | xr.Dataset
+    ) -> LegendBase:
         mdh = self.get_multi_date_handler(count_or_sized_or_ds)
         if mdh:
             return mdh.legend_cfg
         return self.legend_cfg
 
-    def get_multi_date_handler(self, count_or_sized_or_ds: int | Sized | xr.Dataset
-                               ) -> Optional["StyleDefBase.MultiDateHandler"]:
+    def get_multi_date_handler(
+        self, count_or_sized_or_ds: int | Sized | xr.Dataset
+    ) -> Optional["StyleDefBase.MultiDateHandler"]:
         """
         Get the appropriate multidate handler.
 
@@ -462,10 +493,17 @@ class StyleDefBase(OWSExtensibleConfigEntry, OWSMetadataConfig):
                 return mdh
         if count in [0, 1]:
             return None
-        raise WMSException(f"Style {self.name} does not support requests with {count} dates")
+        raise WMSException(
+            f"Style {self.name} does not support requests with {count} dates"
+        )
 
     @classmethod
-    def register_subclass(cls, subclass: type["StyleDefBase"], triggers: Iterable[str], priority: bool = False) -> None:
+    def register_subclass(
+        cls,
+        subclass: type["StyleDefBase"],
+        triggers: Iterable[str],
+        priority: bool = False,
+    ) -> None:
         """
         Register a subclass with the base class
 
@@ -509,6 +547,7 @@ class StyleDefBase(OWSExtensibleConfigEntry, OWSMetadataConfig):
 
         (TODO: Shares code with style base class inefficiently.)
         """
+
         auto_legend: bool = False
 
         non_animate_requires_aggregator = True
@@ -524,32 +563,49 @@ class StyleDefBase(OWSExtensibleConfigEntry, OWSMetadataConfig):
             raw_cfg = cast(CFG_DICT, self._raw_cfg)
             self.style = style
             if "allowed_count_range" not in raw_cfg:
-                raise ConfigException("multi_date handler must have an allowed_count_range")
+                raise ConfigException(
+                    "multi_date handler must have an allowed_count_range"
+                )
             if len(cast(list[int], cfg["allowed_count_range"])) > 2:
-                raise ConfigException("multi_date handler allowed_count_range must have 2 and only 2 members")
+                raise ConfigException(
+                    "multi_date handler allowed_count_range must have 2 and only 2 members"
+                )
             self.min_count, self.max_count = cast(list[int], cfg["allowed_count_range"])
             if self.max_count < self.min_count:
-                raise ConfigException("multi_date handler allowed_count_range: minimum must be less than equal to maximum")
+                raise ConfigException(
+                    "multi_date handler allowed_count_range: minimum must be less than equal to maximum"
+                )
 
             self.animate = cast(bool, cfg.get("animate", False))
             self.frame_duration: int = 1000
             if "aggregator_function" in cfg:
-                self.aggregator: FunctionWrapper | None = FunctionWrapper(style.product,
-                                                  cast(CFG_DICT, cfg["aggregator_function"]),
-                                                                             stand_alone=self.style.stand_alone)
+                self.aggregator: FunctionWrapper | None = FunctionWrapper(
+                    style.product,
+                    cast(CFG_DICT, cfg["aggregator_function"]),
+                    stand_alone=self.style.stand_alone,
+                )
             elif self.animate:
-                self.aggregator = FunctionWrapper(style.product, lambda x: x, stand_alone=True)
+                self.aggregator = FunctionWrapper(
+                    style.product, lambda x: x, stand_alone=True
+                )
                 self.frame_duration = cast(int, cfg.get("frame_duration", 1000))
             else:
                 self.aggregator = None
                 if self.non_animate_requires_aggregator:
-                    raise ConfigException("Aggregator function is required for non-animated multi-date handlers.")
-            self.legend_cfg = self.Legend(self, cast(CFG_DICT, raw_cfg.get("legend", {})))
-            self.preserve_user_date_order = cast(bool, cfg.get("preserve_user_date_order", False))
-            custom_includes = cast(dict[str, CFG_DICT | str | F], cfg.get("custom_includes", {}))
+                    raise ConfigException(
+                        "Aggregator function is required for non-animated multi-date handlers."
+                    )
+            self.legend_cfg = self.Legend(
+                self, cast(CFG_DICT, raw_cfg.get("legend", {}))
+            )
+            self.preserve_user_date_order = cast(
+                bool, cfg.get("preserve_user_date_order", False)
+            )
+            custom_includes = cast(
+                dict[str, CFG_DICT | str | F], cfg.get("custom_includes", {})
+            )
             self.feature_info_includes = {
-                k: FunctionWrapper(self.style, v)
-                for k, v in custom_includes.items()
+                k: FunctionWrapper(self.style, v) for k, v in custom_includes.items()
             }
 
         def applies_to(self, count: int) -> bool:
@@ -584,13 +640,14 @@ class StyleDefBase(OWSExtensibleConfigEntry, OWSMetadataConfig):
             May be overridden by MDH subclasses to support autolegend generation
             """
 
-
     @classmethod
     @override
-    def lookup_impl(cls,
-                    cfg: "datacube_ows.ows_configuration.OWSConfig",
-                    keyvals: Mapping[str, Any],
-                    subs: Mapping[str, Any] | None = None) -> OWSIndexedConfigEntry:
+    def lookup_impl(
+        cls,
+        cfg: "datacube_ows.ows_configuration.OWSConfig",
+        keyvals: Mapping[str, Any],
+        subs: Mapping[str, Any] | None = None,
+    ) -> OWSIndexedConfigEntry:
         """
         Lookup a config entry of this type by identifying label(s)
 
@@ -612,9 +669,11 @@ class StyleDefBase(OWSExtensibleConfigEntry, OWSMetadataConfig):
                 raise OWSEntryNotFound(f"No layer named {keyvals['layer']}") from None
 
         try:
-            return prod.style_index[keyvals['style']]
+            return prod.style_index[keyvals["style"]]
         except KeyError:
-            raise OWSEntryNotFound(f"No style named {keyvals['style']} in layer {keyvals['layer']}") from None
+            raise OWSEntryNotFound(
+                f"No style named {keyvals['style']} in layer {keyvals['layer']}"
+            ) from None
 
 
 # Style class registries
@@ -624,6 +683,7 @@ style_class_reg: list[tuple[type[StyleDefBase], Iterable[str]]] = []
 
 class StyleMask(AbstractMaskRule):
     VALUES_LABEL = "enum"
+
     def __init__(self, cfg: CFG_DICT, style: StyleDefBase) -> None:
         band = cast(str, cfg["band"])
         super().__init__(band, cfg)
@@ -632,10 +692,14 @@ class StyleMask(AbstractMaskRule):
         self.stand_alone = style.stand_alone
         if not self.stand_alone:
             if not self.style.product.flag_bands:
-                raise ConfigException(f"Style {self.style.name} in layer {self.style.product.name} contains a mask, but the layer has no flag bands")
+                raise ConfigException(
+                    f"Style {self.style.name} in layer {self.style.product.name} contains a mask, but the layer has no flag bands"
+                )
 
             if band not in self.style.product.flag_bands:
-                raise ConfigException(f"Style {self.style.name} has a mask that references flag band {band} which is not defined for the layer")
+                raise ConfigException(
+                    f"Style {self.style.name} has a mask that references flag band {band} which is not defined for the layer"
+                )
         if self.stand_alone:
             self.flag_band: FlagBand = OWSFlagBandStandalone(self.band)
         else:
@@ -645,10 +709,13 @@ class StyleMask(AbstractMaskRule):
     def create_mask(self, data: xr.DataArray) -> xr.DataArray | None:
         return super().create_mask(data)
 
+
 # Minimum Viable Proxy Objects, for standalone API
+
 
 class StandaloneGlobalProxy:
     pass
+
 
 class BandIdxProxy:
     def band(self, band):

--- a/datacube_ows/styles/base.py
+++ b/datacube_ows/styles/base.py
@@ -107,7 +107,7 @@ class LegendBase(OWSConfigEntry):
 
 
 class StyleDefBase(OWSExtensibleConfigEntry, OWSMetadataConfig):
-    """"
+    """
     Base Class from which all style classes are extended.
 
     The base class also holds a register of subclasses.  Instantiating the base
@@ -139,7 +139,7 @@ class StyleDefBase(OWSExtensibleConfigEntry, OWSMetadataConfig):
                 stand_alone: bool = False,
                 defer_multi_date: bool = False,
                 user_defined: bool = False) -> "StyleDefBase":
-        """"
+        """
         Determine appropriate subclass to instantiate and initialise.
         """
         if product and style_cfg:
@@ -230,7 +230,7 @@ class StyleDefBase(OWSExtensibleConfigEntry, OWSMetadataConfig):
 
     @override
     def global_config(self) -> "datacube_ows.ows_configuration.OWSConfig":
-        """"Global config object"""
+        """Global config object"""
         return self.product.global_cfg
 
     @override

--- a/datacube_ows/styles/colormap.py
+++ b/datacube_ows/styles/colormap.py
@@ -41,7 +41,13 @@ class AbstractValueMapRule(AbstractMaskRule):
 
     Construct a ValueMap rule-set with ValueMapRule.value_map_from_config
     """
-    def __init__(self, style_def: Union["ColorMapStyleDef", "ColorMapStyleDef.MultiDateHandler"], band: str, cfg: CFG_DICT) -> None:
+
+    def __init__(
+        self,
+        style_def: Union["ColorMapStyleDef", "ColorMapStyleDef.MultiDateHandler"],
+        band: str,
+        cfg: CFG_DICT,
+    ) -> None:
         """
         Construct a Value Map Rule
 
@@ -68,7 +74,9 @@ class AbstractValueMapRule(AbstractMaskRule):
     @property
     @override
     def context(self) -> str:
-        return f"style {self.style.name} in layer {self.style.product.name} valuemap rule"
+        return (
+            f"style {self.style.name} in layer {self.style.product.name} valuemap rule"
+        )
 
     def parse_color(self, cfg: CFG_DICT) -> None:
         self.color_str = cast(str, cfg["color"])
@@ -81,10 +89,11 @@ class AbstractValueMapRule(AbstractMaskRule):
         self.rgba = to_rgba(self.color_str, alpha=alpha)
 
     @classmethod
-    def value_map_from_config(cls,
-                          style_or_mdh: Union["ColorMapStyleDef", "ColorMapStyleDef.MultiDateHandler"],
-                          cfg: CFG_DICT
-                              ) -> dict[str, list["AbstractValueMapRule"]]:
+    def value_map_from_config(
+        cls,
+        style_or_mdh: Union["ColorMapStyleDef", "ColorMapStyleDef.MultiDateHandler"],
+        cfg: CFG_DICT,
+    ) -> dict[str, list["AbstractValueMapRule"]]:
         """
         Create a multi-date value map rule set from a config specification
 
@@ -103,11 +112,15 @@ class AbstractValueMapRule(AbstractMaskRule):
             else:
                 if mdh.min_count != mdh.max_count:
                     raise ConfigException(
-                        "MultiDate value map only supported on multi-date handlers with min_count and max_count equal.")
+                        "MultiDate value map only supported on multi-date handlers with min_count and max_count equal."
+                    )
                 typ = MultiDateValueMapRule
         vmap: dict[str, list[AbstractValueMapRule]] = {}
         for band_name, rules in cfg.items():
-            band_rules = [typ(style_or_mdh, band_name, rule) for rule in cast(list[CFG_DICT], rules)]
+            band_rules = [
+                typ(style_or_mdh, band_name, rule)
+                for rule in cast(list[CFG_DICT], rules)
+            ]
             vmap[band_name] = band_rules
         return vmap
 
@@ -118,8 +131,8 @@ class ValueMapRule(AbstractValueMapRule):
 
     Construct a ValueMap rule-set with ValueMapRule.value_map_from_config
     """
-    def __init__(self, style_cfg: "ColorMapStyleDef", band: str,
-                 cfg: CFG_DICT) -> None:
+
+    def __init__(self, style_cfg: "ColorMapStyleDef", band: str, cfg: CFG_DICT) -> None:
         """
         Construct a Multi-date Value Map Rule
 
@@ -136,8 +149,10 @@ class MultiDateValueMapRule(AbstractValueMapRule):
 
     Construct a Multi-Date ValueMap rule-set with MultiDateValueMapRule.value_map_from_config
     """
-    def __init__(self, mdh: "ColorMapStyleDef.MultiDateHandler", band: str,
-                 cfg: CFG_DICT) -> None:
+
+    def __init__(
+        self, mdh: "ColorMapStyleDef.MultiDateHandler", band: str, cfg: CFG_DICT
+    ) -> None:
         """
         Construct a Multi-date Value Map Rule
 
@@ -150,7 +165,11 @@ class MultiDateValueMapRule(AbstractValueMapRule):
         self.flags: list[FlagSpec] = []
         self.or_flags: list[bool] = []
         self.values: list[list[int]] = []
-        super().__init__(style_def=cast(ColorMapStyleDef.MultiDateHandler, mdh.style), band=band, cfg=cfg)
+        super().__init__(
+            style_def=cast(ColorMapStyleDef.MultiDateHandler, mdh.style),
+            band=band,
+            cfg=cfg,
+        )
 
     @override
     def parse_rule_spec(self, cfg: CFG_DICT) -> None:
@@ -159,15 +178,21 @@ class MultiDateValueMapRule(AbstractValueMapRule):
         else:
             self.invert = [False] * self.mdh.max_count
         if len(self.invert) != self.mdh.max_count:
-            raise ConfigException("Invert entry has wrong number of rule sets for date count")
+            raise ConfigException(
+                "Invert entry has wrong number of rule sets for date count"
+            )
         if "flags" in cfg:
             date_flags = cast(list[CFG_DICT], cfg["flags"])
             if len(date_flags) != self.mdh.max_count:
-                raise ConfigException("Flags entry has wrong number of rule sets for date count")
+                raise ConfigException(
+                    "Flags entry has wrong number of rule sets for date count"
+                )
             for flags in date_flags:
                 or_flag: bool = False
                 if "or" in flags and "and" in flags:
-                    raise ConfigException(f"MultiDateValueMap rule in {self.mdh.style.name} of layer {self.mdh.style.product.name} combines 'and' and 'or' rules")
+                    raise ConfigException(
+                        f"MultiDateValueMap rule in {self.mdh.style.name} of layer {self.mdh.style.product.name} combines 'and' and 'or' rules"
+                    )
                 if "or" in flags:
                     or_flag = True
                     sflags = cast(FlagSpec, flags["or"])
@@ -186,9 +211,13 @@ class MultiDateValueMapRule(AbstractValueMapRule):
         else:
             self.values = []
         if not self.flags and not self.values:
-            raise ConfigException(f"Multi-Date Value map rule in {self.context} must have a non-empty 'flags' or 'values' section.")
+            raise ConfigException(
+                f"Multi-Date Value map rule in {self.context} must have a non-empty 'flags' or 'values' section."
+            )
         if self.flags and self.values:
-            raise ConfigException(f"Multi-Date Value map rule in {self.context} has both a 'flags' and a 'values' section - choose one.")
+            raise ConfigException(
+                f"Multi-Date Value map rule in {self.context} has both a 'flags' and a 'values' section - choose one."
+            )
 
     @override
     def create_mask(self, data: DataArray) -> DataArray | None:
@@ -201,7 +230,9 @@ class MultiDateValueMapRule(AbstractValueMapRule):
         date_slices = (data.sel(time=dt) for dt in data.coords["time"].values)
         mask: DataArray | None = None
         if self.values:
-            for d_slice, vals, invert in zip(date_slices, self.values, self.invert, strict=False):
+            for d_slice, vals, invert in zip(
+                date_slices, self.values, self.invert, strict=False
+            ):
                 d_mask: DataArray | None = None
                 if len(vals) == 0:
                     d_mask = d_slice == d_slice
@@ -213,13 +244,15 @@ class MultiDateValueMapRule(AbstractValueMapRule):
                         else:
                             d_mask |= vmask
                 if d_mask is not None and invert:
-                    d_mask = ~d_mask # pylint: disable=invalid-unary-operand-type
+                    d_mask = ~d_mask  # pylint: disable=invalid-unary-operand-type
                 if mask is None:
                     mask = d_mask
                 elif d_mask is not None:
                     mask &= d_mask
         else:
-            for d_slice, flags, or_flags, invert in zip(date_slices, self.flags, self.or_flags, self.invert, strict=False):
+            for d_slice, flags, or_flags, invert in zip(
+                date_slices, self.flags, self.or_flags, self.invert, strict=False
+            ):
                 d_mask = None
                 if not flags:
                     d_mask = d_slice == d_slice
@@ -232,7 +265,7 @@ class MultiDateValueMapRule(AbstractValueMapRule):
                 else:
                     d_mask = make_mask(d_slice, **cast(CFG_DICT, flags))
                 if invert and d_mask is not None:
-                    d_mask = ~d_mask # pylint: disable=invalid-unary-operand-type
+                    d_mask = ~d_mask  # pylint: disable=invalid-unary-operand-type
                 if mask is None:
                     mask = d_mask
                 elif d_mask is not None:
@@ -245,9 +278,11 @@ def convert_to_uint8(fval: float) -> int:
     return min(max(scaled, 0), 255)
 
 
-def apply_value_map(value_map: MutableMapping[str, list[AbstractValueMapRule]],
-                    data: Dataset,
-                    band_mapper: Callable[[str], str]) -> Dataset:
+def apply_value_map(
+    value_map: MutableMapping[str, list[AbstractValueMapRule]],
+    data: Dataset,
+    band_mapper: Callable[[str], str],
+) -> Dataset:
     imgdata = Dataset(coords={k: v for k, v in data.coords.items() if k != "time"})
     shape = tuple(imgdata.sizes.values())
     for channel in ("red", "green", "blue", "alpha"):
@@ -257,7 +292,7 @@ def apply_value_map(value_map: MutableMapping[str, list[AbstractValueMapRule]],
         # Run through each item
         band = band_mapper(cfg_band)
         bdata = data[band]
-        if bdata.dtype.kind == 'f':
+        if bdata.dtype.kind == "f":
             # Convert back to int for bitmasking
             bdata = ColorMapStyleDef.reint(bdata)
         for rule in reversed(rules):
@@ -280,7 +315,9 @@ class ColorMapLegendBase(StyleDefBase.Legend, OWSMetadataConfig):
     METADATA_ABSTRACT: bool = False
     METADATA_VALUE_RULES: bool = True
 
-    def __init__(self, style_or_mdh: Union["StyleDefBase", "StyleDefBase.Legend"], cfg: CFG_DICT) -> None:
+    def __init__(
+        self, style_or_mdh: Union["StyleDefBase", "StyleDefBase.Legend"], cfg: CFG_DICT
+    ) -> None:
         super().__init__(style_or_mdh, cfg)
         raw_cfg = cast(CFG_DICT, self._raw_cfg)
         self.ncols = cast(int, raw_cfg.get("ncols", 1))
@@ -288,7 +325,9 @@ class ColorMapLegendBase(StyleDefBase.Legend, OWSMetadataConfig):
             raise ConfigException("ncols must be a positive integer")
         self.patches: list[PatchTemplate] = []
 
-    def register_value_map(self, value_map: MutableMapping[str, list["AbstractValueMapRule"]]) -> None:
+    def register_value_map(
+        self, value_map: MutableMapping[str, list["AbstractValueMapRule"]]
+    ) -> None:
         for band in value_map:
             for idx, rule in reversed(list(enumerate(value_map[band]))):
                 # only include values that are not transparent (and that have a non-blank title or abstract)
@@ -306,19 +345,18 @@ class ColorMapLegendBase(StyleDefBase.Legend, OWSMetadataConfig):
         if self.mpl_rcparams:
             plt.rcParams.update(self.mpl_rcparams)
         plt.figure(figsize=(self.width, self.height))
-        plt.axis('off')
+        plt.axis("off")
         if self.title:
-            plt.legend(handles=patches,
-                       loc='center',
-                       ncol=self.ncols,
-                       frameon=False,
-                       title=self.title)
+            plt.legend(
+                handles=patches,
+                loc="center",
+                ncol=self.ncols,
+                frameon=False,
+                title=self.title,
+            )
         else:
-            plt.legend(handles=patches,
-                       loc='center',
-                       ncol=self.ncols,
-                       frameon=False)
-        plt.savefig(bytesio, format='png')
+            plt.legend(handles=patches, loc="center", ncol=self.ncols, frameon=False)
+        plt.savefig(bytesio, format="png")
 
     def patch_label(self, idx: int) -> str | None:
         return self.read_local_metadata(f"rule_{idx}")
@@ -334,19 +372,26 @@ class ColorMapStyleDef(StyleDefBase):
     """
     Style subclass for value-map styles
     """
+
     auto_legend = True
 
-    def __init__(self,
-                 product: "OWSNamedLayer",
-                 style_cfg: CFG_DICT,
-                 stand_alone: bool = False,
-                 user_defined: bool = False) -> None:
+    def __init__(
+        self,
+        product: "OWSNamedLayer",
+        style_cfg: CFG_DICT,
+        stand_alone: bool = False,
+        user_defined: bool = False,
+    ) -> None:
         """
         Constructor - refer to StyleDefBase
         """
-        super().__init__(product, style_cfg, stand_alone=stand_alone, user_defined=user_defined)
+        super().__init__(
+            product, style_cfg, stand_alone=stand_alone, user_defined=user_defined
+        )
         style_cfg = cast(CFG_DICT, self._raw_cfg)
-        self.value_map = AbstractValueMapRule.value_map_from_config(self, cast(CFG_DICT, style_cfg["value_map"]))
+        self.value_map = AbstractValueMapRule.value_map_from_config(
+            self, cast(CFG_DICT, style_cfg["value_map"])
+        )
         self.legend_cfg.register_value_map(self.value_map)
         for mdh in self.multi_date_handlers:
             mdh.legend_cfg.register_value_map(mdh.value_map)
@@ -368,7 +413,9 @@ class ColorMapStyleDef(StyleDefBase):
         return inted
 
     @staticmethod
-    def create_colordata(data: DataArray, rgba: tuple[float, float, float, float], mask: DataArray) -> Dataset:
+    def create_colordata(
+        data: DataArray, rgba: tuple[float, float, float, float], mask: DataArray
+    ) -> Dataset:
         """Colour a mask with a given colour/alpha"""
         target = Dataset(coords=data.coords)
         channels = ["red", "green", "blue", "alpha"]
@@ -417,9 +464,13 @@ class ColorMapStyleDef(StyleDefBase):
             tcfg = cast(CFG_DICT, self._raw_cfg)
             if self.animate:
                 if "value_map" in tcfg:
-                    raise ConfigException("Multidate value maps not supported for animation handlers")
+                    raise ConfigException(
+                        "Multidate value maps not supported for animation handlers"
+                    )
             else:
-                self._value_map = AbstractValueMapRule.value_map_from_config(self, cast(CFG_DICT, tcfg["value_map"]))
+                self._value_map = AbstractValueMapRule.value_map_from_config(
+                    self, cast(CFG_DICT, tcfg["value_map"])
+                )
 
         @property
         def value_map(self) -> dict[str, list["AbstractValueMapRule"]]:
@@ -436,12 +487,17 @@ class ColorMapStyleDef(StyleDefBase):
             :return: RGBA image xarray.  May have a time dimension
             """
             if self.aggregator is None:
-                return apply_value_map(self.value_map, data, self.style.product.band_idx.band)
+                return apply_value_map(
+                    self.value_map, data, self.style.product.band_idx.band
+                )
             agg = self.aggregator(data)
-            return apply_value_map(self.value_map, agg, self.style.product.band_idx.band)
+            return apply_value_map(
+                self.value_map, agg, self.style.product.band_idx.band
+            )
 
         class Legend(ColorMapLegendBase):
             pass
+
 
 # Register ColorMapStyleDef as a style subclass.
 StyleDefBase.register_subclass(ColorMapStyleDef, "value_map")

--- a/datacube_ows/styles/colormap.py
+++ b/datacube_ows/styles/colormap.py
@@ -341,7 +341,7 @@ class ColorMapStyleDef(StyleDefBase):
                  style_cfg: CFG_DICT,
                  stand_alone: bool = False,
                  user_defined: bool = False) -> None:
-        """"
+        """
         Constructor - refer to StyleDefBase
         """
         super().__init__(product, style_cfg, stand_alone=stand_alone, user_defined=user_defined)

--- a/datacube_ows/styles/component.py
+++ b/datacube_ows/styles/component.py
@@ -28,31 +28,52 @@ class ComponentStyleDef(StyleDefBase):
     Style Subclass that allows the behaviour of each component (red, green, blue, alpha) to be
     specified independently.
     """
-    def __init__(self, product: "OWSNamedLayer",
-                 style_cfg: CFG_DICT,
-                 stand_alone: bool = False,
-                 defer_multi_date: bool = False,
-                 user_defined: bool = False) -> None:
+
+    def __init__(
+        self,
+        product: "OWSNamedLayer",
+        style_cfg: CFG_DICT,
+        stand_alone: bool = False,
+        defer_multi_date: bool = False,
+        user_defined: bool = False,
+    ) -> None:
         """
         See superclass
         """
-        super().__init__(product, style_cfg,
-                         stand_alone=stand_alone, defer_multi_date=defer_multi_date, user_defined=user_defined)
+        super().__init__(
+            product,
+            style_cfg,
+            stand_alone=stand_alone,
+            defer_multi_date=defer_multi_date,
+            user_defined=user_defined,
+        )
         style_cfg: CFG_DICT = cast(CFG_DICT, self._raw_cfg)
         self.raw_rgb_components: dict[str, Callable | LINEAR_COMP_DICT] = {}
-        raw_components = cast(dict[str, Callable | LINEAR_COMP_DICT], style_cfg["components"])
+        raw_components = cast(
+            dict[str, Callable | LINEAR_COMP_DICT], style_cfg["components"]
+        )
         for imgband in ["red", "green", "blue", "alpha"]:
-            components = cast(Callable | LINEAR_COMP_DICT | CFG_DICT | None, raw_components.get(imgband))
+            components = cast(
+                Callable | LINEAR_COMP_DICT | CFG_DICT | None,
+                raw_components.get(imgband),
+            )
             if components is None:
                 if imgband == "alpha":
                     continue
-                raise ConfigException(f"No components defined for {imgband} band in style {self.name}, layer {product.name}")
+                raise ConfigException(
+                    f"No components defined for {imgband} band in style {self.name}, layer {product.name}"
+                )
             if callable(components) or "function" in components:
-                self.raw_rgb_components[imgband] = FunctionWrapper(self.product, cast(CFG_DICT | Callable, components),
-                                                                   stand_alone=self.stand_alone)
+                self.raw_rgb_components[imgband] = FunctionWrapper(
+                    self.product,
+                    cast(CFG_DICT | Callable, components),
+                    stand_alone=self.stand_alone,
+                )
                 if not self.stand_alone:
                     if "additional_bands" not in style_cfg:
-                        raise ConfigException("Style with a function component must declare additional_bands.")
+                        raise ConfigException(
+                            "Style with a function component must declare additional_bands."
+                        )
                     for b in cast(list[str], style_cfg.get("additional_bands", [])):
                         self.raw_needed_bands.add(b)
             else:
@@ -65,7 +86,9 @@ class ComponentStyleDef(StyleDefBase):
 
         self.scale_factor = cast(float, style_cfg.get("scale_factor"))
         if "scale_range" in style_cfg:
-            self.scale_min, self.scale_max = cast(list[float | None], style_cfg["scale_range"])
+            self.scale_min, self.scale_max = cast(
+                list[float | None], style_cfg["scale_range"]
+            )
         elif self.scale_factor:
             self.scale_min = 0.0
             self.scale_max = 255.0 * self.scale_factor
@@ -106,7 +129,9 @@ class ComponentStyleDef(StyleDefBase):
         super().make_ready(*args, **kwargs)
         self.raw_rgb_components = {}
 
-    def dealias_components(self, comp_in: LINEAR_COMP_DICT | None) -> LINEAR_COMP_DICT | None:
+    def dealias_components(
+        self, comp_in: LINEAR_COMP_DICT | None
+    ) -> LINEAR_COMP_DICT | None:
         """
         Convert a component dictionary with band aliases to a component dictionary using canonical band names.
 
@@ -119,7 +144,8 @@ class ComponentStyleDef(StyleDefBase):
             return None
         return {
             self.product.band_idx.band(self.local_band(band_alias)): value
-            for band_alias, value in comp_in.items() if band_alias not in ['scale_range']
+            for band_alias, value in comp_in.items()
+            if band_alias not in ["scale_range"]
         }
 
     def compress_band(self, component_name: str, imgband_data: DataArray) -> DataArray:
@@ -145,10 +171,12 @@ class ComponentStyleDef(StyleDefBase):
         :return: RGBA uint8 xarray
         """
         imgdata = cast(dict[Hashable, Any], {})
-        for imgband, components in cast(dict[str, Callable | LINEAR_COMP_DICT], self.rgb_components).items():
+        for imgband, components in cast(
+            dict[str, Callable | LINEAR_COMP_DICT], self.rgb_components
+        ).items():
             if callable(components):
                 imgband_data = components(data)
-                imgband_data = imgband_data.astype('uint8')
+                imgband_data = imgband_data.astype("uint8")
                 imgdata[imgband] = imgband_data
             else:
                 imgband_data = None
@@ -165,8 +193,10 @@ class ComponentStyleDef(StyleDefBase):
                     else:
                         imgband_data = imgband_component
                 if imgband_data is None:
-                    null_np = np.zeros(tuple(data.sizes.values()), 'float64')
-                    imgband_data = DataArray(null_np, data.coords, tuple(data.sizes.keys()))
+                    null_np = np.zeros(tuple(data.sizes.values()), "float64")
+                    imgband_data = DataArray(
+                        null_np, data.coords, tuple(data.sizes.keys())
+                    )
                 if imgband != "alpha":
                     imgband_data = self.compress_band(imgband, imgband_data)
                 imgdata[imgband] = imgband_data.astype("uint8")

--- a/datacube_ows/styles/expression.py
+++ b/datacube_ows/styles/expression.py
@@ -30,9 +30,11 @@ def empty_gen(ev, a: set) -> set:
 def union(ev, a: set, b: set) -> set:
     return a.union(b)
 
+
 def not_supported(op_name: object) -> Callable[[object, object], Any]:
     def impl(ev: object, a: object = None, b: object = None, c: object = None) -> Any:
         raise ConfigException(f"{op_name} not supported")
+
     return impl
 
 
@@ -41,6 +43,7 @@ class ExpressionEvaluator(lark.Transformer):
     """
     Standard expression evaluator
     """
+
     add = operator.add
     floordiv = operator.floordiv
     mod = operator.mod
@@ -70,6 +73,7 @@ class UserDefinedExpressionEvaluator(ExpressionEvaluator):
 
     (Doesn't support exponent operator)
     """
+
     pow = not_supported("Exponent operator")
 
 
@@ -78,6 +82,7 @@ class BandListEvaluator(ExpressionEvaluator):
     """
     Expression evaluator that returns a list of needed bands for the expression.
     """
+
     neg = pos = identity  # type: ignore[assignment]
     add = sub = mul = truediv = floordiv = mod = pow = union  # type: ignore[assignment]
 
@@ -90,6 +95,7 @@ class BandListEvaluator(ExpressionEvaluator):
 
 ### Expression wrapper - callable wrapper for a configurable expression
 
+
 class ExpressionException(ConfigException):
     """
     Exception for invalid expressions
@@ -100,6 +106,7 @@ class Expression:
     """
     Expression wrapper for configurable expression elements
     """
+
     def __init__(self, style: "datacube_ows.styles.StyleDef", expr_str: str) -> None:
         """
         Class constructor
@@ -114,11 +121,17 @@ class Expression:
             self.tree = parser.parse(self.expr_str)
             self.needed_bands = BandListEvaluator(self.style).transform(self.tree)
         except lark.LarkError as e:
-            raise ExpressionException(f"Invalid expression: {e} {self.expr_str}") from None
+            raise ExpressionException(
+                f"Invalid expression: {e} {self.expr_str}"
+            ) from None
         except KeyError as e:
-            raise ExpressionException(f"Unrecognised band '{e}' in {expr_str}") from None
+            raise ExpressionException(
+                f"Unrecognised band '{e}' in {expr_str}"
+            ) from None
         if len(self.needed_bands) == 0:
-            raise ExpressionException(f"Expression references no bands: {self.expr_str}")
+            raise ExpressionException(
+                f"Expression references no bands: {self.expr_str}"
+            )
 
     def eval_cls(self, data: Dataset) -> ExpressionEvaluator:
         """

--- a/datacube_ows/styles/expression.py
+++ b/datacube_ows/styles/expression.py
@@ -121,7 +121,7 @@ class Expression:
             raise ExpressionException(f"Expression references no bands: {self.expr_str}")
 
     def eval_cls(self, data: Dataset) -> ExpressionEvaluator:
-        """"
+        """
         Return an appropriate Expression Evaluator for a given Dataset
         """
         if self.style.user_defined:

--- a/datacube_ows/styles/hybrid.py
+++ b/datacube_ows/styles/hybrid.py
@@ -25,25 +25,33 @@ class HybridStyleDef(ColorRampDef, ComponentStyleDef):
 
     Returns a linear blend of a component image and colour ramp image
     """
+
     auto_legend = False
 
-    def __init__(self,
-                 product: "OWSNamedLayer",
-                 style_cfg: CFG_DICT,
-                 defer_multi_date: bool = False,
-                 stand_alone: bool = False,
-                 user_defined: bool = False) -> None:
+    def __init__(
+        self,
+        product: "OWSNamedLayer",
+        style_cfg: CFG_DICT,
+        defer_multi_date: bool = False,
+        stand_alone: bool = False,
+        user_defined: bool = False,
+    ) -> None:
         """
         See StyleBaseDef
         """
-        super().__init__(product, style_cfg,
-                                 defer_multi_date=defer_multi_date,
-                                 stand_alone=stand_alone,
-                                 user_defined=user_defined)
+        super().__init__(
+            product,
+            style_cfg,
+            defer_multi_date=defer_multi_date,
+            stand_alone=stand_alone,
+            user_defined=user_defined,
+        )
         style_cfg = cast(CFG_DICT, self._raw_cfg)
         self.component_ratio = float(cast(float | str, style_cfg["component_ratio"]))
         if self.component_ratio < 0.0 or self.component_ratio > 1.0:
-            raise ConfigException("Component ratio must be a floating point number between 0 and 1")
+            raise ConfigException(
+                "Component ratio must be a floating point number between 0 and 1"
+            )
 
     @override
     def transform_single_date_data(self, data: Dataset) -> Dataset:
@@ -53,21 +61,25 @@ class HybridStyleDef(ColorRampDef, ComponentStyleDef):
         :param data: Raw data, all bands.
         :return: RGBA uint8 xarray
         """
-        #pylint: disable=too-many-locals
+        # pylint: disable=too-many-locals
         if self.index_function is not None:
-            data['index_function'] = (data.dims, self.index_function(data).data)
+            data["index_function"] = (data.dims, self.index_function(data).data)
 
         imgdata = Dataset(coords=data)
 
-        d: DataArray = data['index_function']
+        d: DataArray = data["index_function"]
         for band, _ in self.rgb_components.items():
-            rampdata = DataArray(self.color_ramp.get_value(d, band),
-                                 coords=d.coords,
-                                 dims=d.dims)
+            rampdata = DataArray(
+                self.color_ramp.get_value(d, band), coords=d.coords, dims=d.dims
+            )
             component_band_data: DataArray | None = None
-            for c_band, c_intensity in cast(LINEAR_COMP_DICT, self.rgb_components[band]).items():
+            for c_band, c_intensity in cast(
+                LINEAR_COMP_DICT, self.rgb_components[band]
+            ).items():
                 if callable(c_intensity):
-                    imgband_component_data = cast(DataArray, c_intensity(data[c_band], c_band, band))
+                    imgband_component_data = cast(
+                        DataArray, c_intensity(data[c_band], c_band, band)
+                    )
                 else:
                     imgband_component_data = data[c_band] * cast(DataArray, c_intensity)
                 if component_band_data is not None:
@@ -76,12 +88,13 @@ class HybridStyleDef(ColorRampDef, ComponentStyleDef):
                     component_band_data = imgband_component_data
                 if band != "alpha":
                     component_band_data = self.compress_band(band, component_band_data)
-            img_band_data = (rampdata * 255.0 * (1.0 - self.component_ratio)
-                             + self.component_ratio * cast(DataArray,
-                                                           component_band_data))
+            img_band_data = rampdata * 255.0 * (
+                1.0 - self.component_ratio
+            ) + self.component_ratio * cast(DataArray, component_band_data)
             imgdata[band] = (d.dims, img_band_data.astype("uint8").data)
 
         return imgdata
+
 
 # Register HybridStyleDef as a priority subclass of StyleDefBase
 #    (priority means takes precedence over ComponentStyleDef and ColourRampDef)

--- a/datacube_ows/styles/ramp.py
+++ b/datacube_ows/styles/ramp.py
@@ -36,6 +36,7 @@ if TYPE_CHECKING:
 
 _LOG: logging.Logger = logging.getLogger(__name__)
 
+
 @dataclass
 class RampNode:
     value: int | float
@@ -58,36 +59,45 @@ def make_ramp_representation(ramp_spec: RAMP_SPEC, style_name: str) -> RampRepr:
     rep: RampRepr = []
     for node in ramp_spec:
         if "value" not in node:
-            raise ConfigException(f'Color ramp element without a value in style {style_name}')
+            raise ConfigException(
+                f"Color ramp element without a value in style {style_name}"
+            )
         if "color" not in node:
-            raise ConfigException(f'Color ramp element without a color in style {style_name}')
+            raise ConfigException(
+                f"Color ramp element without a color in style {style_name}"
+            )
         if "legend" in node:
-                raise ConfigException(
-                    f"Style {style_name} uses a no-longer supported format for legend configuration.  " +
-                    "Please refer to the documentation and update your config")
+            raise ConfigException(
+                f"Style {style_name} uses a no-longer supported format for legend configuration.  "
+                + "Please refer to the documentation and update your config"
+            )
         rep.append(
             RampNode(
                 float(cast(float | str | int, node["value"])),
                 cast(str, node["color"]),
-                alpha=None if node.get("alpha") is None else float(cast(str | int | float, node["alpha"]))
+                alpha=None
+                if node.get("alpha") is None
+                else float(cast(str | int | float, node["alpha"])),
             )
         )
     return rep
 
 
 UNSCALED_DEFAULT_RAMP = [
-        RampNode(-1e-24, "#000080", alpha=0.0),
-        RampNode(0.0, "#000080"),
-        RampNode(0.1, "#0000FF"),
-        RampNode(0.3, "#00FFFF"),
-        RampNode(0.5, "#00FF00"),
-        RampNode(0.7, "#FFFF00"),
-        RampNode(0.9, "#FF0000"),
-        RampNode(1.0, "#800000"),
+    RampNode(-1e-24, "#000080", alpha=0.0),
+    RampNode(0.0, "#000080"),
+    RampNode(0.1, "#0000FF"),
+    RampNode(0.3, "#00FFFF"),
+    RampNode(0.5, "#00FF00"),
+    RampNode(0.7, "#FFFF00"),
+    RampNode(0.9, "#FF0000"),
+    RampNode(1.0, "#800000"),
 ]
 
 
-def scale_unscaled_ramp(rmin: int | float | str, rmax: int | float | str, unscaled: RampRepr) -> RampRepr:
+def scale_unscaled_ramp(
+    rmin: int | float | str, rmax: int | float | str, unscaled: RampRepr
+) -> RampRepr:
     """
     Take a unscaled (normalised) ramp that covers values from 0.0 to 1.0 and scale it linearly to cover the
     provided range.
@@ -105,17 +115,12 @@ def scale_unscaled_ramp(rmin: int | float | str, rmax: int | float | str, unscal
         nmax: float = rmax
     else:
         nmax = float(rmax)
-    return [
-        u.with_value((nmax - nmin) * float(u.value) + nmin)
-        for u in unscaled
-    ]
+    return [u.with_value((nmax - nmin) * float(u.value) + nmin) for u in unscaled]
 
 
-def crack_ramp(ramp: RampRepr) -> tuple[
-    list[float],
-    list[float], list[float],
-    list[float], list[float],
-]:
+def crack_ramp(
+    ramp: RampRepr,
+) -> tuple[list[float], list[float], list[float], list[float], list[float]]:
     """
     Split a colour ramp into separate (input) value and (output) RGBA lists.
 
@@ -155,9 +160,7 @@ def read_mpl_ramp(mpl_ramp: str) -> RampRepr:
     unscaled_cmap.append(RampNode(0.0, rgba_hex))
     for val in val_range:
         rgba_hex = to_hex(cast(tuple[float, float, float, float], cmap(val)))
-        unscaled_cmap.append(
-            RampNode(float(val), rgba_hex)
-        )
+        unscaled_cmap.append(RampNode(float(val), rgba_hex))
     return unscaled_cmap
 
 
@@ -165,16 +168,19 @@ class ColorRamp:
     """
     Represents a colour ramp for image and legend rendering purposes
     """
-    def __init__(self, style: StyleDefBase,
-                       ramp_cfg: CFG_DICT,
-                       legend: "RampLegendBase") -> None:
+
+    def __init__(
+        self, style: StyleDefBase, ramp_cfg: CFG_DICT, legend: "RampLegendBase"
+    ) -> None:
         """
         :param style: The style owning the ramp
         :param ramp_cfg: Style config
         """
         self.style = style
         if "color_ramp" in ramp_cfg:
-            raw_scaled_ramp = make_ramp_representation(cast(RAMP_SPEC, ramp_cfg["color_ramp"]), self.style.name)
+            raw_scaled_ramp = make_ramp_representation(
+                cast(RAMP_SPEC, ramp_cfg["color_ramp"]), self.style.name
+            )
         else:
             rmin, rmax = cast(list[float], ramp_cfg["range"])
             unscaled_ramp = UNSCALED_DEFAULT_RAMP
@@ -232,12 +238,7 @@ class ColorRamp:
     def crack_ramp(self) -> None:
         values, r, g, b, a = crack_ramp(self.ramp)
         self.values = values
-        self.components = {
-            "red": r,
-            "green": g,
-            "blue": b,
-            "alpha": a
-        }
+        self.components = {"red": r, "green": g, "blue": b, "alpha": a}
 
     def get_value(self, data: float | DataArray, band: str) -> numpy.ndarray | float:
         return numpy.interp(data, self.values, self.components[band])
@@ -259,7 +260,7 @@ class ColorRamp:
             float(self.get_value(val, "red")),
             float(self.get_value(val, "green")),
             float(self.get_value(val, "blue")),
-            float(self.get_value(val, "alpha"))
+            float(self.get_value(val, "alpha")),
         )
 
 
@@ -268,7 +269,9 @@ class RampLegendBase(StyleDefBase.Legend, OWSMetadataConfig):
     METADATA_LEGEND_UNITS: bool = True
     METADATA_TICK_LABELS: bool = True
 
-    def __init__(self, style_or_mdh: Union["StyleDefBase", "StyleDefBase.Legend"], cfg: CFG_DICT) -> None:
+    def __init__(
+        self, style_or_mdh: Union["StyleDefBase", "StyleDefBase.Legend"], cfg: CFG_DICT
+    ) -> None:
         super().__init__(style_or_mdh, cfg)
         raw_cfg = cast(CFG_DICT, self._raw_cfg)
         # Range - defaults deferred until we have parsed the associated ramp
@@ -304,42 +307,61 @@ class RampLegendBase(StyleDefBase.Legend, OWSMetadataConfig):
         self.ticks: list[Decimal] = []
         if "ticks_every" in raw_cfg:
             if "tick_count" in raw_cfg:
-                raise ConfigException("Cannot use tick count and ticks_every in the same legend")
+                raise ConfigException(
+                    "Cannot use tick count and ticks_every in the same legend"
+                )
             if "ticks" in raw_cfg:
-                raise ConfigException("Cannot use ticks and ticks_every in the same legend")
+                raise ConfigException(
+                    "Cannot use ticks and ticks_every in the same legend"
+                )
             self.ticks_every = Decimal(cast(int | float | str, raw_cfg["ticks_every"]))
             if self.ticks_every.is_zero() or self.ticks_every.is_signed():
                 raise ConfigException("ticks_every must be greater than zero")
             ticks_handled = True
         if "ticks" in raw_cfg:
             if "tick_count" in raw_cfg:
-                raise ConfigException("Cannot use tick count and ticks in the same legend")
-            self.ticks = [Decimal(t) for t in cast(list[str | int | float], raw_cfg["ticks"])]
+                raise ConfigException(
+                    "Cannot use tick count and ticks in the same legend"
+                )
+            self.ticks = [
+                Decimal(t) for t in cast(list[str | int | float], raw_cfg["ticks"])
+            ]
             ticks_handled = True
         if not ticks_handled:
             self.tick_count = int(cast(str | int, raw_cfg.get("tick_count", 1)))
             if self.tick_count < 0:
                 raise ConfigException("tick_count cannot be negative")
         # prepare for tick labels
-        self.cfg_labels = cast(MutableMapping[str, MutableMapping[str, str]], raw_cfg.get("tick_labels", {}))
+        self.cfg_labels = cast(
+            MutableMapping[str, MutableMapping[str, str]],
+            raw_cfg.get("tick_labels", {}),
+        )
         defaults = self.cfg_labels.get("default", {})
         self.lbl_default_prefix = defaults.get("prefix", "")
         self.lbl_default_suffix = defaults.get("suffix", "")
         self.tick_labels: list[str] = []
         # handle matplotlib args
-        self.strip_location = cast(tuple[float, float, float, float],
-                                   tuple(cast(Iterable[float], raw_cfg.get("strip_location", [0.05, 0.5, 0.9, 0.15]))))
+        self.strip_location = cast(
+            tuple[float, float, float, float],
+            tuple(
+                cast(
+                    Iterable[float],
+                    raw_cfg.get("strip_location", [0.05, 0.5, 0.9, 0.15]),
+                )
+            ),
+        )
         # throw error on legacy syntax
         self.fail_legacy()
 
     def fail_legacy(self) -> None:
         if any(
-                legent in cast(CFG_DICT, self._raw_cfg)
-                for legent in ["major_ticks", "offset", "scale_by", "radix_point"]
+            legent in cast(CFG_DICT, self._raw_cfg)
+            for legent in ["major_ticks", "offset", "scale_by", "radix_point"]
         ):
             raise ConfigException(
-                f"Style {self.style.name} uses a no-longer supported format for legend configuration.  " +
-                "Please refer to the documentation and update your config")
+                f"Style {self.style.name} uses a no-longer supported format for legend configuration.  "
+                + "Please refer to the documentation and update your config"
+            )
 
     def register_ramp(self, ramp: ColorRamp) -> None:
         if self.begin.is_nan():
@@ -358,7 +380,9 @@ class RampLegendBase(StyleDefBase.Legend, OWSMetadataConfig):
                 self.end = Decimal(ramp.ramp[-1].value)
         for t in self.ticks:
             if t < self.begin or t > self.end:
-                raise ConfigException("Explicit ticks must all be within legend begin/end range")
+                raise ConfigException(
+                    "Explicit ticks must all be within legend begin/end range"
+                )
         if self.ticks_every is not None:
             tickval = self.begin
             while tickval < self.end:
@@ -373,7 +397,9 @@ class RampLegendBase(StyleDefBase.Legend, OWSMetadataConfig):
                 dcount = Decimal(self.tick_count)
                 for i in range(0, self.tick_count + 1):
                     tickval = self.begin + (Decimal(i) / dcount) * delta
-                    self.ticks.append(tickval.quantize(self.rounder, rounding=ROUND_HALF_UP))
+                    self.ticks.append(
+                        tickval.quantize(self.rounder, rounding=ROUND_HALF_UP)
+                    )
 
         # handle tick labels
         for tick in self.ticks:
@@ -389,7 +415,6 @@ class RampLegendBase(StyleDefBase.Legend, OWSMetadataConfig):
                 )
         self.parse_metadata(cast(CFG_DICT, self._raw_cfg))
 
-
     def tick_label(self, tick: Decimal) -> str | None:
         try:
             tick_idx = self.ticks.index(tick)
@@ -401,13 +426,17 @@ class RampLegendBase(StyleDefBase.Legend, OWSMetadataConfig):
             _LOG.error("'%s' is a not a valid tick", tick)
             return None
 
-    def create_cdict_ticks(self) -> tuple[
+    def create_cdict_ticks(
+        self,
+    ) -> tuple[
         MutableMapping[str, list[tuple[float, float, float]]],
         MutableMapping[float, str],
     ]:
         normalize_factor = float(self.end) - float(self.begin)
         cdict = cast(MutableMapping[str, list[tuple[float, float, float]]], {})
-        bands = cast(MutableMapping[str, list[tuple[float, float, float]]], defaultdict(list))
+        bands = cast(
+            MutableMapping[str, list[tuple[float, float, float]]], defaultdict(list)
+        )
         started = False
         finished = False
         for index, ramp_node in enumerate(self.style_or_mdh.color_ramp.ramp):
@@ -457,13 +486,12 @@ class RampLegendBase(StyleDefBase.Legend, OWSMetadataConfig):
         ax = fig.add_axes(self.strip_location)
         custom_map = LinearSegmentedColormap(self.plot_name(), cdict)  # type: ignore[arg-type]
         color_bar = matplotlib.colorbar.ColorbarBase(
-            ax,
-            cmap=custom_map,
-            orientation="horizontal")
+            ax, cmap=custom_map, orientation="horizontal"
+        )
         color_bar.set_ticks(list(ticks.keys()))
         color_bar.set_ticklabels(list(ticks.values()))
         color_bar.set_label(self.display_title())
-        plt.savefig(bytesio, format='png')
+        plt.savefig(bytesio, format="png")
 
     # For MetadataConfig
     @property
@@ -472,45 +500,62 @@ class RampLegendBase(StyleDefBase.Legend, OWSMetadataConfig):
         return self.style.title
 
 
-
 class ColorRampDef(StyleDefBase):
     """
     Colour ramp Style subclass
     """
+
     auto_legend = True
 
-    def __init__(self,
-                 product: "OWSNamedLayer",
-                 style_cfg: CFG_DICT,
-                 stand_alone: bool = False,
-                 defer_multi_date: bool = False,
-                 user_defined: bool = False) -> None:
+    def __init__(
+        self,
+        product: "OWSNamedLayer",
+        style_cfg: CFG_DICT,
+        stand_alone: bool = False,
+        defer_multi_date: bool = False,
+        user_defined: bool = False,
+    ) -> None:
         """
         Constructor - refer to StyleDefBase
         """
-        super().__init__(product, style_cfg,
-                           stand_alone=stand_alone, defer_multi_date=True, user_defined=user_defined)
+        super().__init__(
+            product,
+            style_cfg,
+            stand_alone=stand_alone,
+            defer_multi_date=True,
+            user_defined=user_defined,
+        )
         style_cfg = cast(CFG_DICT, self._raw_cfg)
-        self.color_ramp = ColorRamp(self, style_cfg, cast(ColorRampDef.Legend, self.legend_cfg))
-        self.include_in_feature_info = bool(style_cfg.get("include_in_feature_info", True))
+        self.color_ramp = ColorRamp(
+            self, style_cfg, cast(ColorRampDef.Legend, self.legend_cfg)
+        )
+        self.include_in_feature_info = bool(
+            style_cfg.get("include_in_feature_info", True)
+        )
 
         if "index_function" in style_cfg:
-            self.index_function: FunctionWrapper | Expression = FunctionWrapper(self,
-                                                  cast(CFG_DICT, style_cfg["index_function"]),
-                                                  stand_alone=self.stand_alone)
+            self.index_function: FunctionWrapper | Expression = FunctionWrapper(
+                self,
+                cast(CFG_DICT, style_cfg["index_function"]),
+                stand_alone=self.stand_alone,
+            )
             if not self.stand_alone:
                 for band in cast(list[str], style_cfg["needed_bands"]):
                     self.raw_needed_bands.add(band)
         elif "index_expression" in style_cfg:
-            self.index_function = Expression(self, cast(str, style_cfg["index_expression"]))
+            self.index_function = Expression(
+                self, cast(str, style_cfg["index_expression"])
+            )
             for band in self.index_function.needed_bands:
                 self.raw_needed_bands.add(band)
             if self.stand_alone:
                 self.needed_bands = {self.local_band(b) for b in self.raw_needed_bands}
                 self.flag_bands = set()
         else:
-            raise ConfigException("Index function is required for index and hybrid styles. "
-                                  f"Style {self.name} in layer {self.product.name}")
+            raise ConfigException(
+                "Index function is required for index and hybrid styles. "
+                f"Style {self.name} in layer {self.product.name}"
+            )
         if not defer_multi_date:
             self.parse_multi_date(style_cfg)
 
@@ -522,7 +567,7 @@ class ColorRampDef(StyleDefBase):
         :return: Matching dataarray carrying the index value
         """
         index_data = self.index_function(data)
-        data['index_function'] = (index_data.dims, index_data.data)
+        data["index_function"] = (index_data.dims, index_data.data)
         return data["index_function"]
 
     @override
@@ -557,8 +602,12 @@ class ColorRampDef(StyleDefBase):
                 self.color_ramp = style.color_ramp
                 self.pass_raw_data = False
             else:
-                self.feature_info_label = cast(str | None, cfg.get("feature_info_label", None))
-                self.color_ramp = ColorRamp(style, cfg, cast(ColorRampDef.Legend, self.legend_cfg))
+                self.feature_info_label = cast(
+                    str | None, cfg.get("feature_info_label", None)
+                )
+                self.color_ramp = ColorRamp(
+                    style, cfg, cast(ColorRampDef.Legend, self.legend_cfg)
+                )
                 self.pass_raw_data = bool(cfg.get("pass_raw_data", False))
 
         @override

--- a/datacube_ows/styles/ramp.py
+++ b/datacube_ows/styles/ramp.py
@@ -485,7 +485,7 @@ class ColorRampDef(StyleDefBase):
                  stand_alone: bool = False,
                  defer_multi_date: bool = False,
                  user_defined: bool = False) -> None:
-        """"
+        """
         Constructor - refer to StyleDefBase
         """
         super().__init__(product, style_cfg,

--- a/datacube_ows/tile_matrix_sets.py
+++ b/datacube_ows/tile_matrix_sets.py
@@ -39,16 +39,22 @@ webmerc_scale_set = [
 def validate_2d_array(array: list, ident: str, label: str, typ: type) -> None:
     try:
         if len(array) != 2:
-            raise ConfigException(f"In tile matrix set {ident}, {label} must have two values: f{array}")
+            raise ConfigException(
+                f"In tile matrix set {ident}, {label} must have two values: f{array}"
+            )
         validate_array_typ(array, ident, label, typ)
     except TypeError:
-        raise ConfigException(f"In tile matrix set {ident}, {label} must be a list of two values: f{array}") from None
+        raise ConfigException(
+            f"In tile matrix set {ident}, {label} must be a list of two values: f{array}"
+        ) from None
 
 
 def validate_array_typ(array: list, ident: str, label: str, typ: type) -> None:
     for elem in array:
         if not isinstance(elem, typ):
-            raise ConfigException(f"In tile matrix set {ident}, {label} has non-{typ.__name__} value of type {elem.__class__.__name__}: {elem}")
+            raise ConfigException(
+                f"In tile matrix set {ident}, {label} has non-{typ.__name__} value of type {elem.__class__.__name__}: {elem}"
+            )
 
 
 class TileMatrixSet(OWSConfigEntry):
@@ -59,7 +65,7 @@ class TileMatrixSet(OWSConfigEntry):
             "tile_size": [256, 256],
             "scale_set": cast(RAW_CFG, webmerc_scale_set),
             "wkss": "urn:ogc:def:wkss:OGC:1.0:GoogleMapsCompatible",
-        },
+        }
     }
 
     def __init__(self, identifier: str, cfg: CFG_DICT, global_cfg: "OWSConfig") -> None:
@@ -69,38 +75,54 @@ class TileMatrixSet(OWSConfigEntry):
 
         self.crs_name = cast(str, cfg["crs"])
         if self.crs_name not in self.global_cfg.published_CRSs:
-            raise ConfigException(f"Tile matrix set {identifier} has unpublished CRS: {self.crs_name}")
+            raise ConfigException(
+                f"Tile matrix set {identifier} has unpublished CRS: {self.crs_name}"
+            )
         matrix_origin = cast(list, cfg["matrix_origin"])
         validate_2d_array(matrix_origin, identifier, "Matrix origin", float)
         self.matrix_origin = cast(list[float], matrix_origin)
         if len(self.matrix_origin) != 2:
-            raise ConfigException(f"The origin coordinates of tile matrix set {identifier} must have 2 dimensions")
+            raise ConfigException(
+                f"The origin coordinates of tile matrix set {identifier} must have 2 dimensions"
+            )
         tile_size = cast(list, cfg["tile_size"])
         validate_2d_array(tile_size, identifier, "Tile size", int)
         if len(tile_size) != 2:
-            raise ConfigException(f"The tile size of tile matrix set {identifier} must have 2 dimensions")
+            raise ConfigException(
+                f"The tile size of tile matrix set {identifier} must have 2 dimensions"
+            )
         self.tile_size = cast(list[int], tile_size)
         scale_set = cast(list, cfg["scale_set"])
         try:
             validate_array_typ(scale_set, identifier, "Scale set", float)
         except TypeError:
-            raise ConfigException(f"In tile matrix set {identifier}, scale_set is not a list") from None
+            raise ConfigException(
+                f"In tile matrix set {identifier}, scale_set is not a list"
+            ) from None
         self.scale_set = cast(list[float], scale_set)
         if len(self.scale_set) < 1:
-            raise ConfigException(f"Tile matrix set {identifier} has no scale denominators in scale_set")
+            raise ConfigException(
+                f"Tile matrix set {identifier} has no scale denominators in scale_set"
+            )
         self.force_raw_crs_name = bool(cfg.get("force_raw_crs_name", False))
         self.wkss = cast(str | None, cfg.get("wkss"))
-        initial_matrix_exponents = cast(list, cfg.get("matrix_exponent_initial_offsets", [0, 0]))
-        validate_2d_array(initial_matrix_exponents, identifier, "Initial matrix exponents", int)
+        initial_matrix_exponents = cast(
+            list, cfg.get("matrix_exponent_initial_offsets", [0, 0])
+        )
+        validate_2d_array(
+            initial_matrix_exponents, identifier, "Initial matrix exponents", int
+        )
         if len(initial_matrix_exponents) != 2:
             raise ConfigException(
-                f"The initial matrix exponents of tile matrix set {identifier} must have 2 dimensions")
+                f"The initial matrix exponents of tile matrix set {identifier} must have 2 dimensions"
+            )
         self.initial_matrix_exponents = cast(list[int], initial_matrix_exponents)
         unit_coefficients = cast(list, cfg.get("unit_coefficients", [1.0, -1.0]))
         validate_2d_array(unit_coefficients, identifier, "Unit coefficients", float)
         if len(unit_coefficients) != 2:
             raise ConfigException(
-                f"The unit coefficients of tile matrix set {identifier} must have 2 dimensions")
+                f"The unit coefficients of tile matrix set {identifier} must have 2 dimensions"
+            )
         self.unit_coefficients = cast(list[float], unit_coefficients)
 
     @property
@@ -133,15 +155,16 @@ class TileMatrixSet(OWSConfigEntry):
         pixel = [col, row]
         scale_denominator = self.scale_set[tile_matrix]
         pixel_span = [scale_denominator * 0.00028 * u for u in self.unit_coefficients]
-        tile_span = [ps * ts for ps, ts in zip(pixel_span, self.tile_size, strict=False)]
+        tile_span = [
+            ps * ts for ps, ts in zip(pixel_span, self.tile_size, strict=False)
+        ]
 
-        mins = [mo + p * ts for mo, p, ts in zip(self.matrix_origin, pixel, tile_span, strict=False)]
+        mins = [
+            mo + p * ts
+            for mo, p, ts in zip(self.matrix_origin, pixel, tile_span, strict=False)
+        ]
         maxs = [m + ts for m, ts in zip(mins, tile_span, strict=False)]
 
         if self.crs_cfg["vertical_coord_first"]:
-            return (
-                maxs[1], mins[0], mins[1], maxs[0]
-            )
-        return (
-            mins[0], maxs[1], maxs[0], mins[1]
-        )
+            return (maxs[1], mins[0], mins[1], maxs[0])
+        return (mins[0], maxs[1], maxs[0], mins[1])

--- a/datacube_ows/time_utils.py
+++ b/datacube_ows/time_utils.py
@@ -38,11 +38,11 @@ def dataset_center_time(dataset: Dataset) -> datetime.datetime:
     """
     center_time: datetime.datetime = dataset.center_time
     try:
-        metadata_time: str = dataset.metadata_doc['extent']['center_dt']
+        metadata_time: str = dataset.metadata_doc["extent"]["center_dt"]
         center_time = parse(metadata_time)
     except KeyError:
         try:
-            metadata_time = dataset.metadata_doc['properties']['dtr:start_datetime']
+            metadata_time = dataset.metadata_doc["properties"]["dtr:start_datetime"]
             center_time = parse(metadata_time)
         except KeyError:
             pass
@@ -60,7 +60,7 @@ def solar_date(dt: datetime.datetime, tz: datetime.tzinfo) -> datetime.date:
     return dt.astimezone(tz).date()
 
 
-def local_date(ds: Dataset, tz: datetime.tzinfo | None =  None) -> datetime.date:
+def local_date(ds: Dataset, tz: datetime.tzinfo | None = None) -> datetime.date:
     """
     Calculate the local (solar) date for a dataset.
 
@@ -97,14 +97,18 @@ def tz_for_coord(lon: float | int, lat: float | int) -> datetime.tzinfo:
         tzn: str | None = tf.timezone_at(lng=lon, lat=lat)
     except Exception as e:
         # Generally shouldn't happen - a common symptom of various geographic and timezone related bugs
-        _LOG.warning("Timezone detection failed for lat %f, lon %s (%s)", lat, lon, str(e))
+        _LOG.warning(
+            "Timezone detection failed for lat %f, lon %s (%s)", lat, lon, str(e)
+        )
         raise
     if not tzn:
         raise NoTimezoneException("tz find failed.")
     return ZoneInfo(tzn)
 
 
-def local_solar_date_range(geobox: GeoBox, date: datetime.date) -> tuple[datetime.datetime, datetime.datetime]:
+def local_solar_date_range(
+    geobox: GeoBox, date: datetime.date
+) -> tuple[datetime.datetime, datetime.datetime]:
     """
     Converts a date to a local solar date datetime range.
 
@@ -118,7 +122,9 @@ def local_solar_date_range(geobox: GeoBox, date: datetime.date) -> tuple[datetim
     return start.astimezone(timezone.utc), end.astimezone(timezone.utc)
 
 
-def month_date_range(date: datetime.date) -> tuple[datetime.datetime, datetime.datetime]:
+def month_date_range(
+    date: datetime.date,
+) -> tuple[datetime.datetime, datetime.datetime]:
     """
     Take a month from a date and convert to a one month long UTC datetime range encompassing the month.
 
@@ -133,7 +139,9 @@ def month_date_range(date: datetime.date) -> tuple[datetime.datetime, datetime.d
     if m == 13:
         m = 1
         y = y + 1
-    end = datetime.datetime(y, m, 1, 0, 0, 0, tzinfo=timezone.utc) - datetime.timedelta(days=1)
+    end = datetime.datetime(y, m, 1, 0, 0, 0, tzinfo=timezone.utc) - datetime.timedelta(
+        days=1
+    )
     return start, end
 
 
@@ -151,7 +159,9 @@ def year_date_range(date: datetime.date) -> tuple[datetime.datetime, datetime.da
     return start, end
 
 
-def day_summary_date_range(date: datetime.date) -> tuple[datetime.datetime, datetime.datetime]:
+def day_summary_date_range(
+    date: datetime.date,
+) -> tuple[datetime.datetime, datetime.datetime]:
     """
     Convert a date to a UTC datetime range encompassing the calendar date.
 
@@ -160,8 +170,12 @@ def day_summary_date_range(date: datetime.date) -> tuple[datetime.datetime, date
     :param date: A date or datetime object to take the day, month and year from
     :return: A tuple of two UTC datetime objects, delimiting a calendar day.
     """
-    start = datetime.datetime(date.year, date.month, date.day, 0, 0, 0, tzinfo=timezone.utc)
-    end = datetime.datetime(date.year, date.month, date.day, 23, 59, 59, tzinfo=timezone.utc)
+    start = datetime.datetime(
+        date.year, date.month, date.day, 0, 0, 0, tzinfo=timezone.utc
+    )
+    end = datetime.datetime(
+        date.year, date.month, date.day, 23, 59, 59, tzinfo=timezone.utc
+    )
     return start, end
 
 
@@ -187,9 +201,10 @@ def tz_for_geometry(geom: Geometry) -> datetime.tzinfo:
 
 
 def rolling_window_ndays(
-        available_dates: list[datetime.datetime],
-        layer_cfg: OWSExtensibleConfigEntry,
-        ndays: int = 6) -> tuple[datetime.datetime, datetime.datetime]:
+    available_dates: list[datetime.datetime],
+    layer_cfg: OWSExtensibleConfigEntry,
+    ndays: int = 6,
+) -> tuple[datetime.datetime, datetime.datetime]:
     idx = -ndays
     days = available_dates[idx:]
     start, _ = layer_cfg.search_times(days[idx])

--- a/datacube_ows/update_ranges_impl.py
+++ b/datacube_ows/update_ranges_impl.py
@@ -19,27 +19,54 @@ from datacube_ows.startup_utils import initialise_debugging
 
 
 @click.command()
-@click.option("--views", is_flag=True, default=False,
-              help="Refresh the ODC spatio-temporal materialised views.")
-@click.option("--schema", is_flag=True, default=False,
-              help="Create or update the OWS database schema, including the spatio-temporal materialised views.")
-@click.option("--read-role", multiple=True,
-              help="(Only valid with --schema) Role(s) to grant read-only database permissions to")
-@click.option("--write-role", multiple=True,
-              help="(Only valid with --schema) Role(s) to grant both read and write/update database permissions to")
-@click.option("--cleanup", is_flag=True, default=False,
-              help="Cleanup up any datacube-ows 1.8.x tables/views")
-@click.option("-E", "--env", default=None,
-              help="(Only valid with --schema or --read-role or --write-role or --cleanup) environment to write to.")
-@click.option("--version", is_flag=True, default=False,
-              help="Print version string and exit")
+@click.option(
+    "--views",
+    is_flag=True,
+    default=False,
+    help="Refresh the ODC spatio-temporal materialised views.",
+)
+@click.option(
+    "--schema",
+    is_flag=True,
+    default=False,
+    help="Create or update the OWS database schema, including the spatio-temporal materialised views.",
+)
+@click.option(
+    "--read-role",
+    multiple=True,
+    help="(Only valid with --schema) Role(s) to grant read-only database permissions to",
+)
+@click.option(
+    "--write-role",
+    multiple=True,
+    help="(Only valid with --schema) Role(s) to grant both read and write/update database permissions to",
+)
+@click.option(
+    "--cleanup",
+    is_flag=True,
+    default=False,
+    help="Cleanup up any datacube-ows 1.8.x tables/views",
+)
+@click.option(
+    "-E",
+    "--env",
+    default=None,
+    help="(Only valid with --schema or --read-role or --write-role or --cleanup) environment to write to.",
+)
+@click.option(
+    "--version", is_flag=True, default=False, help="Print version string and exit"
+)
 @click.argument("layers", nargs=-1)
-def main(layers: list[str],
-         env: str | None,
-         schema: bool,
-         read_role: list[str],
-         write_role: list[str],
-         cleanup: bool, views: bool, version: bool) -> int:
+def main(
+    layers: list[str],
+    env: str | None,
+    schema: bool,
+    read_role: list[str],
+    write_role: list[str],
+    cleanup: bool,
+    views: bool,
+    version: bool,
+) -> int:
     """Manage datacube-ows range tables.  Exposed on setup as datacube-ows-update
 
     Valid invocations:
@@ -92,7 +119,9 @@ def main(layers: list[str],
     """
     # --version
     if version:
-        click.echo(f"Open Data Cube Open Web Services (datacube-ows) version {__version__}")
+        click.echo(
+            f"Open Data Cube Open Web Services (datacube-ows) version {__version__}"
+        )
         sys.exit(0)
     # Handle old-style calls
     if not layers:
@@ -101,16 +130,24 @@ def main(layers: list[str],
         click.echo("Sorry, cannot update the schema and ranges in the same invocation.")
         sys.exit(1)
     if schema and views:
-        click.echo("Sorry, No point in updating materialised views and updating the schema in the same invocation.")
+        click.echo(
+            "Sorry, No point in updating materialised views and updating the schema in the same invocation."
+        )
         sys.exit(1)
     elif cleanup and layers:
-        click.echo("Sorry, cannot cleanup 1.8.x database entities and update ranges in the same invocation.")
+        click.echo(
+            "Sorry, cannot cleanup 1.8.x database entities and update ranges in the same invocation."
+        )
         sys.exit(1)
     elif views and cleanup:
-        click.echo("Sorry, cannot update the materialised views and cleanup the database in the same invocation.")
+        click.echo(
+            "Sorry, cannot update the materialised views and cleanup the database in the same invocation."
+        )
         sys.exit(1)
     elif views and layers:
-        click.echo("Sorry, cannot update the materialised views and ranges in the same invocation.")
+        click.echo(
+            "Sorry, cannot update the materialised views and ranges in the same invocation."
+        )
         sys.exit(1)
     elif read_role and (views or layers):
         click.echo("Sorry, read-role can't be granted with view or range updates")
@@ -134,7 +171,9 @@ def main(layers: list[str],
             click.echo(f"Unable to connect to the {env or cfg.default_env} database.")
             sys.exit(1)
 
-        click.echo(f"Applying database schema updates to the {dc.index.environment.db_database} database:...")
+        click.echo(
+            f"Applying database schema updates to the {dc.index.environment.db_database} database:..."
+        )
         try:
             if schema:
                 click.echo("Creating or replacing OWS database schema:...")
@@ -165,13 +204,18 @@ def main(layers: list[str],
         click.echo("Done.")
     except sqlalchemy.exc.ProgrammingError as e:
         import psycopg2.errors
+
         if isinstance(e.orig, psycopg2.errors.UndefinedColumn):
-            click.echo("ERROR: OWS schema or extent materialised views appear to be missing")
+            click.echo(
+                "ERROR: OWS schema or extent materialised views appear to be missing"
+            )
             click.echo("")
             click.echo("       Try running with the --schema options first.")
             sys.exit(1)
         elif isinstance(e.orig, psycopg2.errors.NotNullViolation):
-            click.echo("ERROR: OWS materialised views are most likely missing a newly indexed product")
+            click.echo(
+                "ERROR: OWS materialised views are most likely missing a newly indexed product"
+            )
             click.echo("")
             click.echo("       Try running with the --views options first.")
             sys.exit(1)
@@ -190,7 +234,9 @@ def add_ranges(cfg: OWSConfig, layer_names: list[str]) -> bool:
     cache: dict[LayerSignature, list[str]] = {}
     for name in layer_names:
         if name not in cfg.layer_index:
-            click.echo(f"Layer '{name}' does not exist in the OWS configuration - skipping")
+            click.echo(
+                f"Layer '{name}' does not exist in the OWS configuration - skipping"
+            )
             errors = True
             continue
         layer = cfg.layer_index[name]

--- a/datacube_ows/utils.py
+++ b/datacube_ows/utils.py
@@ -18,7 +18,8 @@ from datacube.model import Dataset
 from numpy import datetime64 as npdt64
 from sqlalchemy.engine.base import Connection
 
-F = TypeVar('F', bound=Callable[..., Any])
+F = TypeVar("F", bound=Callable[..., Any])
+
 
 def log_call(func: F) -> F:
     """
@@ -27,11 +28,13 @@ def log_call(func: F) -> F:
     Placing @log_call at the top of a function or method, results in all calls to that function or method
     being logged at debug level.
     """
+
     @wraps(func)
     def log_wrapper(*args, **kwargs) -> F:
         _LOG = logging.getLogger()
         _LOG.debug("%s args: %s kwargs: %s", func.__name__, args, kwargs)
         return func(*args, **kwargs)
+
     return cast(F, log_wrapper)
 
 
@@ -44,6 +47,7 @@ def time_call(func: F) -> F:
 
     For debugging or optimisation research only.  Should not occur in mainline code.
     """
+
     @wraps(func)
     def timing_wrapper(*args, **kwargs) -> Any:
         start: float = monotonic()
@@ -52,78 +56,81 @@ def time_call(func: F) -> F:
         _LOG = logging.getLogger()
         _LOG.debug("%s took: %d ms", func.__name__, int((stop - start) * 1000))
         return result
+
     return cast(F, timing_wrapper)
 
 
-def group_by_begin_datetime(pnames: list[str] | None = None,
-                            truncate_dates: bool = True) -> GroupBy:
+def group_by_begin_datetime(
+    pnames: list[str] | None = None, truncate_dates: bool = True
+) -> GroupBy:
     """
     Returns an ODC GroupBy object, suitable for daily/monthly/yearly/etc statistical/summary data.
     (Or for sub-day time resolution data)
     """
     base_sort_key = lambda ds: ds.time.begin  # noqa: E731
     if pnames:
-        index = {
-            pn: i
-            for i, pn in enumerate(pnames)
-        }
+        index = {pn: i for i, pn in enumerate(pnames)}
         sort_key = lambda ds: (index.get(ds.product.name), base_sort_key(ds))  # noqa: E731
     else:
         sort_key = base_sort_key
     if truncate_dates:
-        grp_by = lambda ds: npdt64(datetime.datetime(  # noqa: E731
-            ds.time.begin.year,
-            ds.time.begin.month,
-            ds.time.begin.day), "ns")
+        grp_by = lambda ds: npdt64(  # noqa: E731
+            datetime.datetime(
+                ds.time.begin.year, ds.time.begin.month, ds.time.begin.day
+            ),
+            "ns",
+        )
     else:
-        grp_by = lambda ds: npdt64(datetime.datetime(  # noqa: E731
-            ds.time.begin.year,
-            ds.time.begin.month,
-            ds.time.begin.day,
-            ds.time.begin.hour,
-            ds.time.begin.minute,
-            ds.time.begin.second), "ns")
+        grp_by = lambda ds: npdt64(  # noqa: E731
+            datetime.datetime(
+                ds.time.begin.year,
+                ds.time.begin.month,
+                ds.time.begin.day,
+                ds.time.begin.hour,
+                ds.time.begin.minute,
+                ds.time.begin.second,
+            ),
+            "ns",
+        )
     return GroupBy(
-        dimension='time',
+        dimension="time",
         group_by_func=grp_by,
-        units='seconds since 1970-01-01 00:00:00',
-        sort_key=sort_key
+        units="seconds since 1970-01-01 00:00:00",
+        sort_key=sort_key,
     )
 
 
 def group_by_solar(pnames: list[str] | None = None) -> GroupBy:
     base_sort_key = lambda ds: ds.time.begin  # noqa: E731
     if pnames:
-        index = {
-            pn: i
-            for i, pn in enumerate(pnames)
-        }
+        index = {pn: i for i, pn in enumerate(pnames)}
         sort_key = lambda ds: (index.get(ds.product.name), base_sort_key(ds))  # noqa: E731
     else:
         sort_key = base_sort_key
     return GroupBy(
-        dimension='time',
+        dimension="time",
         group_by_func=lambda x: npdt64(solar_day(x), "ns"),  # type: ignore[call-overload]
-        units='seconds since 1970-01-01 00:00:00',
-        sort_key=sort_key
+        units="seconds since 1970-01-01 00:00:00",
+        sort_key=sort_key,
     )
 
 
 def group_by_mosaic(pnames: list[str] | None = None) -> GroupBy:
     base_sort_key = lambda ds: ds.time.begin  # noqa: E731
     if pnames:
-        index = {
-            pn: i
-            for i, pn in enumerate(pnames)
-        }
-        sort_key: Callable[[Dataset], tuple] = lambda ds: (solar_day(ds), index.get(ds.product.name), base_sort_key(ds))  # noqa: E731
+        index = {pn: i for i, pn in enumerate(pnames)}
+        sort_key: Callable[[Dataset], tuple] = lambda ds: (  # noqa: E731
+            solar_day(ds),
+            index.get(ds.product.name),
+            base_sort_key(ds),
+        )
     else:
         sort_key = lambda ds: (solar_day(ds), base_sort_key(ds))  # noqa: E731
     return GroupBy(
-        dimension='time',
+        dimension="time",
         group_by_func=lambda n: npdt64(datetime.datetime(1970, 1, 1), "ns"),
-        units='seconds since 1970-01-01 00:00:00',
-        sort_key=sort_key
+        units="seconds since 1970-01-01 00:00:00",
+        sort_key=sort_key,
     )
 
 
@@ -146,8 +153,11 @@ def find_matching_date(dt, dates) -> bool:
     :param dates: List of sorted date-times
     :return: True if match found
     """
+
     def range_of(dt: datetime.datetime) -> tuple[datetime.datetime, datetime.datetime]:
-        start = datetime.datetime(dt.year, dt.month, dt.day, dt.hour, dt.minute, dt.second, tzinfo=dt.tzinfo)
+        start = datetime.datetime(
+            dt.year, dt.month, dt.day, dt.hour, dt.minute, dt.second, tzinfo=dt.tzinfo
+        )
         end = start + datetime.timedelta(seconds=1)
         return start, end
 
@@ -159,7 +169,7 @@ def find_matching_date(dt, dates) -> bool:
         start, end = range_of(region[splitter])
         if dt >= start and dt < end:
             return True
-        region = region[0:splitter] if dt < start else region[splitter + 1:]
+        region = region[0:splitter] if dt < start else region[splitter + 1 :]
 
     return False
 

--- a/datacube_ows/wcs1.py
+++ b/datacube_ows/wcs1.py
@@ -32,7 +32,9 @@ def handle_wcs1(nocase_args) -> tuple:
         return desc_coverages(nocase_args)
     if operation == "GETCOVERAGE":
         return get_coverage(nocase_args)
-    raise WCS1Exception(f"Unrecognised operation: {operation}", locator="Request parameter")
+    raise WCS1Exception(
+        f"Unrecognised operation: {operation}", locator="Request parameter"
+    )
 
 
 @log_call
@@ -55,25 +57,29 @@ def get_capabilities(args) -> tuple:
     elif section == "/wcs_capabilities/contentmetadata":
         show_content_metadata = True
     else:
-        raise WCS1Exception(f"Invalid section: {section}",
-                            WCS1Exception.INVALID_PARAMETER_VALUE,
-                            locator="Section parameter")
+        raise WCS1Exception(
+            f"Invalid section: {section}",
+            WCS1Exception.INVALID_PARAMETER_VALUE,
+            locator="Section parameter",
+        )
 
     # Extract layer metadata from Datacube.
     cfg = get_config()
-    url = args.get('Host', args['url_root'])
+    url = args.get("Host", args["url_root"])
     base_url = get_service_base_url(cfg.allowed_urls, url)
     headers = cache_control_headers(cfg.wms_cap_cache_age)
     headers["Content-Type"] = "application/xml"
     return (
-        render_template("wcs_capabilities.xml",
-                        show_service=show_service,
-                        show_capability=show_capability,
-                        show_content_metadata=show_content_metadata,
-                        cfg=cfg,
-                        base_url=base_url),
+        render_template(
+            "wcs_capabilities.xml",
+            show_service=show_service,
+            show_capability=show_capability,
+            show_content_metadata=show_content_metadata,
+            cfg=cfg,
+            base_url=base_url,
+        ),
         200,
-        cfg.response_headers(headers)
+        cfg.response_headers(headers),
     )
 
 
@@ -91,9 +97,11 @@ def desc_coverages(args) -> tuple:
             if p and p.wcs:
                 products.append(p)
             else:
-                raise WCS1Exception(f"Invalid coverage: {c}",
-                                    WCS1Exception.COVERAGE_NOT_DEFINED,
-                                    locator="Coverage parameter")
+                raise WCS1Exception(
+                    f"Invalid coverage: {c}",
+                    WCS1Exception.COVERAGE_NOT_DEFINED,
+                    locator="Coverage parameter",
+                )
     else:
         for p in cfg.layer_index.values():
             if p.ready and p.wcs:
@@ -102,11 +110,9 @@ def desc_coverages(args) -> tuple:
     headers = cache_control_headers(min_cache_age)
     headers["Content-Type"] = "application/xml"
     return (
-        render_template("wcs_desc_coverage.xml",
-                        cfg=cfg,
-                        products=products),
+        render_template("wcs_desc_coverage.xml", cfg=cfg, products=products),
         200,
-        cfg.response_headers(headers)
+        cfg.response_headers(headers),
     )
 
 
@@ -120,14 +126,16 @@ def get_coverage(args: dict) -> tuple[Any, int, dict]:
         return json_response(qprof.profile())
     headers = {
         "Content-Type": req.format.mime,
-        'content-disposition': f'attachment; filename={req.layer_name}.{req.format.extension}'
+        "content-disposition": f"attachment; filename={req.layer_name}.{req.format.extension}",
     }
     headers.update(req.layer.resource_limits.wcs_cache_rules.cache_headers(n_datasets))  # type: ignore[union-attr]
     return (
         req.format.renderer(req.version)(req, data),
         200,
-        cfg.response_headers({
-            "Content-Type": req.format.mime,
-            'content-disposition': f'attachment; filename={req.layer_name}.{req.format.extension}'
-        })
+        cfg.response_headers(
+            {
+                "Content-Type": req.format.mime,
+                "content-disposition": f"attachment; filename={req.layer_name}.{req.format.extension}",
+            }
+        ),
     )

--- a/datacube_ows/wcs1_utils.py
+++ b/datacube_ows/wcs1_utils.py
@@ -27,6 +27,7 @@ from datacube_ows.wcs_utils import get_bands_from_styles
 
 class WCS1GetCoverageRequest:
     version = Version(1, 0, 0)
+
     # pylint: disable=too-many-instance-attributes, too-many-branches, too-many-statements, too-many-locals
     def __init__(self, args) -> None:
         self.args = args
@@ -34,53 +35,67 @@ class WCS1GetCoverageRequest:
 
         # Argument: Coverage (required)  -> product/layer
         if "coverage" not in args:
-            raise WCS1Exception("No coverage specified",
-                                WCS1Exception.MISSING_PARAMETER_VALUE,
-                                locator="COVERAGE parameter",
-                                valid_keys=list(cfg.layer_index))
+            raise WCS1Exception(
+                "No coverage specified",
+                WCS1Exception.MISSING_PARAMETER_VALUE,
+                locator="COVERAGE parameter",
+                valid_keys=list(cfg.layer_index),
+            )
         self.layer_name = args["coverage"]
         self.layer = cfg.layer_index.get(self.layer_name)
         if not self.layer or not self.layer.wcs:
-            raise WCS1Exception(f"Invalid coverage: {self.layer_name}",
-                                WCS1Exception.COVERAGE_NOT_DEFINED,
-                                locator="COVERAGE parameter",
-                                valid_keys=list(cfg.layer_index))
+            raise WCS1Exception(
+                f"Invalid coverage: {self.layer_name}",
+                WCS1Exception.COVERAGE_NOT_DEFINED,
+                locator="COVERAGE parameter",
+                valid_keys=list(cfg.layer_index),
+            )
 
         # Argument: FORMAT (required) -> a supported format
         if "format" not in args:
-            raise WCS1Exception("No FORMAT parameter supplied",
-                                WCS1Exception.MISSING_PARAMETER_VALUE,
-                                locator="FORMAT parameter",
-                                valid_keys=cfg.wcs_formats_by_name)
+            raise WCS1Exception(
+                "No FORMAT parameter supplied",
+                WCS1Exception.MISSING_PARAMETER_VALUE,
+                locator="FORMAT parameter",
+                valid_keys=cfg.wcs_formats_by_name,
+            )
         if args["format"] not in cfg.wcs_formats_by_name:
-            raise WCS1Exception(f"Unsupported format: {args['format']}",
-                                WCS1Exception.INVALID_PARAMETER_VALUE,
-                                locator="FORMAT parameter",
-                                valid_keys=cfg.wcs_formats_by_name)
+            raise WCS1Exception(
+                f"Unsupported format: {args['format']}",
+                WCS1Exception.INVALID_PARAMETER_VALUE,
+                locator="FORMAT parameter",
+                valid_keys=cfg.wcs_formats_by_name,
+            )
         self.format = cfg.wcs_formats_by_name[args["format"]]
 
         # Argument: (request) CRS (required)
         if "crs" not in args:
-            raise WCS1Exception("No request CRS specified",
-                                WCS1Exception.MISSING_PARAMETER_VALUE,
-                                locator="CRS parameter",
-                                valid_keys=list(cfg.published_CRSs))
+            raise WCS1Exception(
+                "No request CRS specified",
+                WCS1Exception.MISSING_PARAMETER_VALUE,
+                locator="CRS parameter",
+                valid_keys=list(cfg.published_CRSs),
+            )
         self.request_crsid = args["crs"]
         if self.request_crsid not in cfg.published_CRSs:
-            raise WCS1Exception(f"{self.request_crsid} is not a supported CRS",
-                                WCS1Exception.INVALID_PARAMETER_VALUE,
-                                locator="CRS parameter",
-                                valid_keys=list(cfg.published_CRSs))
+            raise WCS1Exception(
+                f"{self.request_crsid} is not a supported CRS",
+                WCS1Exception.INVALID_PARAMETER_VALUE,
+                locator="CRS parameter",
+                valid_keys=list(cfg.published_CRSs),
+            )
         self.request_crs = cfg.crs(self.request_crsid)
 
         # Argument: response_crs (optional)
         if "response_crs" in args:
             self.response_crsid = args["response_crs"]
             if self.response_crsid not in cfg.published_CRSs:
-                raise WCS1Exception(f"{self.response_crsid} is not a supported CRS",
-                                    WCS1Exception.INVALID_PARAMETER_VALUE,
-                                    locator="RESPONSE_CRS parameter",
-                                    valid_keys=list(cfg.published_CRSs))
+                raise WCS1Exception(
+                    f"{self.response_crsid} is not a supported CRS",
+                    WCS1Exception.INVALID_PARAMETER_VALUE,
+                    locator="RESPONSE_CRS parameter",
+                    valid_keys=list(cfg.published_CRSs),
+                )
             self.response_crs = cfg.crs(self.response_crsid)
         else:
             self.response_crsid = self.request_crsid
@@ -97,24 +112,32 @@ class WCS1GetCoverageRequest:
         #       it's not clear to me what that would mean.)
         # For WCS 1.0.0 all bboxes will be specified as minx, miny, maxx, maxy
         if "bbox" not in args:
-            raise WCS1Exception("No BBOX parameter supplied",
-                                WCS1Exception.MISSING_PARAMETER_VALUE,
-                                locator="BBOX or TIME parameter")
+            raise WCS1Exception(
+                "No BBOX parameter supplied",
+                WCS1Exception.MISSING_PARAMETER_VALUE,
+                locator="BBOX or TIME parameter",
+            )
         try:
-            self.minx, self.miny, self.maxx, self.maxy = map(float, args['bbox'].split(','))
+            self.minx, self.miny, self.maxx, self.maxy = map(
+                float, args["bbox"].split(",")
+            )
         except Exception:
-            raise WCS1Exception("Invalid BBOX parameter",
-                                WCS1Exception.INVALID_PARAMETER_VALUE,
-                                locator="BBOX parameter") from None
+            raise WCS1Exception(
+                "Invalid BBOX parameter",
+                WCS1Exception.INVALID_PARAMETER_VALUE,
+                locator="BBOX parameter",
+            ) from None
 
-        self.specified_search_extent = geom.polygon([(self.minx, self.miny),
-                                        (self.minx, self.maxy),
-                                        (self.maxx, self.maxy),
-                                        (self.maxx, self.miny),
-                                        (self.minx, self.miny)
-                                       ],
-                                       crs=self.request_crs
-                                      )
+        self.specified_search_extent = geom.polygon(
+            [
+                (self.minx, self.miny),
+                (self.minx, self.maxy),
+                (self.maxx, self.maxy),
+                (self.maxx, self.miny),
+                (self.minx, self.miny),
+            ],
+            crs=self.request_crs,
+        )
         if self.request_crs == self.response_crs:
             self.extent = self.specified_search_extent
         else:
@@ -126,11 +149,13 @@ class WCS1GetCoverageRequest:
             self.maxy = bbox.top
             self.extent = geom.polygon(
                 [
-                    (self.minx, self.miny), (self.minx, self.maxy),
-                    (self.maxx, self.maxy), (self.maxx, self.miny),
-                    (self.minx, self.miny)
-               ],
-               crs=self.response_crs
+                    (self.minx, self.miny),
+                    (self.minx, self.maxy),
+                    (self.maxx, self.maxy),
+                    (self.maxx, self.miny),
+                    (self.minx, self.miny),
+                ],
+                crs=self.response_crs,
             )
 
         # Argument: TIME
@@ -156,7 +181,10 @@ class WCS1GetCoverageRequest:
                             f"Time value '{t}' not a valid date for coverage {self.layer_name}",
                             WCS1Exception.INVALID_PARAMETER_VALUE,
                             locator="TIME parameter",
-                            valid_keys=[d.strftime('%Y-%m-%d') for d in self.layer.ranges.time_set]
+                            valid_keys=[
+                                d.strftime("%Y-%m-%d")
+                                for d in self.layer.ranges.time_set
+                            ],
                         )
                     self.times.append(time)
                 except ValueError:
@@ -164,7 +192,9 @@ class WCS1GetCoverageRequest:
                         f"Time value '{t}' not a valid ISO-8601 date",
                         WCS1Exception.INVALID_PARAMETER_VALUE,
                         locator="TIME parameter",
-                        valid_keys=[d.strftime('%Y-%m-%d') for d in self.layer.ranges.time_set]
+                        valid_keys=[
+                            d.strftime("%Y-%m-%d") for d in self.layer.ranges.time_set
+                        ],
                     ) from None
             self.times.sort()
 
@@ -173,13 +203,15 @@ class WCS1GetCoverageRequest:
                     "No valid ISO-8601 dates",
                     WCS1Exception.INVALID_PARAMETER_VALUE,
                     locator="TIME parameter",
-                    valid_keys=[d.strftime('%Y-%m-%d') for d in self.layer.ranges.time_set]
+                    valid_keys=[
+                        d.strftime("%Y-%m-%d") for d in self.layer.ranges.time_set
+                    ],
                 )
             if len(self.times) > 1 and not self.format.multi_time:
                 raise WCS1Exception(
                     f"Cannot select more than one time slice with the {self.format.name} format",
                     WCS1Exception.INVALID_PARAMETER_VALUE,
-                    locator="TIME and FORMAT parameters"
+                    locator="TIME and FORMAT parameters",
                 )
 
         # Range constraint parameter: MEASUREMENTS
@@ -194,15 +226,19 @@ class WCS1GetCoverageRequest:
                 try:
                     self.bands.append(self.layer.band_idx.locale_band(b))
                 except ConfigException:
-                    raise WCS1Exception(f"Invalid measurement: {b}",
-                                        WCS1Exception.INVALID_PARAMETER_VALUE,
-                                        locator="MEASUREMENTS parameter",
-                                        valid_keys=self.layer.band_idx.band_labels()) from None
+                    raise WCS1Exception(
+                        f"Invalid measurement: {b}",
+                        WCS1Exception.INVALID_PARAMETER_VALUE,
+                        locator="MEASUREMENTS parameter",
+                        valid_keys=self.layer.band_idx.band_labels(),
+                    ) from None
             if not bands:
-                raise WCS1Exception("No measurements supplied",
-                                    WCS1Exception.INVALID_PARAMETER_VALUE,
-                                    locator="MEASUREMENTS parameter",
-                                    valid_keys = self.layer.band_idx.band_labels())
+                raise WCS1Exception(
+                    "No measurements supplied",
+                    WCS1Exception.INVALID_PARAMETER_VALUE,
+                    locator="MEASUREMENTS parameter",
+                    valid_keys=self.layer.band_idx.band_labels(),
+                )
         elif args.get("styles"):
             # Use style bands.
             # Non-standard protocol extension.
@@ -217,84 +253,110 @@ class WCS1GetCoverageRequest:
 
         # Argument: EXCEPTIONS (optional - defaults to XML)
         if "exceptions" in args and args["exceptions"] != "application/vnd.ogc.se_xml":
-            raise WCS1Exception(f"Unsupported exception format: {args['exceptions']}",
-                                WCS1Exception.INVALID_PARAMETER_VALUE,
-                                locator="EXCEPTIONS parameter")
+            raise WCS1Exception(
+                f"Unsupported exception format: {args['exceptions']}",
+                WCS1Exception.INVALID_PARAMETER_VALUE,
+                locator="EXCEPTIONS parameter",
+            )
 
         # Argument: INTERPOLATION (optional only nearest-neighbour currently supported.)
         #      If 'none' is supported in future, validation of width/height/res will need to change.
         if "interpolation" in args and args["interpolation"] != "nearest neighbor":
-            raise WCS1Exception(f'Unsupported interpolation method: {args["interpolation"]}',
-                                WCS1Exception.INVALID_PARAMETER_VALUE,
-                                locator="INTERPOLATION parameter")
+            raise WCS1Exception(
+                f"Unsupported interpolation method: {args['interpolation']}",
+                WCS1Exception.INVALID_PARAMETER_VALUE,
+                locator="INTERPOLATION parameter",
+            )
 
         if "width" in args:
             if "resx" in args or "resy" in args:
-                raise WCS1Exception("Specify WIDTH/HEIGHT parameters OR RESX/RESY parameters - not both",
-                                    WCS1Exception.MISSING_PARAMETER_VALUE,
-                                    locator="RESX/RESY/WIDTH/HEIGHT parameters")
+                raise WCS1Exception(
+                    "Specify WIDTH/HEIGHT parameters OR RESX/RESY parameters - not both",
+                    WCS1Exception.MISSING_PARAMETER_VALUE,
+                    locator="RESX/RESY/WIDTH/HEIGHT parameters",
+                )
             if "height" not in args:
-                raise WCS1Exception("WIDTH parameter supplied without HEIGHT parameter",
-                                    WCS1Exception.MISSING_PARAMETER_VALUE,
-                                    locator="WIDTH/HEIGHT parameters")
+                raise WCS1Exception(
+                    "WIDTH parameter supplied without HEIGHT parameter",
+                    WCS1Exception.MISSING_PARAMETER_VALUE,
+                    locator="WIDTH/HEIGHT parameters",
+                )
             try:
                 self.height = int(args["height"])
                 if self.height < 1:
                     raise ValueError()
             except ValueError:
-                raise WCS1Exception("HEIGHT parameter must be a positive integer",
-                                    WCS1Exception.INVALID_PARAMETER_VALUE,
-                                    locator="HEIGHT parameter") from None
+                raise WCS1Exception(
+                    "HEIGHT parameter must be a positive integer",
+                    WCS1Exception.INVALID_PARAMETER_VALUE,
+                    locator="HEIGHT parameter",
+                ) from None
             try:
                 self.width = int(args["width"])
                 if self.width < 1:
                     raise ValueError()
             except ValueError:
-                raise WCS1Exception("WIDTH parameter must be a positive integer",
-                                    WCS1Exception.INVALID_PARAMETER_VALUE,
-                                    locator="WIDTH parameter") from None
+                raise WCS1Exception(
+                    "WIDTH parameter must be a positive integer",
+                    WCS1Exception.INVALID_PARAMETER_VALUE,
+                    locator="WIDTH parameter",
+                ) from None
 
             self.resx = (self.maxx - self.minx) / self.width
             self.resy = (self.maxy - self.miny) / self.height
         elif "resx" in args:
             if "height" in args:
-                raise WCS1Exception("Specify WIDTH/HEIGHT parameters OR RESX/RESY parameters - not both",
-                                    WCS1Exception.MISSING_PARAMETER_VALUE,
-                                    locator="RESX/RESY/WIDTH/HEIGHT parameters")
+                raise WCS1Exception(
+                    "Specify WIDTH/HEIGHT parameters OR RESX/RESY parameters - not both",
+                    WCS1Exception.MISSING_PARAMETER_VALUE,
+                    locator="RESX/RESY/WIDTH/HEIGHT parameters",
+                )
             if "resy" not in args:
-                raise WCS1Exception("RESX parameter supplied without RESY parameter",
-                                    WCS1Exception.MISSING_PARAMETER_VALUE,
-                                    locator="RESX/RESY parameters")
+                raise WCS1Exception(
+                    "RESX parameter supplied without RESY parameter",
+                    WCS1Exception.MISSING_PARAMETER_VALUE,
+                    locator="RESX/RESY parameters",
+                )
             try:
                 self.resx = float(args["resx"])
                 if self.resx <= 0.0:
                     raise ValueError(0)
             except ValueError:
-                raise WCS1Exception("RESX parameter must be a positive number",
-                                    WCS1Exception.INVALID_PARAMETER_VALUE,
-                                    locator="RESX parameter") from None
+                raise WCS1Exception(
+                    "RESX parameter must be a positive number",
+                    WCS1Exception.INVALID_PARAMETER_VALUE,
+                    locator="RESX parameter",
+                ) from None
             try:
                 self.resy = float(args["resy"])
                 if self.resy <= 0.0:
                     raise ValueError(0)
             except ValueError:
-                raise WCS1Exception("RESY parameter must be a positive number",
-                                    WCS1Exception.INVALID_PARAMETER_VALUE,
-                                    locator="RESY parameter") from None
+                raise WCS1Exception(
+                    "RESY parameter must be a positive number",
+                    WCS1Exception.INVALID_PARAMETER_VALUE,
+                    locator="RESY parameter",
+                ) from None
             self.width = int(((self.maxx - self.minx) / self.resx) + 0.5)
             self.height = int(((self.maxy - self.miny) / self.resy) + 0.5)
         elif "height" in args:
-            raise WCS1Exception("HEIGHT parameter supplied without WIDTH parameter",
-                                WCS1Exception.MISSING_PARAMETER_VALUE,
-                                locator="WIDTH/HEIGHT parameters")
+            raise WCS1Exception(
+                "HEIGHT parameter supplied without WIDTH parameter",
+                WCS1Exception.MISSING_PARAMETER_VALUE,
+                locator="WIDTH/HEIGHT parameters",
+            )
         elif "resy" in args:
-            raise WCS1Exception("RESY parameter supplied without RESX parameter",
-                                WCS1Exception.MISSING_PARAMETER_VALUE,
-                                locator="RESX/RESY parameters")
+            raise WCS1Exception(
+                "RESY parameter supplied without RESX parameter",
+                WCS1Exception.MISSING_PARAMETER_VALUE,
+                locator="RESX/RESY parameters",
+            )
         else:
-            raise WCS1Exception("You must specify either the WIDTH/HEIGHT parameters or RESX/RESY",
-                                WCS1Exception.MISSING_PARAMETER_VALUE,
-                                locator="RESX/RESY/WIDTH/HEIGHT parameters")
+            raise WCS1Exception(
+                "You must specify either the WIDTH/HEIGHT parameters or RESX/RESY",
+                WCS1Exception.MISSING_PARAMETER_VALUE,
+                locator="RESX/RESY/WIDTH/HEIGHT parameters",
+            )
 
         xscale = (self.maxx - self.minx) / self.width
         yscale = (self.miny - self.maxy) / self.height
@@ -307,25 +369,26 @@ class WCS1GetCoverageRequest:
 
 def get_coverage_data(req, qprof) -> tuple | tuple[int, tuple]:
     # pylint: disable=too-many-locals, protected-access
-    stacker = DataStacker(req.layer,
-                          req.geobox,
-                          req.times,
-                          bands=req.bands)
+    stacker = DataStacker(req.layer, req.geobox, req.times, bands=req.bands)
     qprof.start_event("count-datasets")
     n_datasets = stacker.n_datasets()
     qprof.end_event("count-datasets")
     qprof["n_datasets"] = n_datasets
 
     try:
-        req.layer.resource_limits.check_wcs(n_datasets,
-                                            req.geobox.height, req.geobox.width,
-                                            sum(req.layer.band_idx.dtype_size(b) for b in req.bands),
-                                            len(req.times))
+        req.layer.resource_limits.check_wcs(
+            n_datasets,
+            req.geobox.height,
+            req.geobox.width,
+            sum(req.layer.band_idx.dtype_size(b) for b in req.bands),
+            len(req.times),
+        )
     except ResourceLimited as e:
         if e.wcs_hard or not req.layer.low_res_product_names:
             raise WCS1Exception(
                 f"This request processes too much data to be served in a reasonable amount of time. ({e}) "
-                + "Please reduce the bounds of your request and try again.") from None
+                + "Please reduce the bounds of your request and try again."
+            ) from None
         stacker.resource_limited = True
         qprof["resource_limited"] = str(e)
     if n_datasets == 0:
@@ -336,16 +399,8 @@ def get_coverage_data(req, qprof) -> tuple | tuple[int, tuple]:
         y_range = (req.miny, req.maxy)
         xname = cfg.published_CRSs[req.response_crsid]["horizontal_coord"]
         yname = cfg.published_CRSs[req.response_crsid]["vertical_coord"]
-        xvals = numpy.linspace(
-            x_range[0],
-            x_range[1],
-            num=req.width
-        )
-        yvals = numpy.linspace(
-            y_range[0],
-            y_range[1],
-            num=req.height
-        )
+        xvals = numpy.linspace(x_range[0], x_range[1], num=req.width)
+        yvals = numpy.linspace(y_range[0], y_range[1], num=req.height)
         if req.layer.time_resolution.is_subday():
             timevals = [
                 numpy.datetime64(dt.astimezone(timezone.utc).isoformat(), "ns")
@@ -355,29 +410,30 @@ def get_coverage_data(req, qprof) -> tuple | tuple[int, tuple]:
             timevals = req.times
         if cfg.published_CRSs[req.request_crsid]["vertical_coord_first"]:
             nparrays = {
-                band: (("time", yname, xname),
-                       numpy.full((len(req.times), len(yvals), len(xvals)),
-                                  req.layer.band_idx.nodata_val(band),
-                                  dtype=req.layer.band_idx.dtype_val(band))
-                      )
+                band: (
+                    ("time", yname, xname),
+                    numpy.full(
+                        (len(req.times), len(yvals), len(xvals)),
+                        req.layer.band_idx.nodata_val(band),
+                        dtype=req.layer.band_idx.dtype_val(band),
+                    ),
+                )
                 for band in req.bands
             }
         else:
             nparrays = {
-                band: (("time", xname, yname),
-                       numpy.full((len(req.times), len(xvals), len(yvals)),
-                                  req.layer.band_idx.nodata_val(band),
-                                  dtype=req.layer.band_idx.dtype_val(band))
-                      )
+                band: (
+                    ("time", xname, yname),
+                    numpy.full(
+                        (len(req.times), len(xvals), len(yvals)),
+                        req.layer.band_idx.nodata_val(band),
+                        dtype=req.layer.band_idx.dtype_val(band),
+                    ),
+                )
                 for band in req.bands
             }
         data = xarray.Dataset(
-            nparrays,
-            coords={
-                "time": timevals,
-                xname: xvals,
-                yname: yvals,
-            }
+            nparrays, coords={"time": timevals, xname: xvals, yname: yvals}
         ).astype("int16")
         qprof.start_event("end_empty_dataset")
         qprof["write_action"] = "Write Empty"
@@ -389,8 +445,7 @@ def get_coverage_data(req, qprof) -> tuple | tuple[int, tuple]:
     qprof.end_event("fetch-datasets")
     if qprof.active:
         qprof["datasets"] = {
-            str(q): [str(i) for i in ids]
-            for q, ids in stacker.dsids().items()
+            str(q): [str(i) for i in ids] for q, ids in stacker.dsids().items()
         }
     qprof.start_event("load-data")
     # FIXME: output can be None.
@@ -410,17 +465,17 @@ def get_tiff(req, data: xr.Dataset) -> bytes:
     """Uses rasterio MemoryFiles in order to return a streamable GeoTiff response"""
     # Does not support multi-time dimension data - is this even possible in GeoTiff?
     supported_dtype_map = {
-        'uint8': 1,
-        'int8': 2,
-        'uint16': 3,
-        'int16': 4,
-        'uint32': 5,
-        'int32': 6,
-        'float32': 7,
-        'float64': 8,
-        'complex': 10,
-        'complex64': 11,
-        'complex128': 12,
+        "uint8": 1,
+        "int8": 2,
+        "uint16": 3,
+        "int16": 4,
+        "uint32": 5,
+        "int32": 6,
+        "float32": 7,
+        "float64": 8,
+        "complex": 10,
+        "complex64": 11,
+        "complex128": 12,
     }
 
     dtype_list = [data[array].dtype for array in data.data_vars]
@@ -447,15 +502,24 @@ def get_tiff(req, data: xr.Dataset) -> bytes:
             tiled=True,
             compress="lzw",
             interleave="band",
-            dtype=dtype) as dst:
+            dtype=dtype,
+        ) as dst:
             for idx, band in enumerate(data.data_vars, start=1):
                 dst.write(data[band].values, idx)
                 dst.set_band_description(idx, req.layer.band_idx.band_label(band))
                 if cfg.wcs_tiff_statistics:
-                    dst.update_tags(idx, STATISTICS_MINIMUM=numpy.nanmin(data[band].values))
-                    dst.update_tags(idx, STATISTICS_MAXIMUM=numpy.nanmax(data[band].values))
-                    dst.update_tags(idx, STATISTICS_MEAN=numpy.nanmean(data[band].values))
-                    dst.update_tags(idx, STATISTICS_STDDEV=numpy.nanstd(data[band].values))
+                    dst.update_tags(
+                        idx, STATISTICS_MINIMUM=numpy.nanmin(data[band].values)
+                    )
+                    dst.update_tags(
+                        idx, STATISTICS_MAXIMUM=numpy.nanmax(data[band].values)
+                    )
+                    dst.update_tags(
+                        idx, STATISTICS_MEAN=numpy.nanmean(data[band].values)
+                    )
+                    dst.update_tags(
+                        idx, STATISTICS_STDDEV=numpy.nanstd(data[band].values)
+                    )
         return memfile.read()
 
 

--- a/datacube_ows/wcs2.py
+++ b/datacube_ows/wcs2.py
@@ -44,19 +44,25 @@ def handle_wcs2(nocase_args) -> tuple:
     if operation == "DESCRIBECOVERAGE":
         return desc_coverages(nocase_args)
     if operation == "GETCOVERAGE":
-        return get_coverage(request.args.lists(), bool(nocase_args.get("ows_stats")), nocase_args.get("styles"))
-    raise WCS2Exception(f"Unrecognised operation: {operation}", locator="Request parameter")
+        return get_coverage(
+            request.args.lists(),
+            bool(nocase_args.get("ows_stats")),
+            nocase_args.get("styles"),
+        )
+    raise WCS2Exception(
+        f"Unrecognised operation: {operation}", locator="Request parameter"
+    )
 
 
 @log_call
 def get_capabilities(args: dict) -> tuple[Any, int, dict]:
     # Extract layer metadata from Datacube.
     cfg = get_config()
-    url = args.get('Host', args['url_root'])
+    url = args.get("Host", args["url_root"])
     base_url = get_service_base_url(cfg.allowed_urls, url)
 
     request_obj = kvp_decode_get_capabilities(args)
-    sections = request_obj.sections or ['all']
+    sections = request_obj.sections or ["all"]
 
     # TODO: check for invalid sections
     include_service_identification = False
@@ -65,38 +71,36 @@ def get_capabilities(args: dict) -> tuple[Any, int, dict]:
     include_service_metadata = False
     include_coverage_summary = False
 
-    if 'all' in sections:
+    if "all" in sections:
         include_service_identification = True
         include_service_provider = True
         include_operations_metadata = True
         include_service_metadata = True
         include_coverage_summary = True
-    if 'serviceidentification' in sections:
+    if "serviceidentification" in sections:
         include_service_identification = True
-    if 'serviceprovider' in sections:
+    if "serviceprovider" in sections:
         include_service_provider = True
-    if 'operationsmetadata' in sections:
+    if "operationsmetadata" in sections:
         include_operations_metadata = True
-    if 'servicemetadata' in sections:
+    if "servicemetadata" in sections:
         include_service_metadata = True
-    if 'coveragesummary' in sections:
+    if "coveragesummary" in sections:
         include_coverage_summary = True
 
     assert cfg.contact_info is not None
     assert cfg.contact_info.address is not None
     capabilities = ServiceCapabilities.with_defaults_v20(
-        service_url =base_url + '/wcs',
-        allowed_operations=[
-            'GetCapabilities', 'DescribeCoverage', 'GetCoverage'
-        ],
+        service_url=base_url + "/wcs",
+        allowed_operations=["GetCapabilities", "DescribeCoverage", "GetCoverage"],
         allow_post=False,
         title=cfg.title,
         abstract=cfg.abstract,
         keywords=cfg.keywords,
         fees=cfg.fees,
         access_constraints=[cfg.access_constraints],
-        provider_name='',
-        provider_site='',
+        provider_name="",
+        provider_site="",
         individual_name=cfg.contact_info.person,
         organisation_name=cfg.contact_info.organisation,
         position_name=cfg.contact_info.position,
@@ -115,21 +119,21 @@ def get_capabilities(args: dict) -> tuple[Any, int, dict]:
         coverage_summaries=[
             CoverageSummary(
                 identifier=product.name,
-                coverage_subtype='RectifiedGridCoverage',
+                coverage_subtype="RectifiedGridCoverage",
                 title=product.title,
-                wgs84_bbox=WGS84BoundingBox([
-                    product.ranges.lon.min, product.ranges.lat.min,
-                    product.ranges.lon.max, product.ranges.lat.max,
-                ])
+                wgs84_bbox=WGS84BoundingBox(
+                    [
+                        product.ranges.lon.min,
+                        product.ranges.lat.min,
+                        product.ranges.lon.max,
+                        product.ranges.lat.max,
+                    ]
+                ),
             )
             for product in cfg.layer_index.values()
             if product.ready and not product.hide and product.wcs
         ],
-        formats_supported=[
-            fmt.mime
-            for fmt in cfg.wcs_formats
-            if 2 in fmt.renderers
-        ],
+        formats_supported=[fmt.mime for fmt in cfg.wcs_formats if 2 in fmt.renderers],
         crss_supported=list(cfg.published_CRSs),  # TODO: conversion to URL format
         interpolations_supported=None,  # TODO: find out interpolations
     )
@@ -139,23 +143,19 @@ def get_capabilities(args: dict) -> tuple[Any, int, dict]:
         include_service_provider=include_service_provider,
         include_operations_metadata=include_operations_metadata,
         include_service_metadata=include_service_metadata,
-        include_coverage_summary=include_coverage_summary
+        include_coverage_summary=include_coverage_summary,
     )
 
     headers = cache_control_headers(cfg.wms_cap_cache_age)
     headers["Content-Type"] = result.content_type
-    return (
-        result.value,
-        200,
-        cfg.response_headers(headers)
-    )
+    return (result.value, 200, cfg.response_headers(headers))
 
 
 def create_coverage_description(cfg: OWSConfig, product) -> CoverageDescription:
     axes = [
         RegularAxis(
             label=product.native_CRS_def["horizontal_coord"],
-            index_label='i',
+            index_label="i",
             lower_bound=min(
                 product.ranges.bboxes[product.native_CRS]["left"],
                 product.ranges.bboxes[product.native_CRS]["right"],
@@ -165,12 +165,12 @@ def create_coverage_description(cfg: OWSConfig, product) -> CoverageDescription:
                 product.ranges.bboxes[product.native_CRS]["right"],
             ),
             resolution=product.resolution_x,
-            uom='deg',
+            uom="deg",
             size=product.grid_high_x,
         ),
         RegularAxis(
             label=product.native_CRS_def["vertical_coord"],
-            index_label='j',
+            index_label="j",
             lower_bound=min(
                 product.ranges.bboxes[product.native_CRS]["top"],
                 product.ranges.bboxes[product.native_CRS]["bottom"],
@@ -180,7 +180,7 @@ def create_coverage_description(cfg: OWSConfig, product) -> CoverageDescription:
                 product.ranges.bboxes[product.native_CRS]["bottom"],
             ),
             resolution=product.resolution_y,
-            uom='deg',
+            uom="deg",
             size=product.grid_high_y,
         ),
     ]
@@ -194,11 +194,11 @@ def create_coverage_description(cfg: OWSConfig, product) -> CoverageDescription:
         size = (end - start).days // product.time_axis_interval
         axes.append(
             RegularAxis(
-                label='time',
-                index_label='k',
+                label="time",
+                index_label="k",
                 lower_bound=start.isoformat(),
                 upper_bound=end.isoformat(),
-                resolution=f'P{product.time_axis_interval}D',
+                resolution=f"P{product.time_axis_interval}D",
                 uom="ISO-8601",
                 type=SpatioTemporalType.TEMPORAL,
                 size=size,
@@ -207,26 +207,22 @@ def create_coverage_description(cfg: OWSConfig, product) -> CoverageDescription:
     elif product.time_resolution.is_subday():
         axes.append(
             IrregularAxis(
-                label='time',
-                index_label='k',
-                positions=[
-                    f'{t.isoformat()}'
-                    for t in product.ranges.times
-                ],
-                uom='ISO-8601',
+                label="time",
+                index_label="k",
+                positions=[f"{t.isoformat()}" for t in product.ranges.times],
+                uom="ISO-8601",
                 type=SpatioTemporalType.TEMPORAL,
             )
         )
     else:
         axes.append(
             IrregularAxis(
-                label='time',
-                index_label='k',
+                label="time",
+                index_label="k",
                 positions=[
-                    f'{t.isoformat()}T00:00:00.000Z'
-                    for t in product.ranges.times
+                    f"{t.isoformat()}T00:00:00.000Z" for t in product.ranges.times
                 ],
-                uom='ISO-8601',
+                uom="ISO-8601",
                 type=SpatioTemporalType.TEMPORAL,
             )
         )
@@ -234,22 +230,21 @@ def create_coverage_description(cfg: OWSConfig, product) -> CoverageDescription:
     return CoverageDescription(
         identifier=product.name,
         title=product.title,
-        abstract=product.definition.get('description'),
+        abstract=product.definition.get("description"),
         range_type=[
             Field(
                 name=band_label,
                 description=band_label,
                 uom=band_label,
-                nil_values=dict.fromkeys(product.band_idx.band_nodata_vals(), 'invalid')
+                nil_values=dict.fromkeys(
+                    product.band_idx.band_nodata_vals(), "invalid"
+                ),
             )
             for band_label in product.band_idx.band_labels()
         ],
-        grid=Grid(
-            axes=axes,
-            srs=product.native_CRS,
-        ),
+        grid=Grid(axes=axes, srs=product.native_CRS),
         native_format=cfg.wcs_formats_by_name[product.native_format].mime,
-        coverage_subtype='RectifiedGridCoverage',
+        coverage_subtype="RectifiedGridCoverage",
     )
 
 
@@ -266,13 +261,14 @@ def desc_coverages(args) -> tuple:
         if product and product.wcs:
             products.append(product)
         else:
-            raise WCS2Exception(f"Invalid coverage: {coverage_id}",
-                                WCS2Exception.NO_SUCH_COVERAGE,
-                                locator=coverage_id)
+            raise WCS2Exception(
+                f"Invalid coverage: {coverage_id}",
+                WCS2Exception.NO_SUCH_COVERAGE,
+                locator=coverage_id,
+            )
 
     coverage_descriptions = [
-        create_coverage_description(cfg, product)
-        for product in products
+        create_coverage_description(cfg, product) for product in products
     ]
 
     version = request_obj.version
@@ -282,28 +278,24 @@ def desc_coverages(args) -> tuple:
     elif version == (2, 1):
         result = encoders_v21.xml_encode_coverage_descriptions(coverage_descriptions)
     else:
-        raise WCS2Exception(f"Unsupported version: {version}",
-                            WCS2Exception.INVALID_PARAMETER_VALUE,
-                            locator="version")
+        raise WCS2Exception(
+            f"Unsupported version: {version}",
+            WCS2Exception.INVALID_PARAMETER_VALUE,
+            locator="version",
+        )
     min_cache_age = min(p.resource_limits.wcs_desc_cache_rule for p in products)
     headers = cache_control_headers(min_cache_age)
     headers["Content-Type"] = result.content_type
-    return (
-        result.value,
-        200,
-        resp_headers(headers)
-    )
+    return (result.value, 200, resp_headers(headers))
 
 
 @log_call
-def get_coverage(args, ows_stats: bool = False, styles=None) -> tuple[str | bytes, int, dict[str, str]]:
+def get_coverage(
+    args, ows_stats: bool = False, styles=None
+) -> tuple[str | bytes, int, dict[str, str]]:
     request_obj = kvp_decode_get_coverage(args)
     qprof = QueryProfiler(ows_stats)
     output, headers = get_coverage_data(request_obj, styles, qprof)
     if ows_stats:
         return json_response(qprof.profile())
-    return (
-        output,
-        200,
-        resp_headers(headers)
-    )
+    return (output, 200, resp_headers(headers))

--- a/datacube_ows/wcs2_utils.py
+++ b/datacube_ows/wcs2_utils.py
@@ -29,19 +29,21 @@ _LOG: logging.Logger = logging.getLogger(__name__)
 
 def uniform_crs(cfg: OWSConfig, crs: str) -> str:
     """Helper function to transform a URL style EPSG definition to an 'EPSG:nnn' one"""
-    if crs.startswith('http://www.opengis.net/def/crs/EPSG/'):
-        code = crs.rpartition('/')[-1]
-        crs = f'EPSG:{code}'
-    elif crs.startswith('urn:ogc:def:crs:EPSG:'):
-        code = crs.rpartition(':')[-1]
-        crs = f'EPSG:{code}'
-    elif crs.startswith('EPSG') or crs in cfg.published_CRSs:
+    if crs.startswith("http://www.opengis.net/def/crs/EPSG/"):
+        code = crs.rpartition("/")[-1]
+        crs = f"EPSG:{code}"
+    elif crs.startswith("urn:ogc:def:crs:EPSG:"):
+        code = crs.rpartition(":")[-1]
+        crs = f"EPSG:{code}"
+    elif crs.startswith("EPSG") or crs in cfg.published_CRSs:
         pass
     else:
-        raise WCS2Exception(f"Not a CRS: {crs}",
-                            WCS2Exception.NOT_A_CRS,
-                            locator=crs,
-                            valid_keys=list(cfg.published_CRSs))
+        raise WCS2Exception(
+            f"Not a CRS: {crs}",
+            WCS2Exception.NOT_A_CRS,
+            locator=crs,
+            valid_keys=list(cfg.published_CRSs),
+        )
     return crs
 
 
@@ -53,10 +55,12 @@ def get_coverage_data(request, styles, qprof) -> tuple:
     layer_name = request.coverage_id
     layer = cfg.layer_index.get(layer_name)
     if not layer or not layer.wcs:
-        raise WCS2Exception(f"Invalid coverage: {layer_name}",
-                            WCS2Exception.NO_SUCH_COVERAGE,
-                            locator="COVERAGE parameter",
-                            valid_keys=list(cfg.layer_index))
+        raise WCS2Exception(
+            f"Invalid coverage: {layer_name}",
+            WCS2Exception.NO_SUCH_COVERAGE,
+            locator="COVERAGE parameter",
+            valid_keys=list(cfg.layer_index),
+        )
 
     #
     # CRS handling
@@ -65,18 +69,22 @@ def get_coverage_data(request, styles, qprof) -> tuple:
     native_crs = layer.native_CRS
     subsetting_crs = uniform_crs(cfg, request.subsetting_crs or native_crs)
     if subsetting_crs not in cfg.published_CRSs:
-        raise WCS2Exception(f"Invalid subsettingCrs: {subsetting_crs}",
-                            WCS2Exception.SUBSETTING_CRS_NOT_SUPPORTED,
-                            locator=subsetting_crs,
-                            valid_keys=list(cfg.published_CRSs))
+        raise WCS2Exception(
+            f"Invalid subsettingCrs: {subsetting_crs}",
+            WCS2Exception.SUBSETTING_CRS_NOT_SUPPORTED,
+            locator=subsetting_crs,
+            valid_keys=list(cfg.published_CRSs),
+        )
 
     output_crs = uniform_crs(cfg, request.output_crs or subsetting_crs or native_crs)
 
     if output_crs not in cfg.published_CRSs:
-        raise WCS2Exception(f"Invalid outputCrs: {output_crs}",
-                            WCS2Exception.OUTPUT_CRS_NOT_SUPPORTED,
-                            locator=output_crs,
-                            valid_keys=list(cfg.published_CRSs))
+        raise WCS2Exception(
+            f"Invalid outputCrs: {output_crs}",
+            WCS2Exception.OUTPUT_CRS_NOT_SUPPORTED,
+            locator=output_crs,
+            valid_keys=list(cfg.published_CRSs),
+        )
 
     #
     # Subsetting/Scaling
@@ -90,42 +98,46 @@ def get_coverage_data(request, styles, qprof) -> tuple:
     if len(subsets) != len({subset.dimension.lower() for subset in subsets}):
         dimensions = [subset.dimension.lower() for subset in subsets]
         duplicate_dimensions = [
-            item
-            for item, count in collections.Counter(dimensions).items()
-            if count > 1
+            item for item, count in collections.Counter(dimensions).items() if count > 1
         ]
 
-        raise WCS2Exception(f"Duplicate dimension{'s' if len(duplicate_dimensions) > 1 else ''}: "
-                            f"{', '.join(duplicate_dimensions)}",
-                            WCS2Exception.INVALID_SUBSETTING,
-                            locator=','.join(duplicate_dimensions)
-                            )
+        raise WCS2Exception(
+            f"Duplicate dimension{'s' if len(duplicate_dimensions) > 1 else ''}: "
+            f"{', '.join(duplicate_dimensions)}",
+            WCS2Exception.INVALID_SUBSETTING,
+            locator=",".join(duplicate_dimensions),
+        )
 
     for subset in subsets:
         dimension = subset.dimension.lower()
-        if dimension == 'time':
+        if dimension == "time":
             if isinstance(subset, Trim):
                 if "," in subset.high:
                     raise WCS2Exception(
                         "Subsets can only contain 2 elements - the lower and upper bounds. For arbitrary date lists, use WCS1",
                         WCS2Exception.INVALID_SUBSETTING,
-                        locator="time")
+                        locator="time",
+                    )
                 if layer.time_resolution.is_subday():
-                    low: date | datetime | None = default_to_utc(parse(subset.low)) if subset.low is not None else None
-                    high: date | datetime | None = default_to_utc(parse(subset.high)) if subset.high is not None else None
+                    low: date | datetime | None = (
+                        default_to_utc(parse(subset.low))
+                        if subset.low is not None
+                        else None
+                    )
+                    high: date | datetime | None = (
+                        default_to_utc(parse(subset.high))
+                        if subset.high is not None
+                        else None
+                    )
                 else:
                     low = parse(subset.low).date() if subset.low is not None else None
-                    high = parse(subset.high).date() if subset.high is not None else None
+                    high = (
+                        parse(subset.high).date() if subset.high is not None else None
+                    )
                 if low is not None:
-                    times = [
-                        time for time in times
-                        if time >= low
-                    ]
+                    times = [time for time in times if time >= low]
                 if high is not None:
-                    times = [
-                        time for time in times
-                        if time <= high
-                    ]
+                    times = [time for time in times if time <= high]
             elif isinstance(subset, Slice):
                 point = parse(subset.point).date()
                 times = [point]
@@ -136,9 +148,11 @@ def get_coverage_data(request, styles, qprof) -> tuple:
                 elif isinstance(subset, Slice):
                     scaler.slice(dimension, subset.point)
             except WCSScalerUnknownDimension:
-                raise WCS2Exception(f'Invalid subsetting axis {subset.dimension}',
-                                WCS2Exception.INVALID_AXIS_LABEL,
-                                locator=subset.dimension) from None
+                raise WCS2Exception(
+                    f"Invalid subsetting axis {subset.dimension}",
+                    WCS2Exception.INVALID_AXIS_LABEL,
+                    locator=subset.dimension,
+                ) from None
 
     #
     # Transform spatial extent to native CRS.
@@ -153,24 +167,24 @@ def get_coverage_data(request, styles, qprof) -> tuple:
     if len(scales) != len({subset.axis.lower() for subset in scales}):
         axes = [subset.axis.lower() for subset in scales]
         duplicate_axes = [
-            item
-            for item, count in collections.Counter(axes).items()
-            if count > 1
+            item for item, count in collections.Counter(axes).items() if count > 1
         ]
-        raise WCS2Exception(f"Duplicate scales for ax{'i' if len(duplicate_axes) == 1 else 'e'}s: "
-                            f"{', '.join(duplicate_axes)}",
-                            WCS2Exception.INVALID_SCALE_FACTOR,
-                            locator=','.join(duplicate_axes)
-                            )
+        raise WCS2Exception(
+            f"Duplicate scales for ax{'i' if len(duplicate_axes) == 1 else 'e'}s: "
+            f"{', '.join(duplicate_axes)}",
+            WCS2Exception.INVALID_SCALE_FACTOR,
+            locator=",".join(duplicate_axes),
+        )
 
     for scale in scales:
         axis = scale.axis.lower()
 
-        if axis in ('time', 'k'):
-            raise WCS2Exception(f'Cannot scale axis {scale.axis}',
-                                WCS2Exception.INVALID_SCALE_FACTOR,
-                                locator=scale.axis
-                                )
+        if axis in ("time", "k"):
+            raise WCS2Exception(
+                f"Cannot scale axis {scale.axis}",
+                WCS2Exception.INVALID_SCALE_FACTOR,
+                locator=scale.axis,
+            )
         if isinstance(scale, ScaleAxis):
             scaler.scale_axis(axis, scale.factor)
         elif isinstance(scale, ScaleSize):
@@ -188,27 +202,34 @@ def get_coverage_data(request, styles, qprof) -> tuple:
         for range_subset in request.range_subset:
             if isinstance(range_subset, str):
                 if range_subset not in band_labels:
-                    raise WCS2Exception(f'No such field {range_subset}',
-                                WCS2Exception.NO_SUCH_FIELD,
-                                locator=range_subset,
-                                valid_keys=band_labels
-                                )
+                    raise WCS2Exception(
+                        f"No such field {range_subset}",
+                        WCS2Exception.NO_SUCH_FIELD,
+                        locator=range_subset,
+                        valid_keys=band_labels,
+                    )
                 bands.append(range_subset)
             else:
                 if range_subset.start not in band_labels:
-                    raise WCS2Exception(f'No such field {range_subset.start}',
-                                        WCS2Exception.ILLEGAL_FIELD_SEQUENCE,
-                                        locator=range_subset.start,
-                                        valid_keys = band_labels)
+                    raise WCS2Exception(
+                        f"No such field {range_subset.start}",
+                        WCS2Exception.ILLEGAL_FIELD_SEQUENCE,
+                        locator=range_subset.start,
+                        valid_keys=band_labels,
+                    )
                 if range_subset.end not in band_labels:
-                    raise WCS2Exception(f'No such field {range_subset.end}',
-                                        WCS2Exception.ILLEGAL_FIELD_SEQUENCE,
-                                        locator=range_subset.end,
-                                        valid_keys = band_labels)
+                    raise WCS2Exception(
+                        f"No such field {range_subset.end}",
+                        WCS2Exception.ILLEGAL_FIELD_SEQUENCE,
+                        locator=range_subset.end,
+                        valid_keys=band_labels,
+                    )
 
                 start = band_labels.index(range_subset.start)
                 end = band_labels.index(range_subset.end)
-                bands.extend(band_labels[start:(end + 1) if end > start else (end - 1)])
+                bands.extend(
+                    band_labels[start : (end + 1) if end > start else (end - 1)]
+                )
     # Uncomment to restore original styles parameter hack.
     #
     # elif styles:
@@ -228,26 +249,24 @@ def get_coverage_data(request, styles, qprof) -> tuple:
         try:
             fmt = cfg.wcs_formats_by_mime[request.format]
         except KeyError:
-            raise WCS2Exception(f"Unsupported format: {request.format}",
-                                WCS2Exception.INVALID_PARAMETER_VALUE,
-                                locator="FORMAT",
-                                valid_keys=list(cfg.wcs_formats_by_mime)) from None
+            raise WCS2Exception(
+                f"Unsupported format: {request.format}",
+                WCS2Exception.INVALID_PARAMETER_VALUE,
+                locator="FORMAT",
+                valid_keys=list(cfg.wcs_formats_by_mime),
+            ) from None
 
     if len(times) > 1 and not fmt.multi_time:
         raise WCS2Exception(
             "Format does not support multi-time datasets - "
             "either constrain the time dimension or choose a different format",
             WCS2Exception.INVALID_SUBSETTING,
-            locator="FORMAT or SUBSET"
-                            )
+            locator="FORMAT or SUBSET",
+        )
     affine = scaler.affine()
-    geobox = GeoBox((scaler.size.y, scaler.size.x),
-                             affine, cfg.crs(output_crs))
+    geobox = GeoBox((scaler.size.y, scaler.size.x), affine, cfg.crs(output_crs))
 
-    stacker = DataStacker(layer,
-                          geobox,
-                          times,
-                          bands=bands)
+    stacker = DataStacker(layer, geobox, times, bands=bands)
     qprof.end_event("setup")
     qprof.start_event("count-datasets")
     n_datasets = stacker.n_datasets()
@@ -255,31 +274,35 @@ def get_coverage_data(request, styles, qprof) -> tuple:
     qprof["n_datasets"] = n_datasets
 
     try:
-        layer.resource_limits.check_wcs(n_datasets,
-                                              geobox.height, geobox.width,
-                                              sum(layer.band_idx.dtype_size(b) for b in bands),
-                                              len(times)
-                                       )
+        layer.resource_limits.check_wcs(
+            n_datasets,
+            geobox.height,
+            geobox.width,
+            sum(layer.band_idx.dtype_size(b) for b in bands),
+            len(times),
+        )
     except ResourceLimited as e:
         if e.wcs_hard or not layer.low_res_product_names:
             raise WCS2Exception(
                 f"This request processes too much data to be served in a reasonable amount of time. ({e}) "
-                + "Please reduce the bounds of your request and try again.") from None
+                + "Please reduce the bounds of your request and try again."
+            ) from None
         stacker.resource_limited = True
         qprof["resource_limited"] = str(e)
 
     if n_datasets == 0:
-        raise WCS2Exception("The requested spatio-temporal subsets return no data.",
-                        WCS2Exception.INVALID_SUBSETTING,
-                        http_response=404)
+        raise WCS2Exception(
+            "The requested spatio-temporal subsets return no data.",
+            WCS2Exception.INVALID_SUBSETTING,
+            http_response=404,
+        )
 
     qprof.start_event("fetch-datasets")
     datasets = stacker.datasets()
     qprof.end_event("fetch-datasets")
     if qprof.active:
         qprof["datasets"] = {
-            str(q): [str(i) for i in ids]
-            for q, ids in stacker.dsids().items()
+            str(q): [str(i) for i in ids] for q, ids in stacker.dsids().items()
         }
     qprof.start_event("load-data")
     # FIXME: output can be None.
@@ -295,16 +318,17 @@ def get_coverage_data(request, styles, qprof) -> tuple:
     #
     # TODO: configurable
     #
-    if fmt.mime == 'image/geotiff':
-        output = fmt.renderer(request.version)(request, output, output_crs,
-                              layer, scaler.size.x, scaler.size.y, affine)
+    if fmt.mime == "image/geotiff":
+        output = fmt.renderer(request.version)(
+            request, output, output_crs, layer, scaler.size.x, scaler.size.y, affine
+        )
 
     else:
         output = fmt.renderer(request.version)(request, output, output_crs)
 
     headers = {
         "Content-Type": fmt.mime,
-        'content-disposition': f'attachment; filename={request.coverage_id}.{fmt.extension}',
+        "content-disposition": f"attachment; filename={request.coverage_id}.{fmt.extension}",
     }
     headers.update(layer.resource_limits.wcs_cache_rules.cache_headers(n_datasets))
     return output, headers
@@ -314,17 +338,17 @@ def get_tiff(request, data, crs, product, width: int, height, affine):
     """Uses rasterio MemoryFiles in order to return a streamable GeoTiff response"""
     # Does not support multi-time dimension data - is this even possible in GeoTiff?
     supported_dtype_map = {
-        'uint8': 1,
-        'int8': 2,
-        'uint16': 3,
-        'int16': 4,
-        'uint32': 5,
-        'int32': 6,
-        'float32': 7,
-        'float64': 8,
-        'complex': 10,
-        'complex64': 11,
-        'complex128': 12,
+        "uint8": 1,
+        "int8": 2,
+        "uint16": 3,
+        "int16": 4,
+        "uint32": 5,
+        "int32": 6,
+        "float32": 7,
+        "float64": 8,
+        "complex": 10,
+        "complex64": 11,
+        "complex128": 12,
     }
 
     dtype_list = [data[array].dtype for array in data.data_vars]
@@ -346,18 +370,18 @@ def get_tiff(request, data, crs, product, width: int, height, affine):
 
         kwargs = {}
         if gtiff.tile_width is not None:
-            kwargs['blockxsize'] = gtiff.tile_width
+            kwargs["blockxsize"] = gtiff.tile_width
         if gtiff.tile_height is not None:
-            kwargs['blockysize'] = gtiff.tile_height
+            kwargs["blockysize"] = gtiff.tile_height
 
         if gtiff.predictor:
             predictor = gtiff.predictor.lower()
-            if predictor == 'horizontal':
-                kwargs['predictor'] = 2
-            elif predictor == 'floatingpoint':
-                kwargs['predictor'] = 3
-        elif dtype == "float64":
+            if predictor == "horizontal":
+                kwargs["predictor"] = 2
+            elif predictor == "floatingpoint":
                 kwargs["predictor"] = 3
+        elif dtype == "float64":
+            kwargs["predictor"] = 3
         else:
             kwargs["predictor"] = 2
 
@@ -372,15 +396,25 @@ def get_tiff(request, data, crs, product, width: int, height, affine):
             tiled=gtiff.tiling if gtiff.tiling is not None else True,
             compress=gtiff.compression.lower() if gtiff.compression else "lzw",
             interleave=gtiff.interleave or "band",
-            dtype=dtype, **kwargs) as dst:
+            dtype=dtype,
+            **kwargs,
+        ) as dst:
             for idx, band in enumerate(data.data_vars, start=1):
                 dst.write(data[band].values, idx)
                 dst.set_band_description(idx, product.band_idx.band_label(band))
                 if cfg.wcs_tiff_statistics:
-                    dst.update_tags(idx, STATISTICS_MINIMUM=numpy.nanmin(data[band].values))
-                    dst.update_tags(idx, STATISTICS_MAXIMUM=numpy.nanmax(data[band].values))
-                    dst.update_tags(idx, STATISTICS_MEAN=numpy.nanmean(data[band].values))
-                    dst.update_tags(idx, STATISTICS_STDDEV=numpy.nanstd(data[band].values))
+                    dst.update_tags(
+                        idx, STATISTICS_MINIMUM=numpy.nanmin(data[band].values)
+                    )
+                    dst.update_tags(
+                        idx, STATISTICS_MAXIMUM=numpy.nanmax(data[band].values)
+                    )
+                    dst.update_tags(
+                        idx, STATISTICS_MEAN=numpy.nanmean(data[band].values)
+                    )
+                    dst.update_tags(
+                        idx, STATISTICS_STDDEV=numpy.nanstd(data[band].values)
+                    )
         return memfile.read()
 
 

--- a/datacube_ows/wcs_scaler.py
+++ b/datacube_ows/wcs_scaler.py
@@ -35,13 +35,13 @@ class SpatialParameter:
         self.y = y
 
     def is_x_dim(self, dimension: str) -> bool:
-        if dimension == self.crs_def['horizontal_coord'].lower():
+        if dimension == self.crs_def["horizontal_coord"].lower():
             return True
-        if dimension == self.crs_def['vertical_coord'].lower():
+        if dimension == self.crs_def["vertical_coord"].lower():
             return False
-        if dimension == self.layer.native_CRS_def['horizontal_coord'].lower():
+        if dimension == self.layer.native_CRS_def["horizontal_coord"].lower():
             return True
-        if dimension == self.layer.native_CRS_def['vertical_coord'].lower():
+        if dimension == self.layer.native_CRS_def["vertical_coord"].lower():
             return False
         if dimension in ("x", "i", "lon", "long", "lng", "longitude"):
             return True
@@ -160,10 +160,8 @@ class WCSScaler:
                 is_point = True
             elif self.is_slice("x") or self.is_slice("y"):
                 geom = odc_geom.line(
-                    [
-                        (self.min.x, self.min.y),
-                        (self.max.x, self.max.y)
-                    ], old_crs_obj)
+                    [(self.min.x, self.min.y), (self.max.x, self.max.y)], old_crs_obj
+                )
             else:
                 geom = odc_geom.polygon(
                     [
@@ -173,7 +171,7 @@ class WCSScaler:
                         (self.max.x, self.min.y),
                         (self.min.x, self.min.y),
                     ],
-                    old_crs_obj
+                    old_crs_obj,
                 )
             new_crs_obj = self.cfg.crs(new_crs)
             grid = self.layer.grids[new_crs]
@@ -181,8 +179,7 @@ class WCSScaler:
                 prj_pt = geom.to_crs(new_crs_obj)
                 x, y = prj_pt.coords[0]
                 self.min.set(x, y)
-                self.max.set(x + grid["resolution"][0],
-                             y + grid["resolution"][1])
+                self.max.set(x + grid["resolution"][0], y + grid["resolution"][1])
                 self.size.set(1, 1)
             else:
                 proj_geom = geom.to_crs(new_crs_obj)
@@ -217,9 +214,7 @@ class WCSScaler:
             raise WCSScalerOverspecifiedDimension()
         grid = self.layer.grids[self.crs]
         res = grid["resolution"][0 if self.min.is_x_dim(dimension) else 1]
-        scaled_size = abs(
-            (dim_max - dim_min) * factor / res
-        )
+        scaled_size = abs((dim_max - dim_min) * factor / res)
         self.set_size(dimension, scaled_size)
 
     def scale_size(self, dimension: str, size: int) -> None:
@@ -239,10 +234,10 @@ class WCSScaler:
         # Y axis is reversed: image coordinate conventions
         y_scale = (self.min.y - self.max.y) / self.size.y
         # if self.crs_def["vertical_coord_first"]:
-            # This should probably happen, but can't because PostGIS wants
-            # coords to be horizontal first, regardless of what the CRS says.
-            # trans_aff = Affine.translation(self.min.y, self.max.x)
-            # scale_aff = Affine.scale(y_scale, x_scale)
+        # This should probably happen, but can't because PostGIS wants
+        # coords to be horizontal first, regardless of what the CRS says.
+        # trans_aff = Affine.translation(self.min.y, self.max.x)
+        # scale_aff = Affine.scale(y_scale, x_scale)
         # else:
         trans_aff = Affine.translation(self.min.x, self.max.y)
         scale_aff = Affine.scale(x_scale, y_scale)

--- a/datacube_ows/wms.py
+++ b/datacube_ows/wms.py
@@ -31,8 +31,11 @@ def handle_wms(nocase_args: dict[str, str]) -> tuple | None:
         return feature_info(nocase_args)
     if operation == "GETLEGENDGRAPHIC":
         return legend_graphic(nocase_args)
-    raise WMSException(f"Unrecognised operation: {operation}", WMSException.OPERATION_NOT_SUPPORTED,
-                       "Request parameter")
+    raise WMSException(
+        f"Unrecognised operation: {operation}",
+        WMSException.OPERATION_NOT_SUPPORTED,
+        "Request parameter",
+    )
 
 
 @log_call
@@ -41,15 +44,12 @@ def get_capabilities(args) -> tuple[str, int, dict[str, str]]:
     # Note: Only WMS v1.3.0 is fully supported at this stage, so no version negotiation is necessary
     # Extract layer metadata from Datacube.
     cfg = get_config()
-    url = args.get('Host', args['url_root'])
+    url = args.get("Host", args["url_root"])
     base_url = get_service_base_url(cfg.allowed_urls, url)
     headers = cache_control_headers(cfg.wms_cap_cache_age)
     headers["Content-Type"] = "application/xml"
     return (
-        render_template(
-            "wms_capabilities.xml",
-            cfg=cfg,
-            base_url=base_url),
+        render_template("wms_capabilities.xml", cfg=cfg, base_url=base_url),
         200,
-        cfg.response_headers(headers)
+        cfg.response_headers(headers),
     )

--- a/datacube_ows/wms_utils.py
+++ b/datacube_ows/wms_utils.py
@@ -29,16 +29,18 @@ from datacube_ows.styles.expression import ExpressionException
 from datacube_ows.utils import default_to_utc, find_matching_date
 
 RESAMPLING_METHODS = {
-    'nearest': Resampling.nearest,
-    'cubic': Resampling.cubic,
-    'bilinear': Resampling.bilinear,
-    'cubic_spline': Resampling.cubic_spline,
-    'lanczos': Resampling.lanczos,
-    'average': Resampling.average,
+    "nearest": Resampling.nearest,
+    "cubic": Resampling.cubic,
+    "bilinear": Resampling.bilinear,
+    "cubic_spline": Resampling.cubic_spline,
+    "lanczos": Resampling.lanczos,
+    "average": Resampling.average,
 }
 
 
-def _bounding_pts(minx: int, miny: int, maxx: int, maxy: int, src_crs, dst_crs=None) -> tuple[float, float, float, float]:
+def _bounding_pts(
+    minx: int, miny: int, maxx: int, maxy: int, src_crs, dst_crs=None
+) -> tuple[float, float, float, float]:
     # pylint: disable=too-many-locals
     p1 = geom.point(minx, maxy, src_crs)
     p2 = geom.point(minx, miny, src_crs)
@@ -63,47 +65,45 @@ def _bounding_pts(minx: int, miny: int, maxx: int, maxy: int, src_crs, dst_crs=N
 
 def _get_geobox_xy(args, crs: CRS) -> tuple:
     if get_config().published_CRSs[str(crs)]["vertical_coord_first"]:
-        miny, minx, maxy, maxx = map(float, args['bbox'].split(','))
+        miny, minx, maxy, maxx = map(float, args["bbox"].split(","))
     else:
-        minx, miny, maxx, maxy = map(float, args['bbox'].split(','))
+        minx, miny, maxx, maxy = map(float, args["bbox"].split(","))
     return minx, miny, maxx, maxy
 
 
 def _get_geobox(args, crs: CRS) -> GeoBox:
-    width = int(args['width'])
-    height = int(args['height'])
+    width = int(args["width"])
+    height = int(args["height"])
     minx, miny, maxx, maxy = _get_geobox_xy(args, crs)
 
     if minx == maxx or miny == maxy:
         raise WMSException("Bounding box must enclose a non-zero area")
 
     if crs.epsg == 3857 and (maxx < -13_000_000 or minx > 13_000_000):
-            # EPSG:3857 query AND closer to the anti-meridian than the prime meridian:
-            # re-project to epsg:3832 (Pacific Web-Mercator)
-            ll = geom.point(x=minx, y=miny, crs=crs).to_crs("epsg:3832")
-            ur = geom.point(x=maxx, y=maxy, crs=crs).to_crs("epsg:3832")
-            minx, miny = ll.coords[0]
-            maxx, maxy = ur.coords[0]
-            crs = CRS("epsg:3832")
+        # EPSG:3857 query AND closer to the anti-meridian than the prime meridian:
+        # re-project to epsg:3832 (Pacific Web-Mercator)
+        ll = geom.point(x=minx, y=miny, crs=crs).to_crs("epsg:3832")
+        ur = geom.point(x=maxx, y=maxy, crs=crs).to_crs("epsg:3832")
+        minx, miny = ll.coords[0]
+        maxx, maxy = ur.coords[0]
+        crs = CRS("epsg:3832")
 
-    return create_geobox(
-        crs,
-        minx, miny, maxx, maxy,
-        width, height
-    )
+    return create_geobox(crs, minx, miny, maxx, maxy, width, height)
 
 
 def _get_polygon(args, crs: CRS) -> geom.Geometry:
     minx, miny, maxx, maxy = _get_geobox_xy(args, crs)
-    return geom.polygon([(minx, maxy), (minx, miny), (maxx, miny), (maxx, maxy), (minx, maxy)], crs)
+    return geom.polygon(
+        [(minx, maxy), (minx, miny), (maxx, miny), (maxx, maxy), (minx, maxy)], crs
+    )
 
 
 def zoom_factor(args, crs) -> float:
     # Determine the geographic "zoom factor" for the request.
     # (Larger zoom factor means deeper zoom.  Smaller zoom factor means larger area.)
     # Extract request bbox and crs
-    width = int(args['width'])
-    height = int(args['height'])
+    width = int(args["width"])
+    height = int(args["height"])
     minx, miny, maxx, maxy = _get_geobox_xy(args, crs)
 
     # Project to a geographic coordinate system
@@ -111,12 +111,12 @@ def zoom_factor(args, crs) -> float:
     # "standardised" in some sense, not dependent on the CRS of the request.
     # TODO: can we do better in polar regions?
     minx, miny, maxx, maxy = _bounding_pts(
-        minx, miny,
-        maxx, maxy,
-        crs, dst_crs="epsg:4326"
+        minx, miny, maxx, maxy, crs, dst_crs="epsg:4326"
     )
     # Create geobox affine transformation (N.B. Don't need an actual Geobox)
-    affine = Affine.translation(minx, miny) * Affine.scale((maxx - minx) / width, (maxy - miny) / height)
+    affine = Affine.translation(minx, miny) * Affine.scale(
+        (maxx - minx) / width, (maxy - miny) / height
+    )
     # Zoom factor is the reciprocal of the square root of the transform determinant
     # (The determinant is x scale factor multiplied by the y scale factor)
     return 1.0 / math.sqrt(affine.determinant)
@@ -126,12 +126,14 @@ def img_coords_to_geopoint(geobox, i, j) -> geom.Geometry:
     cfg = get_config()
     h_coord = cfg.published_CRSs[str(geobox.crs)]["horizontal_coord"]
     v_coord = cfg.published_CRSs[str(geobox.crs)]["vertical_coord"]
-    return geom.point(geobox.coordinates[h_coord].values[int(i)],
-                          geobox.coordinates[v_coord].values[int(j)],
-                          geobox.crs)
+    return geom.point(
+        geobox.coordinates[h_coord].values[int(i)],
+        geobox.coordinates[v_coord].values[int(j)],
+        geobox.crs,
+    )
 
 
-def get_layer_from_arg(args, argname: str ="layers") -> OWSNamedLayer:
+def get_layer_from_arg(args, argname: str = "layers") -> OWSNamedLayer:
     layers = args.get(argname, "").split(",")
     if len(layers) != 1:
         raise WMSException("Multi-layer requests not supported")
@@ -141,29 +143,41 @@ def get_layer_from_arg(args, argname: str ="layers") -> OWSNamedLayer:
     cfg = get_config()
     layer = cfg.layer_index.get(lyr)
     if not layer:
-        raise WMSException(f"Layer {lyr} is not defined",
-                           WMSException.LAYER_NOT_DEFINED,
-                           locator="Layer parameter",
-                           valid_keys=list(cfg.layer_index))
+        raise WMSException(
+            f"Layer {lyr} is not defined",
+            WMSException.LAYER_NOT_DEFINED,
+            locator="Layer parameter",
+            valid_keys=list(cfg.layer_index),
+        )
     return layer
 
 
-def get_arg(args, argname: str, verbose_name: str, lower: bool = False,
-            errcode=None, permitted_values=None):
+def get_arg(
+    args,
+    argname: str,
+    verbose_name: str,
+    lower: bool = False,
+    errcode=None,
+    permitted_values=None,
+):
     fmt = args.get(argname, "")
     if lower:
         fmt = fmt.lower()
     if not fmt:
-        raise WMSException(f"No {verbose_name} specified",
-                           errcode,
-                           locator=f"{argname} parameter",
-                           valid_keys=permitted_values)
+        raise WMSException(
+            f"No {verbose_name} specified",
+            errcode,
+            locator=f"{argname} parameter",
+            valid_keys=permitted_values,
+        )
 
     if permitted_values and fmt not in permitted_values:
-        raise WMSException(f"{verbose_name} {fmt} is not supported",
-                           errcode,
-                           locator=f"{argname} parameter",
-                           valid_keys=permitted_values)
+        raise WMSException(
+            f"{verbose_name} {fmt} is not supported",
+            errcode,
+            locator=f"{argname} parameter",
+            valid_keys=permitted_values,
+        )
     return fmt
 
 
@@ -173,23 +187,27 @@ def get_times_for_layer(layer: OWSNamedLayer) -> list[datetime | date]:
 
 def get_times(args, layer: OWSNamedLayer) -> list[datetime | date]:
     # Time parameter
-    times_raw = args.get('time', '')
-    times = times_raw.split(',')
+    times_raw = args.get("time", "")
+    times = times_raw.split(",")
 
     return [parse_time_item(item, layer) for item in times]
 
 
 def parse_time_item(item: str, layer: OWSNamedLayer) -> datetime | date:
-    times = item.split('/')
+    times = item.split("/")
     # Time range handling follows the implementation described by GeoServer
     # https://docs.geoserver.org/stable/en/user/services/wms/time.html
 
     # If all times are equal we can proceed
     if len(times) > 1:
         # TODO WMS Time range selections (/ notation) are poorly and incompletely implemented.
-        start, end = parse_wms_time_strings(times, with_tz=layer.time_resolution.is_subday())
+        start, end = parse_wms_time_strings(
+            times, with_tz=layer.time_resolution.is_subday()
+        )
         if layer.time_resolution.is_subday():
-            matching_times: list[datetime] = [t for t in layer.ranges.times if start <= t <= end]
+            matching_times: list[datetime] = [
+                t for t in layer.ranges.times if start <= t <= end
+            ]
         else:
             start, end = start.date(), end.date()
             matching_times = [t for t in layer.ranges.times if start <= t <= end]
@@ -200,11 +218,13 @@ def parse_time_item(item: str, layer: OWSNamedLayer) -> datetime | date:
             raise WMSException(
                 f"No data available for time dimension range '{start}'-'{end}' for this layer",
                 WMSException.INVALID_DIMENSION_VALUE,
-                locator="Time parameter")
+                locator="Time parameter",
+            )
         raise WMSException(
             f"Time dimension range '{start}'-'{end}' not valid for this layer",
             WMSException.INVALID_DIMENSION_VALUE,
-            locator="Time parameter")
+            locator="Time parameter",
+        )
     if not times[0]:
         # default to last available time if not supplied.
         product_times = get_times_for_layer(layer)
@@ -216,7 +236,8 @@ def parse_time_item(item: str, layer: OWSNamedLayer) -> datetime | date:
         raise WMSException(
             f"Time dimension value '{times[0]}' not valid for this layer",
             WMSException.INVALID_DIMENSION_VALUE,
-            locator="Time parameter") from None
+            locator="Time parameter",
+        ) from None
 
     # Validate time parameter for requested layer.
     if layer.regular_time_axis:
@@ -226,46 +247,55 @@ def parse_time_item(item: str, layer: OWSNamedLayer) -> datetime | date:
             raise WMSException(
                 f"Time dimension value '{times[0]}' not valid for this layer",
                 WMSException.INVALID_DIMENSION_VALUE,
-                locator="Time parameter")
+                locator="Time parameter",
+            )
         if day > end:
             raise WMSException(
                 f"Time dimension value '{times[0]}' not valid for this layer",
                 WMSException.INVALID_DIMENSION_VALUE,
-                locator="Time parameter")
+                locator="Time parameter",
+            )
         if (day - start).days % layer.time_axis_interval != 0:
             raise WMSException(
                 f"Time dimension value '{times[0]}' not valid for this layer",
                 WMSException.INVALID_DIMENSION_VALUE,
-                locator="Time parameter")
+                locator="Time parameter",
+            )
         return day
     if layer.time_resolution.is_subday():
         if not find_matching_date(time, layer.ranges.times):
             raise WMSException(
                 f"Time dimension value '{times[0]}' not valid for this layer",
                 WMSException.INVALID_DIMENSION_VALUE,
-                locator="Time parameter")
+                locator="Time parameter",
+            )
         return time
     if day not in layer.ranges.time_set:
         raise WMSException(
             f"Time dimension value '{times[0]}' not valid for this layer",
             WMSException.INVALID_DIMENSION_VALUE,
-            locator="Time parameter")
+            locator="Time parameter",
+        )
     return day
 
 
 def parse_time_delta(delta_str) -> relativedelta:
-    pattern = (r'P((?P<years>\d+)Y)?((?P<months>\d+)M)?((?P<days>\d+)D)?'
-               r'(T(((?P<hours>\d+)H)?((?P<minutes>\d+)M)?((?P<seconds>\d+)S)?)?)?')
+    pattern = (
+        r"P((?P<years>\d+)Y)?((?P<months>\d+)M)?((?P<days>\d+)D)?"
+        r"(T(((?P<hours>\d+)H)?((?P<minutes>\d+)M)?((?P<seconds>\d+)S)?)?)?"
+    )
     parts = re.search(pattern, delta_str).groupdict()
     return relativedelta(**{k: int(v) for k, v in parts.items() if v is not None})  # type: ignore[arg-type]
 
 
 def parse_wms_time_string(t: str, start: bool = True) -> datetime | relativedelta:
-    if t.upper() == 'PRESENT':
+    if t.upper() == "PRESENT":
         return datetime.now(timezone.utc)
-    if t.startswith('P'):
+    if t.startswith("P"):
         return parse_time_delta(t)
-    default = datetime(1970, 1, 1) if start else datetime(1970, 12, 31, 23, 23, 59, 999999)  # default year ignored
+    default = (
+        datetime(1970, 1, 1) if start else datetime(1970, 12, 31, 23, 23, 59, 999999)
+    )  # default year ignored
     return parse(t, default=default)
 
 
@@ -281,7 +311,8 @@ def parse_wms_time_strings(parts: list[str], with_tz: bool = False) -> tuple:
             raise WMSException(
                 f"Could not understand time value '{parts}'",
                 WMSException.INVALID_DIMENSION_VALUE,
-                locator="Time parameter")
+                locator="Time parameter",
+            )
         fuzzy_end = parse_wms_time_string(parts[-1], start=True)
         return fuzzy_end - start + a_tiny_bit, end
     if isinstance(end, relativedelta):
@@ -296,13 +327,18 @@ class GetParameters:
     def __init__(self, args) -> None:
         self.cfg = get_config()
         # Version
-        self.version = get_arg(args, "version", "WMS version",
-                               permitted_values=['1.1.1', '1.3.0'])
+        self.version = get_arg(
+            args, "version", "WMS version", permitted_values=["1.1.1", "1.3.0"]
+        )
         # CRS
-        crs_arg = "srs" if self.version == '1.1.1' else "crs"
-        self.crsid = get_arg(args, crs_arg, "Coordinate Reference System",
-                             errcode=WMSException.INVALID_CRS,
-                             permitted_values=list(self.cfg.published_CRSs))
+        crs_arg = "srs" if self.version == "1.1.1" else "crs"
+        self.crsid = get_arg(
+            args,
+            crs_arg,
+            "Coordinate Reference System",
+            errcode=WMSException.INVALID_CRS,
+            permitted_values=list(self.cfg.published_CRSs),
+        )
         self.crs = self.cfg.crs(self.crsid)
         # Layers
         self.layer = self.get_layer(args)
@@ -335,39 +371,52 @@ def single_style_from_args(layer: OWSNamedLayer, args, required: bool = True):
         try:
             plt.get_cmap(mpl_ramp)
         except Exception:
-            raise WMSException(f"Invalid Matplotlib ramp name: {mpl_ramp}",
-                               locator="Colorscalerange parameter") from None
+            raise WMSException(
+                f"Invalid Matplotlib ramp name: {mpl_ramp}",
+                locator="Colorscalerange parameter",
+            ) from None
         colorscalerange = args.get("colorscalerange", "0,1").split(",")
         if len(colorscalerange) != 2:
-            raise WMSException("Colorscale range must be two numbers, sorted and separated by a comma.",
-                               locator="Colorscalerange parameter")
+            raise WMSException(
+                "Colorscale range must be two numbers, sorted and separated by a comma.",
+                locator="Colorscalerange parameter",
+            )
         try:
             colorscalerange = [float(r) for r in colorscalerange]
         except ValueError:
-            raise WMSException("Colorscale range must be two numbers, sorted and separated by a comma.",
-                               locator="Colorscalerange parameter") from None
+            raise WMSException(
+                "Colorscale range must be two numbers, sorted and separated by a comma.",
+                locator="Colorscalerange parameter",
+            ) from None
         if colorscalerange[0] >= colorscalerange[1]:
-            raise WMSException("Colorscale range must be two numbers, sorted and separated by a comma.",
-                               locator="Colorscalerange parameter")
+            raise WMSException(
+                "Colorscale range must be two numbers, sorted and separated by a comma.",
+                locator="Colorscalerange parameter",
+            )
         try:
-            style: StyleDefBase | None = StyleDef(layer, {
-                "name": "custom_user_style",
-                "index_expression": code,
-                "mpl_ramp": mpl_ramp,
-                "range": colorscalerange,
-                "legend": {
-                    "title": "User-Custom Index",
-                    "show_legend": True,
-                    "begin": str(colorscalerange[0]),
-                    "end": str(colorscalerange[1]),
-                }
-            }, stand_alone=True, user_defined=True)
+            style: StyleDefBase | None = StyleDef(
+                layer,
+                {
+                    "name": "custom_user_style",
+                    "index_expression": code,
+                    "mpl_ramp": mpl_ramp,
+                    "range": colorscalerange,
+                    "legend": {
+                        "title": "User-Custom Index",
+                        "show_legend": True,
+                        "begin": str(colorscalerange[0]),
+                        "end": str(colorscalerange[1]),
+                    },
+                },
+                stand_alone=True,
+                user_defined=True,
+            )
         except ExpressionException as e:
-            raise WMSException(f"Code expression invalid: {e}",
-                               locator="Code parameter") from None
+            raise WMSException(
+                f"Code expression invalid: {e}", locator="Code parameter"
+            ) from None
         except ConfigException as e:
-            raise WMSException(f"Code invalid: {e}",
-                               locator="Code parameter") from None
+            raise WMSException(f"Code invalid: {e}", locator="Code parameter") from None
     else:
         # Regular WMS Styles
         styles = args.get("styles", "").split(",")
@@ -380,21 +429,28 @@ def single_style_from_args(layer: OWSNamedLayer, args, required: bool = True):
             style_r = layer.default_style.name
         style = layer.style_index.get(style_r)
         if not style:
-            raise WMSException(f"Style {style_r} is not defined",
-                               WMSException.STYLE_NOT_DEFINED,
-                               locator="Style parameter",
-                               valid_keys=list(layer.style_index))
+            raise WMSException(
+                f"Style {style_r} is not defined",
+                WMSException.STYLE_NOT_DEFINED,
+                locator="Style parameter",
+                valid_keys=list(layer.style_index),
+            )
     return style
+
 
 class GetLegendGraphicParameters:
     def __init__(self, args) -> None:
-        self.layer = get_layer_from_arg(args, 'layer')
+        self.layer = get_layer_from_arg(args, "layer")
 
         # Validate Format parameter
-        self.format = get_arg(args, "format", "image format",
-                              errcode=WMSException.INVALID_FORMAT,
-                              lower=True,
-                              permitted_values=["image/png"])
+        self.format = get_arg(
+            args,
+            "format",
+            "image format",
+            errcode=WMSException.INVALID_FORMAT,
+            lower=True,
+            permitted_values=["image/png"],
+        )
         self.style = single_style_from_args(self.layer, args)
         self.styles = [self.style]
         # Time parameter
@@ -405,19 +461,27 @@ class GetMapParameters(GetParameters):
     @override
     def method_specific_init(self, args) -> None:
         # Validate Format parameter
-        self.format = get_arg(args, "format", "image format",
-                              errcode=WMSException.INVALID_FORMAT,
-                              lower=True,
-                              permitted_values=["image/png"])
+        self.format = get_arg(
+            args,
+            "format",
+            "image format",
+            errcode=WMSException.INVALID_FORMAT,
+            lower=True,
+            permitted_values=["image/png"],
+        )
 
         self.style = single_style_from_args(self.layer, args)
         cfg = get_config()
         if self.geobox.width > cfg.wms_max_width:
-            raise WMSException(f"Width {self.geobox.width} exceeds supported maximum {self.cfg.wms_max_width}.",
-                               locator="Width parameter")
+            raise WMSException(
+                f"Width {self.geobox.width} exceeds supported maximum {self.cfg.wms_max_width}.",
+                locator="Width parameter",
+            )
         if self.geobox.height > cfg.wms_max_height:
-            raise WMSException(f"Width {self.geobox.height} exceeds supported maximum {self.cfg.wms_max_height}.",
-                               locator="Height parameter")
+            raise WMSException(
+                f"Width {self.geobox.height} exceeds supported maximum {self.cfg.wms_max_height}.",
+                locator="Height parameter",
+            )
 
         # Zoom factor
         self.zf = zoom_factor(args, self.crs)
@@ -444,19 +508,30 @@ class GetFeatureInfoParameters(GetParameters):
     @override
     def method_specific_init(self, args) -> None:
         # Validate Formata parameter
-        self.format = get_arg(args, "info_format", "info format", lower=True,
-                              errcode=WMSException.INVALID_FORMAT,
-                              permitted_values=["application/json", "text/html"])
+        self.format = get_arg(
+            args,
+            "info_format",
+            "info format",
+            lower=True,
+            errcode=WMSException.INVALID_FORMAT,
+            permitted_values=["application/json", "text/html"],
+        )
         # Point coords
         coords = ["x", "y"] if self.version == "1.1.1" else ["i", "j"]
         i = args.get(coords[0])
         j = args.get(coords[1])
         if i is None:
-            raise WMSException("HorizontalCoordinate not supplied", WMSException.INVALID_POINT,
-                               f"{coords[0]} parameter")
+            raise WMSException(
+                "HorizontalCoordinate not supplied",
+                WMSException.INVALID_POINT,
+                f"{coords[0]} parameter",
+            )
         if j is None:
-            raise WMSException("Vertical coordinate not supplied", WMSException.INVALID_POINT,
-                               f"{coords[0]} parameter")
+            raise WMSException(
+                "Vertical coordinate not supplied",
+                WMSException.INVALID_POINT,
+                f"{coords[0]} parameter",
+            )
         self.i = int(i)
         self.j = int(j)
         self.style = single_style_from_args(self.layer, args, required=False)
@@ -475,14 +550,17 @@ def cosine_of_solar_zenith(lat: float, lon: float, utc_dt) -> float:
     # Estimate cosine of solar zenith angle
     # (angle between sun and local zenith) at requested latitude, longitude and datetime.
     # Formula taken from https://en.wikipedia.org/wiki/Solar_zenith_angle
-    utc_seconds_since_midnight = ((utc_dt.hour * 60) + utc_dt.minute) * 60 + utc_dt.second
+    utc_seconds_since_midnight = (
+        (utc_dt.hour * 60) + utc_dt.minute
+    ) * 60 + utc_dt.second
     utc_hour_deg_angle = (utc_seconds_since_midnight / (60 * 60 * 24) * 360.0) - 180.0
     local_hour_deg_angle = utc_hour_deg_angle + lon
     local_hour_angle_rad = math.radians(local_hour_deg_angle)
     latitude_rad = math.radians(lat)
     solar_decl_rad = declination_rad(utc_dt)
-    return math.sin(latitude_rad) * math.sin(solar_decl_rad) \
-             + math.cos(latitude_rad) * math.cos(solar_decl_rad) * math.cos(local_hour_angle_rad)
+    return math.sin(latitude_rad) * math.sin(solar_decl_rad) + math.cos(
+        latitude_rad
+    ) * math.cos(solar_decl_rad) * math.cos(local_hour_angle_rad)
 
 
 def solar_correct_data(data, dataset) -> float:
@@ -507,6 +585,6 @@ def wofls_fuser(dest: numpy.ndarray, src: numpy.ndarray) -> numpy.ndarray:
 
 
 def item_fuser(dest: numpy.ndarray, src: numpy.ndarray) -> numpy.ndarray:
-    where_combined = numpy.isnan(dest) | (dest == -6666.)
+    where_combined = numpy.isnan(dest) | (dest == -6666.0)
     numpy.copyto(dest, src, where=where_combined)
     return dest

--- a/datacube_ows/wmts.py
+++ b/datacube_ows/wmts.py
@@ -18,10 +18,9 @@ from datacube_ows.utils import log_call
 _LOG: logging.Logger = logging.getLogger(__name__)
 
 
-
-
 # NB. No need to disambiguate method names shared with WMS because WMTS requires
 # a "SERVICE" parameter with every request.
+
 
 @log_call
 def handle_wmts(nocase_args) -> tuple:
@@ -35,8 +34,11 @@ def handle_wmts(nocase_args) -> tuple:
         return get_tile(nocase_args)
     if operation == "GETFEATUREINFO":
         return get_feature_info(nocase_args)
-    raise WMTSException(f"Unrecognised operation: {operation}", WMTSException.OPERATION_NOT_SUPPORTED,
-                       "Request parameter")
+    raise WMTSException(
+        f"Unrecognised operation: {operation}",
+        WMTSException.OPERATION_NOT_SUPPORTED,
+        "Request parameter",
+    )
 
 
 @log_call
@@ -45,7 +47,7 @@ def get_capabilities(args) -> tuple:
     # Note: Only WMS v1.0.0 exists at this stage, so no version negotiation is necessary
     # Extract layer metadata from Datacube.
     cfg = get_config()
-    url = args.get('Host', args['url_root'])
+    url = args.get("Host", args["url_root"])
     base_url = get_service_base_url(cfg.allowed_urls, url)
     section = args.get("section")
     if section:
@@ -81,9 +83,11 @@ def get_capabilities(args) -> tuple:
             elif s == "themes":
                 show_themes = True
             else:
-                raise WMTSException(f"Invalid section: {section}",
-                                WMTSException.INVALID_PARAMETER_VALUE,
-                                locator="Section parameter")
+                raise WMTSException(
+                    f"Invalid section: {section}",
+                    WMTSException.INVALID_PARAMETER_VALUE,
+                    locator="Section parameter",
+                )
     headers = cache_control_headers(cfg.wms_cap_cache_age)
     headers["Content-Type"] = "application/xml"
     return (
@@ -95,9 +99,10 @@ def get_capabilities(args) -> tuple:
             show_service_provider=show_service_provider,
             show_ops_metadata=show_ops_metadata,
             show_contents=show_contents,
-            show_themes=show_themes),
+            show_themes=show_themes,
+        ),
         200,
-        cfg.response_headers(headers)
+        cfg.response_headers(headers),
     )
 
 
@@ -123,7 +128,7 @@ def wmts_args_to_wms(args, cfg) -> dict:
         "height": 256,
         "format": format_,
         "exceptions": "application/vnd.ogc.se_xml",
-        "requestid": args["requestid"]
+        "requestid": args["requestid"],
     }
 
     tms = cfg.tile_matrix_sets.get(tileMatrixSet)
@@ -152,14 +157,15 @@ def wmts_args_to_wms(args, cfg) -> dict:
         col = int(col)
     except ValueError:
         raise WMTSException(f"Invalid Tile Col: {col}") from None
-    wms_args["bbox"] = "{:f},{:f},{:f},{:f}".format(*tms.wms_bbox_coords(tileMatrix, row, col))
+    wms_args["bbox"] = "{:f},{:f},{:f},{:f}".format(
+        *tms.wms_bbox_coords(tileMatrix, row, col)
+    )
 
     # GetFeatureInfo only args
     if "i" in args:
         wms_args["i"] = args["i"]
         wms_args["j"] = args.get("j", "")
         wms_args["info_format"] = args.get("infoformat", "")
-
 
     if args.get("ows_stats"):
         wms_args["ows_stats"] = "y"
@@ -176,10 +182,12 @@ def get_tile(args) -> tuple:
         return get_map(wms_args)
     except WMSException as wmse:
         first_error = wmse.errors[0]
-        e = WMTSException(first_error["msg"],
-                            code=first_error["code"],
-                            locator=first_error["locator"],
-                            http_response=wmse.http_response)
+        e = WMTSException(
+            first_error["msg"],
+            code=first_error["code"],
+            locator=first_error["locator"],
+            http_response=wmse.http_response,
+        )
         for error in wmse.errors[1:]:
             e.add_error(error["msg"], code=error["code"], locator=error["locator"])
         raise e from None
@@ -195,10 +203,12 @@ def get_feature_info(args) -> tuple:
         return feature_info(wms_args)
     except WMSException as wmse:
         first_error = wmse.errors[0]
-        e = WMTSException(first_error["msg"],
-                          code=first_error["code"],
-                          locator=first_error["locator"],
-                          http_response=wmse.http_response)
+        e = WMTSException(
+            first_error["msg"],
+            code=first_error["code"],
+            locator=first_error["locator"],
+            http_response=wmse.http_response,
+        )
         for error in wmse.errors[1:]:
             e.add_error(error["msg"], code=error["code"], locator=error["locator"])
         raise e from None

--- a/datacube_ows/wsgi.py
+++ b/datacube_ows/wsgi.py
@@ -5,7 +5,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-#pylint: skip-file
+# pylint: skip-file
 import os
 import sys
 
@@ -25,12 +25,10 @@ application = app
 
 def main() -> None:
     if "--version" in sys.argv:
-        print("Open Data Cube Open Web Services (datacube-ows) version",
-              __version__
-              )
+        print("Open Data Cube Open Web Services (datacube-ows) version", __version__)
         exit(0)
     app.run()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/integration_tests/cfg/ows_test_cfg.py
+++ b/integration_tests/cfg/ows_test_cfg.py
@@ -168,9 +168,8 @@ style_ls_simple_rgb = {
         "show_legend": True,
         "url": {
             "en": "https://user-images.githubusercontent.com/4548530/112120795-b215b880-8c12-11eb-8bfa-1033961fb1ba.png"
-        }
-    }
-
+        },
+    },
 }
 
 style_fc_c3_rgb_unmasked = {
@@ -305,9 +304,9 @@ style_ndvi = {
             },
             "1.0": {
                 "label": "high",
-            }
-        }
-    }
+            },
+        },
+    },
 }
 
 style_ndvi_expr = {
@@ -405,7 +404,7 @@ style_ls_ndvi_delta = {
                 "kwargs": {
                     "band1": "nir",
                     "band2": "red",
-                }
+                },
             },
             "mpl_ramp": "RdYlBu",
             "range": [-1.0, 1.0],
@@ -416,22 +415,18 @@ style_ls_ndvi_delta = {
                     "-1.0",
                     "0.0",
                     "1.0",
-                ]
+                ],
             },
             "custom_includes": {
                 "red_diff": {
                     "function": f"{cfgbase}utils.new_twodate_finfo",
                     "mapped_bands": True,
-                    "kwargs": {
-                        "band": "red"
-                    }
+                    "kwargs": {"band": "red"},
                 },
                 "nir_diff": {
                     "function": f"{cfgbase}utils.new_twodate_finfo",
                     "mapped_bands": True,
-                    "kwargs": {
-                        "band": "nir"
-                    }
+                    "kwargs": {"band": "nir"},
                 },
             },
             "feature_info_label": "ndvi_delta",
@@ -599,7 +594,6 @@ ows_cfg = {
         "message_file": f"{trans_dir}/integration_tests/cfg/message.po",
         "translations_directory": f"{trans_dir}/integration_tests/cfg/translations",
         "supported_languages": ["en", "de"],
-
         # URL that humans can visit to learn more about the service(s) or organization
         # should be fully qualified
         "info_url": "http://opendatacube.org",
@@ -701,7 +695,6 @@ ows_cfg = {
         # Optional, defaults to 256x256
         "max_width": 512,
         "max_height": 512,
-
         "caps_cache_maxage": 5,
         # These define the AuthorityURLs.
         # They represent the authorities that define the "Identifiers" defined layer by layer below.
@@ -752,7 +745,7 @@ ows_cfg = {
         },
         # The wcs:native_format must be declared in wcs:formats dict above.
         "native_format": "GeoTIFF",
-        "default_desc_cache_maxage": 300, # 5 minutes
+        "default_desc_cache_maxage": 300,  # 5 minutes
     },  ###### End of "wcs" section
     # Products published by this datacube_ows instance.
     # The layers section is a list of layer definitions.  Each layer may be either:
@@ -871,7 +864,7 @@ ows_cfg = {
                             },
                             "patch_url_function": f"{cfgbase}utils.trivial_identity",
                         },
-                    ]
+                    ],
                 },
                 {
                     "title": "DEA Config Samples",
@@ -913,19 +906,23 @@ ows_cfg = {
                                     "band": "fmask_alias",
                                     "products": ["ga_s2am_ard_3", "ga_s2bm_ard_3"],
                                     "ignore_time": False,
-                                    "ignore_info_flags": []
+                                    "ignore_info_flags": [],
                                 },
                                 {
                                     "band": "land",
-                                    "products": ["geodata_coast_100k", "geodata_coast_100k"],
+                                    "products": [
+                                        "geodata_coast_100k",
+                                        "geodata_coast_100k",
+                                    ],
                                     "ignore_time": True,
-                                    "ignore_info_flags": []
+                                    "ignore_info_flags": [],
                                 },
                             ],
-                            "time_axis": {
-                                "time_interval": 1
+                            "time_axis": {"time_interval": 1},
+                            "styling": {
+                                "default_style": "ndci",
+                                "styles": styles_s2_ga_list,
                             },
-                            "styling": {"default_style": "ndci", "styles": styles_s2_ga_list},
                         },
                         {
                             "title": "A Broken Layer",
@@ -948,19 +945,20 @@ ows_cfg = {
                                     "band": "fmask_alias",
                                     "product": "spaghetti_gateaux",
                                     "ignore_time": False,
-                                    "ignore_info_flags": []
+                                    "ignore_info_flags": [],
                                 },
                                 {
                                     "band": "land",
                                     "product": "spaghetti_gateaux",
                                     "ignore_time": True,
-                                    "ignore_info_flags": []
+                                    "ignore_info_flags": [],
                                 },
                             ],
-                            "time_axis": {
-                                "time_interval": 1
+                            "time_axis": {"time_interval": 1},
+                            "styling": {
+                                "default_style": "ndci",
+                                "styles": styles_s2_ga_list,
                             },
-                            "styling": {"default_style": "ndci", "styles": styles_s2_ga_list},
                         },
                         {
                             "inherits": {
@@ -978,8 +976,8 @@ ows_cfg = {
                                 "pass_layer_cfg": True,
                                 "kwargs": {
                                     "ndays": 6,
-                                }
-                            }
+                                },
+                            },
                         },
                         {
                             "title": "DEA Fractional Cover (Landsat)",
@@ -1023,8 +1021,8 @@ ows_cfg = {
                                 "default_style": "fc_rgb_unmasked",
                                 "styles": [style_fc_c3_rgb_unmasked],
                             },
-                        }
-                    ]
+                        },
+                    ],
                 },
                 {
                     "title": "Landsat-8 Geomedian",
@@ -1046,8 +1044,8 @@ ows_cfg = {
                         "default_style": "simple_rgb",
                         "styles": styles_ls_list,
                     },
-                }
-            ] ####### End of "postgres" layers
+                },
+            ],  ####### End of "postgres" layers
         },
         {
             "title": "Postgis Data",
@@ -1133,7 +1131,7 @@ ows_cfg = {
                             },
                             "patch_url_function": f"{cfgbase}utils.trivial_identity",
                         },
-                    ]
+                    ],
                 },
                 {
                     "title": "DEA Config Samples",
@@ -1176,19 +1174,23 @@ ows_cfg = {
                                     "band": "fmask_alias",
                                     "products": ["ga_s2am_ard_3", "ga_s2bm_ard_3"],
                                     "ignore_time": False,
-                                    "ignore_info_flags": []
+                                    "ignore_info_flags": [],
                                 },
                                 {
                                     "band": "land",
-                                    "products": ["geodata_coast_100k", "geodata_coast_100k"],
+                                    "products": [
+                                        "geodata_coast_100k",
+                                        "geodata_coast_100k",
+                                    ],
                                     "ignore_time": True,
-                                    "ignore_info_flags": []
+                                    "ignore_info_flags": [],
                                 },
                             ],
-                            "time_axis": {
-                                "time_interval": 1
+                            "time_axis": {"time_interval": 1},
+                            "styling": {
+                                "default_style": "ndci",
+                                "styles": styles_s2_ga_list,
                             },
-                            "styling": {"default_style": "ndci", "styles": styles_s2_ga_list},
                         },
                         {
                             "inherits": {
@@ -1206,8 +1208,8 @@ ows_cfg = {
                                 "pass_layer_cfg": True,
                                 "kwargs": {
                                     "ndays": 6,
-                                }
-                            }
+                                },
+                            },
                         },
                         {
                             "title": "DEA Fractional Cover (Landsat) (postgis db)",
@@ -1252,8 +1254,8 @@ ows_cfg = {
                                 "default_style": "fc_rgb_unmasked",
                                 "styles": [style_fc_c3_rgb_unmasked],
                             },
-                        }
-                    ]
+                        },
+                    ],
                 },
                 {
                     "title": "Landsat-8 Geomedian (postgis db)",
@@ -1276,8 +1278,8 @@ ows_cfg = {
                         "default_style": "simple_rgb",
                         "styles": styles_ls_list,
                     },
-                }
-            ]  ####### End of "postgis" layers
+                },
+            ],  ####### End of "postgis" layers
         },
-    ]  ##### End of "layers" list.
+    ],  ##### End of "layers" list.
 }  #### End of test configuration object

--- a/integration_tests/cfg/ows_test_cfg_bad.py
+++ b/integration_tests/cfg/ows_test_cfg_bad.py
@@ -6,15 +6,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-
 # THIS IS A TESTING FILE FOR TESTING ERROR HANDLING.
 # Do not use it as an example, it is deliberately invalid.
 #
 # Please refer to datacube_ows/ows_cfg_example.py for EXAMPLE CONFIG
 
-ows_cfg = {
-    "glerbal": {
-        "turtle": "An invalid configuration",
-    },
-    "liars": []
-}
+ows_cfg = {"glerbal": {"turtle": "An invalid configuration"}, "liars": []}

--- a/integration_tests/cfg/ows_test_cfg_no_i18n.py
+++ b/integration_tests/cfg/ows_test_cfg_no_i18n.py
@@ -6,7 +6,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-
 # THIS IS A TESTING FILE
 # Please refer to datacube_ows/ows_cfg_example.py for EXAMPLE CONFIG
 
@@ -32,9 +31,7 @@ bands_fc = {
     "NPV": ["non_photosynthetic_vegetation", "brown_vegetation"],
 }
 
-bands_wofs_obs = {
-    "water": [],
-}
+bands_wofs_obs = {"water": []}
 
 
 # REUSABLE CONFIG FRAGMENTS - Style definitions
@@ -83,14 +80,8 @@ style_infrared_false_colour = {
             # by defining a band alias.)
             "scale_range": [5.0, 4000.0],
         },
-        "green": {
-            "swir2": 1.0,
-            "scale_range": [25.0, 4000.0],
-        },
-        "blue": {
-            "nir": 1.0,
-            "scale_range": [0.0, 3000.0],
-        },
+        "green": {"swir2": 1.0, "scale_range": [25.0, 4000.0]},
+        "blue": {"nir": 1.0, "scale_range": [0.0, 3000.0]},
     },
     # The style scale_range can be omitted if all components have a component-specific scale_range defined.
     # "scale_range": [0.0, 3000.0]
@@ -176,9 +167,7 @@ style_ndvi_delta = {
         {"value": 1.0, "color": "#114D04"},
     ],
     "include_in_feature_info": True,
-    "legend": {
-        "show_legend": True,
-    },
+    "legend": {"show_legend": True},
     # Define behaviour(s) for multi-date requests. If not declared, style only supports single-date requests.
     "multi_date": [
         # A multi-date handler.  Different handlers can be declared for different numbers of dates in a request.
@@ -245,10 +234,7 @@ style_fc_simple = {
     "components": {"red": {"BS": 1.0}, "green": {"PV": 1.0}, "blue": {"NPV": 1.0}},
     "scale_range": [0.0, 100.0],
     "pq_masks": [
-        {
-            "band": "water",
-            "flags": {"dry": True},
-        },
+        {"band": "water", "flags": {"dry": True}},
         {
             "band": "water",
             "flags": {
@@ -375,10 +361,7 @@ style_wofs_obs_wet_only = {
             {
                 "title": "Dry",
                 "abstract": "Dry",
-                "flags": {
-                    "dry": True,
-                    "sea": False,
-                },
+                "flags": {"dry": True, "sea": False},
                 "color": "#D99694",
                 "alpha": 0.0,
             },
@@ -429,7 +412,7 @@ ows_cfg = {
         # These HTML headers are added to all responses
         # Optional, default {} - no added headers
         "response_headers": {
-            "Access-Control-Allow-Origin": "*",  # CORS header (strongly recommended)
+            "Access-Control-Allow-Origin": "*"  # CORS header (strongly recommended)
         },
         # Which web service(s) should be implemented by this instance
         # Optional, defaults: wms,wmts: True, wcs: False
@@ -454,11 +437,7 @@ ows_cfg = {
         "abstract": """This web-service serves georectified raster data from our very own special Open Datacube instance.""",
         # Keywords included for all services and products
         # Optional - defaults to empty list.
-        "keywords": [
-            "satellite",
-            "australia",
-            "time-series",
-        ],
+        "keywords": ["satellite", "australia", "time-series"],
         # Contact info.
         # Optional but strongly recommended - defaults to blank.
         "contact_info": {
@@ -542,7 +521,6 @@ ows_cfg = {
         # Optional, defaults to 256x256
         "max_width": 512,
         "max_height": 512,
-
         # These define the AuthorityURLs.
         # They represent the authorities that define the "Identifiers" defined layer by layer below.
         # The spec allows AuthorityURLs to be defined anywhere on the Layer heirarchy, but datacube_ows treats them
@@ -639,7 +617,7 @@ ows_cfg = {
                             "ignore_time": False,
                             "ignore_info_flags": [],
                             "manual_merge": True,
-                        },
+                        }
                     ],
                     "image_processing": {
                         # Extent mask function
@@ -678,9 +656,7 @@ ows_cfg = {
                     },
                 },  ##### End of ls8_level1_pds product definition.
                 {
-                    "inherits": {
-                        "layer": "ls8_usgs_level1_scene_layer",
-                    },
+                    "inherits": {"layer": "ls8_usgs_level1_scene_layer"},
                     "title": "Level 1 USGS Landsat-8 Public Data Set Clone",
                     "abstract": "Imagery from the Level 1 Landsat-8 USGS Public Data Set Clone",
                     "name": "ls8_usgs_level1_scene_layer_clone",
@@ -722,7 +698,7 @@ For service status information, see https://status.dea.ga.gov.au
                             "ignore_time": False,
                             "ignore_info_flags": [],
                             "fuse_func": "datacube_ows.wms_utils.wofls_fuser",
-                        },
+                        }
                     ],
                     "wcs": {
                         "native_crs": "EPSG:3577",
@@ -731,9 +707,7 @@ For service status information, see https://status.dea.ga.gov.au
                     },
                     "styling": {
                         "default_style": "simple_fc",
-                        "styles": [
-                            style_fc_simple,
-                        ],
+                        "styles": [style_fc_simple],
                     },
                 },
                 {
@@ -791,7 +765,7 @@ For service status information, see https://status.dea.ga.gov.au
                             "ignore_time": False,
                             "ignore_info_flags": [],
                             "fuse_func": "datacube_ows.wms_utils.wofls_fuser",
-                        },
+                        }
                     ],
                     "wcs": {
                         "native_crs": "EPSG:3577",
@@ -800,9 +774,7 @@ For service status information, see https://status.dea.ga.gov.au
                     },
                     "styling": {
                         "default_style": "simple_fc",
-                        "styles": [
-                            style_fc_simple,
-                        ],
+                        "styles": [style_fc_simple],
                     },
                 },
                 {
@@ -831,7 +803,7 @@ For service status information, see https://status.dea.ga.gov.au
                             "ignore_time": False,
                             "ignore_info_flags": [],
                             "fuse_func": "datacube_ows.wms_utils.wofls_fuser",
-                        },
+                        }
                     ],
                     "wcs": {
                         "native_crs": "EPSG:3577",
@@ -840,9 +812,7 @@ For service status information, see https://status.dea.ga.gov.au
                     },
                     "styling": {
                         "default_style": "simple_fc",
-                        "styles": [
-                            style_fc_simple,
-                        ],
+                        "styles": [style_fc_simple],
                     },
                 },
                 {
@@ -872,7 +842,7 @@ Fractional Cover version 2.2.1, 25 metre, 100km tile, Australian Albers Equal Ar
                             "ignore_time": False,
                             "ignore_info_flags": [],
                             "fuse_func": "datacube_ows.wms_utils.wofls_fuser",
-                        },
+                        }
                     ],
                     "wcs": {
                         "native_crs": "EPSG:3577",
@@ -881,9 +851,7 @@ Fractional Cover version 2.2.1, 25 metre, 100km tile, Australian Albers Equal Ar
                     },
                     "styling": {
                         "default_style": "simple_fc",
-                        "styles": [
-                            style_fc_simple,
-                        ],
+                        "styles": [style_fc_simple],
                     },
                 },
             ],

--- a/integration_tests/cfg/utils.py
+++ b/integration_tests/cfg/utils.py
@@ -24,7 +24,9 @@ def new_finfo_platform(data, ds):
     return ds.metadata.platform
 
 
-def new_twodate_finfo(data: xr.Dataset, band, band_mapper: Callable | None = None) -> xr.Dataset:
+def new_twodate_finfo(
+    data: xr.Dataset, band, band_mapper: Callable | None = None
+) -> xr.Dataset:
     if band_mapper is not None:
         band = band_mapper(band)
     data1, data2 = (data.sel(time=dt) for dt in data.coords["time"].values)

--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -51,7 +51,9 @@ def runner() -> CliRunner:
 
 
 @pytest.helpers.register
-def enclosed_bbox(bbox: tuple[float, float, float, float], flip: bool = False) -> tuple[float, float, float, float]:
+def enclosed_bbox(
+    bbox: tuple[float, float, float, float], flip: bool = False
+) -> tuple[float, float, float, float]:
     lon_min, lat_min, lon_max, lat_max = bbox
     lon_range = lon_max - lon_min
     lat_range = lat_max - lat_min
@@ -72,7 +74,9 @@ def enclosed_bbox(bbox: tuple[float, float, float, float], flip: bool = False) -
 
 
 @pytest.helpers.register
-def disjoint_bbox(bbox: tuple[float, float, float, float]) -> tuple[float, float, float, float]:
+def disjoint_bbox(
+    bbox: tuple[float, float, float, float],
+) -> tuple[float, float, float, float]:
     lon_min, lat_min, lon_max, lat_max = bbox
     lon_range = lon_max - lon_min
     lat_range = lat_max - lat_min
@@ -84,8 +88,11 @@ def disjoint_bbox(bbox: tuple[float, float, float, float]) -> tuple[float, float
         lat_min - 0.2 * lat_range,
     )
 
+
 @pytest.helpers.register
-def representative_bbox(bbox: tuple[float, float, float, float]) -> tuple[float, float, float, float]:
+def representative_bbox(
+    bbox: tuple[float, float, float, float],
+) -> tuple[float, float, float, float]:
     lon_min, lat_min, lon_max, lat_max = bbox
     lon_range = lon_max - lon_min
     lat_range = lat_max - lat_min

--- a/integration_tests/metadata/metadata_importer.py
+++ b/integration_tests/metadata/metadata_importer.py
@@ -10,8 +10,18 @@ from datacube.index.hl import Doc2Dataset
 dc = Datacube()
 dc_pgis = Datacube(env="owspostgis")
 
-doc2ds = Doc2Dataset(dc.index, products=["s2_l2a", "geodata_coast_100k"], skip_lineage=True, verify_lineage=False)
-doc2ds_pgis = Doc2Dataset(dc_pgis.index, products=["s2_l2a", "geodata_coast_100k"], skip_lineage=True, verify_lineage=False)
+doc2ds = Doc2Dataset(
+    dc.index,
+    products=["s2_l2a", "geodata_coast_100k"],
+    skip_lineage=True,
+    verify_lineage=False,
+)
+doc2ds_pgis = Doc2Dataset(
+    dc_pgis.index,
+    products=["s2_l2a", "geodata_coast_100k"],
+    skip_lineage=True,
+    verify_lineage=False,
+)
 
 for line in fileinput.input():  # noqa: SIM115
     filename, uri = line.split()

--- a/integration_tests/test_cfg_parser.py
+++ b/integration_tests/test_cfg_parser.py
@@ -62,7 +62,15 @@ def test_cfg_parser_msg_file_null(runner) -> None:
 
 
 def test_cfg_parser_msg_file_null_badcfg(runner) -> None:
-    result = runner.invoke(main, ["extract", "-m", "/dev/null", "integration_tests.cfg.ows_test_cfg_bad.ows_cfg"])
+    result = runner.invoke(
+        main,
+        [
+            "extract",
+            "-m",
+            "/dev/null",
+            "integration_tests.cfg.ows_test_cfg_bad.ows_cfg",
+        ],
+    )
     assert result.exit_code == 0
 
 
@@ -85,144 +93,296 @@ def test_cfg_parser_version(runner) -> None:
 
 
 def test_cfg_parser_bad_cfgenv(runner) -> None:
-    result = runner.invoke(main, ["check"], env={"DATACUBE_OWS_CFG": "integration_tests.cfg.ows_test_cfg_bad.ows_cfg"})
+    result = runner.invoke(
+        main,
+        ["check"],
+        env={"DATACUBE_OWS_CFG": "integration_tests.cfg.ows_test_cfg_bad.ows_cfg"},
+    )
     assert result.exit_code == 1
 
 
 def test_cfg_parser_good_cfgarg(runner) -> None:
-    result = runner.invoke(main, ["check", "integration_tests.cfg.ows_test_cfg.ows_cfg"])
+    result = runner.invoke(
+        main, ["check", "integration_tests.cfg.ows_test_cfg.ows_cfg"]
+    )
     assert result.exit_code == 0
 
 
 def test_cfg_parser_bad_cfgarg(runner) -> None:
-    result = runner.invoke(main, ["check", "integration_tests.cfg.ows_test_cfg.ows_cfg", "integration_tests.cfg.ows_test_cfg_bad.ows_cfg"])
+    result = runner.invoke(
+        main,
+        [
+            "check",
+            "integration_tests.cfg.ows_test_cfg.ows_cfg",
+            "integration_tests.cfg.ows_test_cfg_bad.ows_cfg",
+        ],
+    )
     assert result.exit_code == 1
 
 
 def test_cfg_write_new_translation_directory(runner) -> None:
     this_dir = os.path.dirname(__file__)
-    result = runner.invoke(main, ["translation", "-n", "-m", f"{this_dir}/cfg/message.po", "-d", f"{this_dir}/cfg/test_translations", "-D", "ows_cfg", "de"])
+    result = runner.invoke(
+        main,
+        [
+            "translation",
+            "-n",
+            "-m",
+            f"{this_dir}/cfg/message.po",
+            "-d",
+            f"{this_dir}/cfg/test_translations",
+            "-D",
+            "ows_cfg",
+            "de",
+        ],
+    )
     assert result.exit_code == 0
 
 
 def test_cfg_write_update_translation_directory(runner) -> None:
     this_dir = os.path.dirname(__file__)
-    result = runner.invoke(main, ["translation", "-m", f"{this_dir}/cfg/message.po", "-d", f"{this_dir}/cfg/test_translations", "-D", "ows_cfg", "de"])
+    result = runner.invoke(
+        main,
+        [
+            "translation",
+            "-m",
+            f"{this_dir}/cfg/message.po",
+            "-d",
+            f"{this_dir}/cfg/test_translations",
+            "-D",
+            "ows_cfg",
+            "de",
+        ],
+    )
     assert result.exit_code == 0
 
 
 def test_cfg_write_new_translation_directory_cfg(runner) -> None:
     this_dir = os.path.dirname(__file__)
-    result = runner.invoke(main, ["translation", "-n",
-                                  "-d", f"{this_dir}/cfg/test_translations",
-                                  "-D", "ows_cfg",
-                                  "-c", "integration_tests.cfg.ows_test_cfg.ows_cfg",
-                                  "de"])
+    result = runner.invoke(
+        main,
+        [
+            "translation",
+            "-n",
+            "-d",
+            f"{this_dir}/cfg/test_translations",
+            "-D",
+            "ows_cfg",
+            "-c",
+            "integration_tests.cfg.ows_test_cfg.ows_cfg",
+            "de",
+        ],
+    )
     assert result.exit_code == 0
 
 
 def test_cfg_write_new_translation_directory_all_langs(runner) -> None:
     this_dir = os.path.dirname(__file__)
-    result = runner.invoke(main, ["translation", "-n", "-m", f"{this_dir}/cfg/message.po", "-d", f"{this_dir}/cfg/test_translations", "-D", "ows_cfg", "all"])
+    result = runner.invoke(
+        main,
+        [
+            "translation",
+            "-n",
+            "-m",
+            f"{this_dir}/cfg/message.po",
+            "-d",
+            f"{this_dir}/cfg/test_translations",
+            "-D",
+            "ows_cfg",
+            "all",
+        ],
+    )
     assert result.exit_code == 0
 
 
 def test_cfg_write_update_translation_directory_all_langs(runner) -> None:
     this_dir = os.path.dirname(__file__)
-    result = runner.invoke(main, ["translation", "-m", f"{this_dir}/cfg/message.po", "-d", f"{this_dir}/cfg/test_translations", "-D", "ows_cfg", "all"])
+    result = runner.invoke(
+        main,
+        [
+            "translation",
+            "-m",
+            f"{this_dir}/cfg/message.po",
+            "-d",
+            f"{this_dir}/cfg/test_translations",
+            "-D",
+            "ows_cfg",
+            "all",
+        ],
+    )
     assert result.exit_code == 0
 
 
 def test_cfg_write_new_translation_directory_all_bad_cfg(runner) -> None:
     this_dir = os.path.dirname(__file__)
-    result = runner.invoke(main, ["translation", "-n",
-                                  "-m", f"{this_dir}/cfg/message.po",
-                                  "-d", f"{this_dir}/cfg/test_translations",
-                                  "-D", "ows_cfg",
-                                  "-c", "integration_tests.cfg.ows_test_cfg_bad.ows_cfg",
-                                  "all"])
+    result = runner.invoke(
+        main,
+        [
+            "translation",
+            "-n",
+            "-m",
+            f"{this_dir}/cfg/message.po",
+            "-d",
+            f"{this_dir}/cfg/test_translations",
+            "-D",
+            "ows_cfg",
+            "-c",
+            "integration_tests.cfg.ows_test_cfg_bad.ows_cfg",
+            "all",
+        ],
+    )
     assert result.exit_code == 1
 
 
 def test_cfg_write_new_translation_directory_no_domain(runner) -> None:
     this_dir = os.path.dirname(__file__)
-    result = runner.invoke(main, ["translation", "-n",
-                                  "-m", f"{this_dir}/cfg/message.po",
-                                  "-d", f"{this_dir}/cfg/test_translations",
-                                  "all"])
+    result = runner.invoke(
+        main,
+        [
+            "translation",
+            "-n",
+            "-m",
+            f"{this_dir}/cfg/message.po",
+            "-d",
+            f"{this_dir}/cfg/test_translations",
+            "all",
+        ],
+    )
     assert result.exit_code == 0
 
 
 def test_cfg_write_new_translation_directory_no_msg_file(runner) -> None:
     this_dir = os.path.dirname(__file__)
-    result = runner.invoke(main, ["translation", "-n",
-                                  "-d", f"{this_dir}/cfg/test_translations",
-                                  "-D", "ows_cfg",
-                                  "-c", "integration_tests.cfg.ows_test_cfg_bad.ows_cfg",
-                                  "all"])
+    result = runner.invoke(
+        main,
+        [
+            "translation",
+            "-n",
+            "-d",
+            f"{this_dir}/cfg/test_translations",
+            "-D",
+            "ows_cfg",
+            "-c",
+            "integration_tests.cfg.ows_test_cfg_bad.ows_cfg",
+            "all",
+        ],
+    )
     assert result.exit_code == 1
+
 
 def test_cfg_write_new_translation_directory_missing_msg_file(runner) -> None:
     this_dir = os.path.dirname(__file__)
-    result = runner.invoke(main, ["translation", "-n",
-                                  "-d", f"{this_dir}/cfg/test_translations",
-                                  "-m", f"{this_dir}/cfg/non_existent_file.po",
-                                  "-D", "ows_cfg",
-                                  "all"])
+    result = runner.invoke(
+        main,
+        [
+            "translation",
+            "-n",
+            "-d",
+            f"{this_dir}/cfg/test_translations",
+            "-m",
+            f"{this_dir}/cfg/non_existent_file.po",
+            "-D",
+            "ows_cfg",
+            "all",
+        ],
+    )
     assert result.exit_code == 1
+
 
 def test_cfg_write_translation_directory_cfg_directory(runner) -> None:
     this_dir = os.path.dirname(__file__)
-    result = runner.invoke(main, ["translation",
-                                  "-m", f"{this_dir}/cfg/message.po",
-                                  "-D", "ows_cfg",
-                                  "all"])
+    result = runner.invoke(
+        main,
+        ["translation", "-m", f"{this_dir}/cfg/message.po", "-D", "ows_cfg", "all"],
+    )
     assert result.exit_code == 0
+
 
 def test_cfg_write_new_translation_directory_no_directory(runner) -> None:
     this_dir = os.path.dirname(__file__)
-    result = runner.invoke(main, ["translation", "-n",
-                                  "-m", f"{this_dir}/cfg/message.po",
-                                  "-D", "ows_cfg",
-                                  "-c", "integration_tests.cfg.ows_test_cfg_no_i18n.ows_cfg",
-                                  "all"])
+    result = runner.invoke(
+        main,
+        [
+            "translation",
+            "-n",
+            "-m",
+            f"{this_dir}/cfg/message.po",
+            "-D",
+            "ows_cfg",
+            "-c",
+            "integration_tests.cfg.ows_test_cfg_no_i18n.ows_cfg",
+            "all",
+        ],
+    )
     assert result.exit_code == 1
-    result = runner.invoke(main, ["translation", "-n",
-                                  "-D", "ows_cfg",
-                                  "-d", f"{this_dir}/cfg/test_translations",
-                                  "-c", "integration_tests.cfg.ows_test_cfg_no_i18n.ows_cfg",
-                                  "all"])
+    result = runner.invoke(
+        main,
+        [
+            "translation",
+            "-n",
+            "-D",
+            "ows_cfg",
+            "-d",
+            f"{this_dir}/cfg/test_translations",
+            "-c",
+            "integration_tests.cfg.ows_test_cfg_no_i18n.ows_cfg",
+            "all",
+        ],
+    )
     assert result.exit_code == 1
 
 
 def test_cfg_new_translation_no_language(runner) -> None:
     this_dir = os.path.dirname(__file__)
-    result = runner.invoke(main, ["translation", "-n", "-m", f"{this_dir}/cfg/message.po", "-d", f"{this_dir}/cfg/test_translations", "-D", "ows_cfg"])
+    result = runner.invoke(
+        main,
+        [
+            "translation",
+            "-n",
+            "-m",
+            f"{this_dir}/cfg/message.po",
+            "-d",
+            f"{this_dir}/cfg/test_translations",
+            "-D",
+            "ows_cfg",
+        ],
+    )
     assert result.exit_code == 1
 
 
 @pytest.mark.xfail(reason="Permission denied")
 def test_cfg_parser_compile(runner) -> None:
     this_dir = os.path.dirname(__file__)
-    result = runner.invoke(main, ["compile", "-d", f"{this_dir}/cfg/test_translations", "-D", "ows_cfg", "en"])
+    result = runner.invoke(
+        main,
+        ["compile", "-d", f"{this_dir}/cfg/test_translations", "-D", "ows_cfg", "en"],
+    )
     assert result.exit_code == 0
+
 
 @pytest.mark.xfail(reason="Permission denied")
 def test_cfg_parser_compile_all(runner) -> None:
     this_dir = os.path.dirname(__file__)
-    result = runner.invoke(main, ["compile", "-d", f"{this_dir}/cfg/test_translations", "-D", "ows_cfg", "all"])
+    result = runner.invoke(
+        main,
+        ["compile", "-d", f"{this_dir}/cfg/test_translations", "-D", "ows_cfg", "all"],
+    )
     assert result.exit_code == 0
 
 
 def test_cfg_parser_compile_no_lang(runner) -> None:
     this_dir = os.path.dirname(__file__)
-    result = runner.invoke(main, ["compile", "-d", f"{this_dir}/cfg/test_translations", "-D", "ows_cfg"])
+    result = runner.invoke(
+        main, ["compile", "-d", f"{this_dir}/cfg/test_translations", "-D", "ows_cfg"]
+    )
     assert result.exit_code == 1
 
 
 def test_cfg_parser_compile_no_domain(runner) -> None:
     this_dir = os.path.dirname(__file__)
-    result = runner.invoke(main, ["compile", "-d", f"{this_dir}/cfg/test_translations", "en"])
+    result = runner.invoke(
+        main, ["compile", "-d", f"{this_dir}/cfg/test_translations", "en"]
+    )
     assert result.exit_code == 0
 
 
@@ -233,13 +393,24 @@ def test_cfg_parser_compile_default_dir(runner) -> None:
 
 
 def test_cfg_parser_compile_no_dir(runner) -> None:
-    result = runner.invoke(main, ["compile", "-c", "integration_tests.cfg.ows_test_cfg_no_i18n.ows_cfg", "en"])
+    result = runner.invoke(
+        main,
+        ["compile", "-c", "integration_tests.cfg.ows_test_cfg_no_i18n.ows_cfg", "en"],
+    )
     assert result.exit_code == 1
+
 
 def test_cfg_parser_compile_bad_cfg(runner) -> None:
     this_dir = os.path.dirname(__file__)
-    result = runner.invoke(main, ["compile",
-                                  "-c", "integration_tests.cfg.ows_test_cfg_bad.ows_cfg",
-                                  "-d", f"{this_dir}/cfg/test_translations",
-                                  "en"])
+    result = runner.invoke(
+        main,
+        [
+            "compile",
+            "-c",
+            "integration_tests.cfg.ows_test_cfg_bad.ows_cfg",
+            "-d",
+            f"{this_dir}/cfg/test_translations",
+            "en",
+        ],
+    )
     assert result.exit_code == 1

--- a/integration_tests/test_i18n.py
+++ b/integration_tests/test_i18n.py
@@ -11,16 +11,17 @@ def test_wms_i18n(ows_server) -> None:
     resp = retrying_requests.get(
         ows_server.url + "/wms?request=GetCapabilities&service=WMS&version=1.3.0",
         timeout=10,
-        headers={"Accept-Language": "de"}
+        headers={"Accept-Language": "de"},
     )
     assert resp.status_code == 200
     assert "German translation" in resp.text
+
 
 def test_wcs1_i18n(ows_server) -> None:
     resp = retrying_requests.get(
         ows_server.url + "/wcs?request=GetCapabilities&service=WCS&version=1.0.0",
         timeout=10,
-        headers={"Accept-Language": "de"}
+        headers={"Accept-Language": "de"},
     )
     assert resp.status_code == 200
     assert "German translation" in resp.text
@@ -28,9 +29,11 @@ def test_wcs1_i18n(ows_server) -> None:
 
 def test_wcs1_bands_i18n(ows_server, product_name: str) -> None:
     resp = retrying_requests.get(
-        ows_server.url + "/wcs?request=DescribeCoverage&service=WCS&version=1.0.0&coverageid=" + product_name,
+        ows_server.url
+        + "/wcs?request=DescribeCoverage&service=WCS&version=1.0.0&coverageid="
+        + product_name,
         timeout=10,
-        headers={"Accept-Language": "de"}
+        headers={"Accept-Language": "de"},
     )
     assert resp.status_code == 200
     assert "gruen" in resp.text
@@ -40,7 +43,7 @@ def test_wcs2_i18n(ows_server) -> None:
     resp = retrying_requests.get(
         ows_server.url + "/wcs?request=GetCapabilities&service=WCS&version=2.0.1",
         timeout=10,
-        headers={"Accept-Language": "de"}
+        headers={"Accept-Language": "de"},
     )
     assert resp.status_code == 200
     assert "German translation" in resp.text
@@ -48,9 +51,11 @@ def test_wcs2_i18n(ows_server) -> None:
 
 def test_wcs2_bands_i18n(ows_server, product_name: str) -> None:
     resp = retrying_requests.get(
-        ows_server.url + "/wcs?request=DescribeCoverage&service=WCS&version=2.0.1&coverageid=" + product_name,
+        ows_server.url
+        + "/wcs?request=DescribeCoverage&service=WCS&version=2.0.1&coverageid="
+        + product_name,
         timeout=10,
-        headers={"Accept-Language": "de"}
+        headers={"Accept-Language": "de"},
     )
     assert resp.status_code == 200
     assert "gruen" in resp.text

--- a/integration_tests/test_layers.py
+++ b/integration_tests/test_layers.py
@@ -10,6 +10,7 @@ from datacube_ows.ows_configuration import OWSConfig, get_config, read_config
 
 src_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
+
 def test_metadata_export() -> None:
     cfg = get_config(refresh=True)
 

--- a/integration_tests/test_routes.py
+++ b/integration_tests/test_routes.py
@@ -4,8 +4,7 @@
 # Copyright (c) 2017-2024 OWS Contributors
 # SPDX-License-Identifier: Apache-2.0
 
-"""Run with DB to simulate actual function
-"""
+"""Run with DB to simulate actual function"""
 
 
 def test_db_connect_success(flask_client) -> None:

--- a/integration_tests/test_update_ranges.py
+++ b/integration_tests/test_update_ranges.py
@@ -7,6 +7,7 @@
 """Test update ranges on DB using Click testing
 https://click.palletsprojects.com/en/7.x/testing/
 """
+
 from datacube_ows.update_ranges_impl import main
 
 
@@ -23,31 +24,70 @@ def test_update_ranges_schema_without_roles(runner) -> None:
     assert result.exit_code == 0
 
 
-def test_update_ranges_schema_with_roles(runner, read_role_name: str, write_role_name: str) -> None:
-    result = runner.invoke(main, ["--schema", "--read-role", read_role_name, "--write-role", write_role_name])
+def test_update_ranges_schema_with_roles(
+    runner, read_role_name: str, write_role_name: str
+) -> None:
+    result = runner.invoke(
+        main,
+        ["--schema", "--read-role", read_role_name, "--write-role", write_role_name],
+    )
     assert "appear to be missing" not in result.output
     assert "Insufficient Privileges" not in result.output
     assert "Cannot find SQL resource" not in result.output
     assert result.exit_code == 0
-    result = runner.invoke(main, ["-E", "owspostgis",
-                                  "--schema", "--read-role", read_role_name, "--write-role", write_role_name])
+    result = runner.invoke(
+        main,
+        [
+            "-E",
+            "owspostgis",
+            "--schema",
+            "--read-role",
+            read_role_name,
+            "--write-role",
+            write_role_name,
+        ],
+    )
     assert "appear to be missing" not in result.output
     assert "Insufficient Privileges" not in result.output
     assert "Cannot find SQL resource" not in result.output
     assert result.exit_code == 0
-    result = runner.invoke(main, ["-E", "nonononodontcallanenviornmentthis",
-                                  "--schema", "--read-role", read_role_name, "--write-role", write_role_name])
+    result = runner.invoke(
+        main,
+        [
+            "-E",
+            "nonononodontcallanenviornmentthis",
+            "--schema",
+            "--read-role",
+            read_role_name,
+            "--write-role",
+            write_role_name,
+        ],
+    )
     assert "Unable to connect to the nonono" in result.output
     assert result.exit_code == 1
 
 
-def test_update_ranges_roles_only(runner, read_role_name: str, write_role_name: str) -> None:
-    result = runner.invoke(main, ["--read-role", read_role_name, "--write-role", write_role_name])
+def test_update_ranges_roles_only(
+    runner, read_role_name: str, write_role_name: str
+) -> None:
+    result = runner.invoke(
+        main, ["--read-role", read_role_name, "--write-role", write_role_name]
+    )
     assert "appear to be missing" not in result.output
     assert "Insufficient Privileges" not in result.output
     assert "Cannot find SQL resource" not in result.output
     assert result.exit_code == 0
-    result = runner.invoke(main, ["-E", "owspostgis", "--read-role", read_role_name, "--write-role", write_role_name])
+    result = runner.invoke(
+        main,
+        [
+            "-E",
+            "owspostgis",
+            "--read-role",
+            read_role_name,
+            "--write-role",
+            write_role_name,
+        ],
+    )
     assert "appear to be missing" not in result.output
     assert "Insufficient Privileges" not in result.output
     assert "Cannot find SQL resource" not in result.output

--- a/integration_tests/test_version.py
+++ b/integration_tests/test_version.py
@@ -7,6 +7,7 @@
 """Test update ranges on DB using Click testing
 https://click.palletsprojects.com/en/7.x/testing/
 """
+
 from datacube_ows.__init__ import __version__
 from datacube_ows.update_ranges_impl import main
 

--- a/integration_tests/test_wcs_server.py
+++ b/integration_tests/test_wcs_server.py
@@ -135,11 +135,7 @@ def test_wcs1_server(ows_server) -> None:
 def test_wcs1_getcov_nocov(ows_server) -> None:
     check_wcs_error(
         ows_server.url + "/wcs",
-        params={
-            "request": "GetCoverage",
-            "service": "WCS",
-            "version": "1.0.0",
-        },
+        params={"request": "GetCoverage", "service": "WCS", "version": "1.0.0"},
         expected_error_message="No coverage specified",
         expected_status_code=400,
     )
@@ -283,7 +279,7 @@ def test_wcs1_multi_time_exceptions(ows_server) -> None:
             "crs": "EPSG:4326",
             "format": "GeoTIFF",
             "bbox": extents["bbox"],
-            "time": extents['times'],
+            "time": extents["times"],
             "resx": 0.01,
             "resy": 0.01,
         },
@@ -608,6 +604,7 @@ def test_wcs1_style(ows_server) -> None:
     )
     assert r.status_code == 200
 
+
 def test_wcs1_ows_stats(ows_server) -> None:
     wcs = WebCoverageService(url=ows_server.url + "/wcs", version="1.0.0", timeout=120)
     contents = list(wcs.contents)
@@ -633,7 +630,7 @@ def test_wcs1_ows_stats(ows_server) -> None:
             "styles": "simple_rgb",
             "resx": "0.01",
             "resy": "0.01",
-            "ows_stats": "y"
+            "ows_stats": "y",
         },
     )
     assert r.status_code == 200
@@ -1014,10 +1011,7 @@ def test_wcs1_describecov_badcov(ows_server) -> None:
 def test_wcs1_describecov_all(ows_server) -> None:
     r = retrying_requests.get(
         ows_server.url + "/wcs",
-        params={
-            "request": "DescribeCoverage",
-            "version": "1.0.0",
-        },
+        params={"request": "DescribeCoverage", "version": "1.0.0"},
     )
     assert r.status_code == 200
 
@@ -1101,10 +1095,7 @@ def test_wcs20_getcoverage_geotiff_bigimage(ows_server) -> None:
     assert "too much data for a single request" in str(e.value)
     # Test default request
     with pytest.raises(ServiceException) as e:
-        _ = wcs.getCoverage(
-            identifier=[layer.name],
-            format="application/x-netcdf",
-        )
+        _ = wcs.getCoverage(identifier=[layer.name], format="application/x-netcdf")
     assert "too much data for a single request" in str(e.value)
 
 
@@ -1141,7 +1132,7 @@ def test_wcs20_getcoverage_crs_alias(ows_server) -> None:
     # Ensure that we have at least some layers available
     contents = list(wcs.contents)
     for lyr_name in contents:
-        if not lyr_name.startswith('s2_l'):
+        if not lyr_name.startswith("s2_l"):
             layer = cfg.layer_index[lyr_name]
             break
     extent = ODCExtent(layer)
@@ -1153,7 +1144,11 @@ def test_wcs20_getcoverage_crs_alias(ows_server) -> None:
         format="application/x-netcdf",
         # to select the subset, find one valid coordination and replace the
         # number and keep the .3 and .4
-        subsets=[("x", 131.0, 131.2), ("y", -12.1, -11.9), ("time", "2017-08-03", "2017-08-08")],
+        subsets=[
+            ("x", 131.0, 131.2),
+            ("y", -12.1, -11.9),
+            ("time", "2017-08-03", "2017-08-08"),
+        ],
         subsettingcrs="I-CANT-BELIEVE-ITS-NOT-EPSG:4326",
         scalesize="x(400),y(300)",
         timeout=90,
@@ -1211,9 +1206,10 @@ def test_wcs20_getcoverage_multidate_netcdf(ows_server) -> None:
             subsets=subsets,
             subsettingcrs="EPSG:4326",
             scalesize="x(400),y(300)",
-            timeout=90
+            timeout=90,
         )
         assert resp
+
 
 def test_wcs21_server(ows_server) -> None:
     # N.B. At time of writing owslib does not support WCS 2.1, so we have to make requests manually.
@@ -1293,6 +1289,7 @@ def test_wcs21_getcoverage(ows_server) -> None:
     )
     assert r.status_code == 200
 
+
 def test_wcs21_ows_stats(ows_server) -> None:
     cfg = get_config(refresh=True)
     layer = None
@@ -1317,7 +1314,7 @@ def test_wcs21_ows_stats(ows_server) -> None:
             "subsettingcrs": "EPSG:4326",
             "scalesize": "x(400),y(400)",
             "subset": subsets,
-            "ows_stats": "y"
+            "ows_stats": "y",
         },
     )
     assert r.status_code == 200
@@ -1426,11 +1423,7 @@ def test_wcs2_getcov_trim_time(ows_server) -> None:
         ODCExtent.OFFSET_SUBSET_FOR_TIMES, ODCExtent.FIRST_TWO
     )
     if len(subsets[2].split(",")) == 1:
-        subsets = [
-            subsets[0],
-            subsets[1],
-            'time("2021-12-30","2022-01-01")'
-        ]
+        subsets = [subsets[0], subsets[1], 'time("2021-12-30","2022-01-01")']
 
     r = retrying_requests.get(
         ows_server.url + "/wcs",
@@ -1447,6 +1440,7 @@ def test_wcs2_getcov_trim_time(ows_server) -> None:
     )
     assert r.status_code == 200
 
+
 def test_wcs2_getcov_badtrim_time(ows_server) -> None:
     cfg = get_config(refresh=True)
     layer = None
@@ -1459,11 +1453,7 @@ def test_wcs2_getcov_badtrim_time(ows_server) -> None:
     subsets = extent.raw_wcs2_subsets(
         ODCExtent.OFFSET_SUBSET_FOR_TIMES, ODCExtent.FIRST_TWO
     )
-    subsets = [
-        subsets[0],
-        subsets[1],
-        'time("2021-12-30","2021-12-31","2022-01-01")'
-    ]
+    subsets = [subsets[0], subsets[1], 'time("2021-12-30","2021-12-31","2022-01-01")']
 
     check_wcs_error(
         ows_server.url + "/wcs",
@@ -1661,6 +1651,8 @@ def test_wcs2_getcov_styles(ows_server) -> None:
         },
     )
     assert r.status_code == 200
+
+
 # WCS2 style parameter disabled.
 #    r = retrying_requests.get(
 #       ows_server.url + "/wcs",
@@ -1853,7 +1845,7 @@ def test_wcs2_getcov_native_format(ows_server) -> None:
     cfg = get_config(refresh=True)
     layer = None
     for lyr in cfg.layer_index.values():
-        if lyr.ready and not lyr.hide and not lyr.name.startswith('s2_l'):
+        if lyr.ready and not lyr.hide and not lyr.name.startswith("s2_l"):
             layer = lyr
             break
     assert layer

--- a/integration_tests/test_wms_server.py
+++ b/integration_tests/test_wms_server.py
@@ -16,13 +16,15 @@ from datacube_ows.legend_utils import retrying_requests
 
 
 def get_xsd(name: str) -> etree.XMLSchema:
-    path = Path(__file__).resolve().parent.parent / 'wms_xsds' / name
+    path = Path(__file__).resolve().parent.parent / "wms_xsds" / name
     with open(path) as xsd_f:
         schema_doc = etree.parse(xsd_f)
     return etree.XMLSchema(schema_doc)
 
 
-def check_wms_error(url, expected_error_message=None, expected_status_code: int = 400) -> None:
+def check_wms_error(
+    url, expected_error_message=None, expected_status_code: int = 400
+) -> None:
     with pytest.raises(Exception) as e:
         _ = request.urlopen(url, timeout=10)
     # Validate status code
@@ -37,9 +39,7 @@ def check_wms_error(url, expected_error_message=None, expected_status_code: int 
 
     # Confirm error message is appropriate, ignore case
     if expected_error_message:
-        assert (
-            resp_xml[0].text.strip().casefold() == expected_error_message.casefold()
-        )
+        assert resp_xml[0].text.strip().casefold() == expected_error_message.casefold()
 
 
 def test_no_request(ows_server) -> None:
@@ -107,7 +107,9 @@ def test_getcap_response(ows_server) -> None:
         geo_bbox = layer.findall(
             "./{http://www.opengis.net/wms}BoundingBox[@CRS='EPSG:4326']"
         )[0]
-        assert math.isclose(float(wLong.text), float(geo_bbox.attrib["miny"]), rel_tol=1e-8)
+        assert math.isclose(
+            float(wLong.text), float(geo_bbox.attrib["miny"]), rel_tol=1e-8
+        )
 
 
 def test_wms_server(ows_server) -> None:
@@ -119,7 +121,7 @@ def test_wms_server(ows_server) -> None:
     # Ensure that we have expected layers
     assert "s2_ard_granule_nbar_t" in wms.contents
     # Ensure that bad layers are hidden
-    assert 'spaghetti_gateaux' not in wms.contents
+    assert "spaghetti_gateaux" not in wms.contents
 
 
 def test_wms_getmap(ows_server) -> None:
@@ -149,72 +151,85 @@ def test_wms_getmap(ows_server) -> None:
 
 
 def test_wms_getmap_requests(ows_server, product_name: str) -> None:
-    resp = retrying_requests.get(ows_server.url + '/wms', params={
-        "service": "WMS",
-        "version": "1.3.0",
-        "request": "GetMap",
-        "layers": product_name,
-        "width": "150",
-        "height": "150",
-        "crs": "EPSG:4326",
-        "bbox": "-15.28507087113431,123.98504300790977,-14.27072582535469,124.64289867785524",
-        "format": "image/png",
-        "exceptions": "XML",
-        "time": "2021-12-31 02:01:38"
-    })
+    resp = retrying_requests.get(
+        ows_server.url + "/wms",
+        params={
+            "service": "WMS",
+            "version": "1.3.0",
+            "request": "GetMap",
+            "layers": product_name,
+            "width": "150",
+            "height": "150",
+            "crs": "EPSG:4326",
+            "bbox": "-15.28507087113431,123.98504300790977,-14.27072582535469,124.64289867785524",
+            "format": "image/png",
+            "exceptions": "XML",
+            "time": "2021-12-31 02:01:38",
+        },
+    )
     # Confirm success
     assert resp.status_code == 200
 
+
 def test_wms_getmap_bad_requests(ows_server) -> None:
-    resp = retrying_requests.get(ows_server.url + '/wms', params={
-        "service": "WMS",
-        "version": "1.3.0",
-        "request": "GetMap",
-        "layers": "s2_l2a,some_other_layer",
-        "width": "150",
-        "height": "150",
-        "crs": "EPSG:4326",
-        "bbox": "-43.28507087113431,146.18504300790977,-43.07072582535469,146.64289867785524",
-        "format": "image/png",
-        "exceptions": "XML",
-        "time": "2019-07-09"
-    })
+    resp = retrying_requests.get(
+        ows_server.url + "/wms",
+        params={
+            "service": "WMS",
+            "version": "1.3.0",
+            "request": "GetMap",
+            "layers": "s2_l2a,some_other_layer",
+            "width": "150",
+            "height": "150",
+            "crs": "EPSG:4326",
+            "bbox": "-43.28507087113431,146.18504300790977,-43.07072582535469,146.64289867785524",
+            "format": "image/png",
+            "exceptions": "XML",
+            "time": "2019-07-09",
+        },
+    )
     # Confirm success
     assert resp.status_code == 400
     assert "Multi-layer requests not supported" in resp.text
-    resp = retrying_requests.get(ows_server.url + '/wms', params={
-        "service": "WMS",
-        "version": "1.3.0",
-        "request": "GetMap",
-        "layers": "not_a_real_layer",
-        "width": "150",
-        "height": "150",
-        "crs": "EPSG:4326",
-        "bbox": "-43.28507087113431,146.18504300790977,-43.07072582535469,146.64289867785524",
-        "format": "image/png",
-        "exceptions": "XML",
-        "time": "2019-07-09"
-    })
+    resp = retrying_requests.get(
+        ows_server.url + "/wms",
+        params={
+            "service": "WMS",
+            "version": "1.3.0",
+            "request": "GetMap",
+            "layers": "not_a_real_layer",
+            "width": "150",
+            "height": "150",
+            "crs": "EPSG:4326",
+            "bbox": "-43.28507087113431,146.18504300790977,-43.07072582535469,146.64289867785524",
+            "format": "image/png",
+            "exceptions": "XML",
+            "time": "2019-07-09",
+        },
+    )
     # Confirm success
     assert resp.status_code == 400
     assert "Layer not_a_real_layer is not defined" in resp.text
 
 
 def test_wms_getmap_qprof(ows_server, product_name: str) -> None:
-    resp = retrying_requests.get(ows_server.url + '/wms', params={
-                            "service": "WMS",
-                            "version": "1.3.0",
-                            "request": "GetMap",
-                            "layers": product_name,
-                            "width": "150",
-                            "height": "150",
-                            "crs": "EPSG:4326",
-                            "bbox": "-15.28507087113431,123.98504300790977,-14.27072582535469,124.64289867785524",
-                            "format": "image/png",
-                            "exceptions": "XML",
-                            "time": "2021-12-31 02:01:38",
-                            "ows_stats": "yes"
-    })
+    resp = retrying_requests.get(
+        ows_server.url + "/wms",
+        params={
+            "service": "WMS",
+            "version": "1.3.0",
+            "request": "GetMap",
+            "layers": product_name,
+            "width": "150",
+            "height": "150",
+            "crs": "EPSG:4326",
+            "bbox": "-15.28507087113431,123.98504300790977,-14.27072582535469,124.64289867785524",
+            "format": "image/png",
+            "exceptions": "XML",
+            "time": "2021-12-31 02:01:38",
+            "ows_stats": "yes",
+        },
+    )
     # Confirm success
     assert resp.status_code == 200
     js = resp.json()
@@ -252,8 +267,7 @@ def test_wms_multidate_getmap(ows_server) -> None:
         layers=["s2_l2a"],
         styles=["ndvi_delta"],
         srs="EPSG:4326",
-        bbox=(122.32, -15.25,
-              124.64, -12.66),
+        bbox=(122.32, -15.25, 124.64, -12.66),
         size=(150, 150),
         format="image/png",
         transparent=True,
@@ -268,7 +282,7 @@ def test_wms_style_looping_getmap(ows_server) -> None:
 
     # Ensure that we have at least some layers available
     test_layer_names = ["s2_l2a", "s2_l2a_clone"]
-    test_time = '2021-12-21T02:01:19'
+    test_time = "2021-12-21T02:01:19"
     for test_layer_name in test_layer_names:
         test_layer = wms.contents[test_layer_name]
 
@@ -305,8 +319,8 @@ def test_wms_getfeatureinfo(ows_server) -> None:
             test_times = [None]
         elif len(test_times) > 8:
             test_times = [test_times[0], test_times[6], test_times[-1]]
-        elif len(test_times) == 1 and '/' in test_times[0]:
-            test_times = test_times[0].split('/')
+        elif len(test_times) == 1 and "/" in test_times[0]:
+            test_times = test_times[0].split("/")
             test_times = list(test_times[0:2])
         for test_time in test_times:
             bbox = test_layer.boundingBoxWGS84
@@ -345,24 +359,29 @@ def test_custom_feature_info(ows_server, product_name: str) -> None:
     wms = WebMapService(url=ows_server.url + "/wms", version="1.3.0", timeout=300)
 
     test_layer = wms.contents[product_name]
-    query_times = ['2021-12-21T02:01:19', '2021-12-26T02:01:29']
+    query_times = ["2021-12-21T02:01:19", "2021-12-26T02:01:29"]
     bbox = test_layer.boundingBoxWGS84
-    response = retrying_requests.get(ows_server.url + '/wms', params={
-        "service": "WMS",
-        "version": "1.3.0",
-        "request": "GetFeatureInfo",
-        "query_layers": product_name,
-        "width": "256",
-        "height": "256",
-        "crs": "EPSG:4326",
-        "bbox": ",".join(str(f) for f in pytest.helpers.enclosed_bbox(bbox, flip=True)),
-        "info_format": "application/json",
-        "feature_count": "20",
-        "styles": "ndvi_delta",
-        "time": ",".join(query_times),
-        "i": "250",
-        "j": "250",
-    })
+    response = retrying_requests.get(
+        ows_server.url + "/wms",
+        params={
+            "service": "WMS",
+            "version": "1.3.0",
+            "request": "GetFeatureInfo",
+            "query_layers": product_name,
+            "width": "256",
+            "height": "256",
+            "crs": "EPSG:4326",
+            "bbox": ",".join(
+                str(f) for f in pytest.helpers.enclosed_bbox(bbox, flip=True)
+            ),
+            "info_format": "application/json",
+            "feature_count": "20",
+            "styles": "ndvi_delta",
+            "time": ",".join(query_times),
+            "i": "250",
+            "j": "250",
+        },
+    )
     assert response.status_code == 200
     js = response.json()
     feature = js["features"][0]
@@ -392,17 +411,17 @@ def test_wms_getlegend(ows_server) -> None:
         # check if this layer has a legend
         legend_url = test_layer_styles[style].get("legend")
         if legend_url:
-            resp = retrying_requests.head(legend_url, headers={
-                                "Accept-Language": "en-US,en,q=0.7"
-                            },
-                            allow_redirects=False
+            resp = retrying_requests.head(
+                legend_url,
+                headers={"Accept-Language": "en-US,en,q=0.7"},
+                allow_redirects=False,
             )
             assert resp.status_code == 200
             assert resp.headers.get("content-type") == "image/png"
-            resp = retrying_requests.head(legend_url, headers={
-                                "Accept-Language": "sw,sw,q=0.7"
-                            },
-                        allow_redirects=False
+            resp = retrying_requests.head(
+                legend_url,
+                headers={"Accept-Language": "sw,sw,q=0.7"},
+                allow_redirects=False,
             )
             assert resp.status_code == 200
             assert resp.headers.get("content-type") == "image/png"

--- a/integration_tests/test_wmts_server.py
+++ b/integration_tests/test_wmts_server.py
@@ -22,7 +22,9 @@ def get_xsd(name: str) -> etree.XMLSchema:
     return etree.XMLSchema(schema_doc)
 
 
-def check_wmts_error(url, expected_error_message=None, expected_status_code: int = 400) -> None:
+def check_wmts_error(
+    url, expected_error_message=None, expected_status_code: int = 400
+) -> None:
     with pytest.raises(Exception) as e:
         _ = request.urlopen(url, timeout=10)
     # Validate status code
@@ -131,11 +133,14 @@ def test_wmts_gettile(ows_server) -> None:
     assert tile
     assert tile.info()["Content-Type"] == "image/png"
 
+
 def test_wmts_getfeatinfo(ows_server) -> None:
-    url = ows_server.url + ("/wmts?SERVICE=WMTS&REQUEST=GetFeatureInfo&VERSION=1.0.0&" +
-                            "LAYER=s2_l2a&STYLE=simple_rgb&" +
-                            "TILEMATRIXSET=WholeWorld_WebMercator&TILEMATRIX=13&" +
-                            "TILEROW=5171&TILECOL=7458&I=102&J=204&INFOFORMAT=application%2Fjson")
+    url = ows_server.url + (
+        "/wmts?SERVICE=WMTS&REQUEST=GetFeatureInfo&VERSION=1.0.0&"
+        + "LAYER=s2_l2a&STYLE=simple_rgb&"
+        + "TILEMATRIXSET=WholeWorld_WebMercator&TILEMATRIX=13&"
+        + "TILEROW=5171&TILECOL=7458&I=102&J=204&INFOFORMAT=application%2Fjson"
+    )
     resp = retrying_requests.get(url)
     assert resp.status_code == 200
     assert resp.headers["content-type"] == "application/json"
@@ -144,55 +149,67 @@ def test_wmts_getfeatinfo(ows_server) -> None:
 
 
 def test_wmts_gettile_errwrap(ows_server) -> None:
-    url = ows_server.url + ("/wmts?SERVICE=WMTS&REQUEST=GetTile&VERSION=1.0.0&" +
-                            "LAYER=s2_l2a&STYLE=simple_rgb&" +
-                            "TILEMATRIXSET=WholeWorld_WebMercator&TILEMATRIX=13&" +
-                            "TILEROW=5171&TILECOL=7458FORMAT=image%2Fjpg")
+    url = ows_server.url + (
+        "/wmts?SERVICE=WMTS&REQUEST=GetTile&VERSION=1.0.0&"
+        + "LAYER=s2_l2a&STYLE=simple_rgb&"
+        + "TILEMATRIXSET=WholeWorld_WebMercator&TILEMATRIX=13&"
+        + "TILEROW=5171&TILECOL=7458FORMAT=image%2Fjpg"
+    )
     resp = retrying_requests.get(url)
     assert resp.status_code == 400
 
 
 def test_wmts_getfeatinfo_errwrap(ows_server) -> None:
-    url = ows_server.url + ("/wmts?SERVICE=WMTS&REQUEST=GetFeatureInfo&VERSION=1.0.0&" +
-                            "LAYER=s2_l2a&STYLE=simple_rgb&" +
-                            "TILEMATRIXSET=WholeWorld_WebMercator&TILEMATRIX=13&" +
-                            "TILEROW=5171&TILECOL=7458&I=102&J=204&INFOFORMAT=application%2Fpdf")
+    url = ows_server.url + (
+        "/wmts?SERVICE=WMTS&REQUEST=GetFeatureInfo&VERSION=1.0.0&"
+        + "LAYER=s2_l2a&STYLE=simple_rgb&"
+        + "TILEMATRIXSET=WholeWorld_WebMercator&TILEMATRIX=13&"
+        + "TILEROW=5171&TILECOL=7458&I=102&J=204&INFOFORMAT=application%2Fpdf"
+    )
     resp = retrying_requests.get(url)
     assert resp.status_code == 400
 
 
 def test_wmts_arg_errors(ows_server) -> None:
-    url = ows_server.url + ("/wmts?SERVICE=WMTS&REQUEST=GetFeatureInfo&VERSION=1.0.0&" +
-                            "LAYER=s2_l2a&STYLE=simple_rgb&" +
-                            "TILEMATRIXSET=WholeWorld_WebMercator&TILEMATRIX=foo&" +
-                            "TILEROW=5171&TILECOL=7458&I=102&J=204&INFOFORMAT=application%2Fjson")
+    url = ows_server.url + (
+        "/wmts?SERVICE=WMTS&REQUEST=GetFeatureInfo&VERSION=1.0.0&"
+        + "LAYER=s2_l2a&STYLE=simple_rgb&"
+        + "TILEMATRIXSET=WholeWorld_WebMercator&TILEMATRIX=foo&"
+        + "TILEROW=5171&TILECOL=7458&I=102&J=204&INFOFORMAT=application%2Fjson"
+    )
     resp = retrying_requests.get(url)
     assert resp.status_code == 400
     assert "Invalid Tile Matrix" in resp.text
     assert "foo" in resp.text
 
-    url = ows_server.url + ("/wmts?SERVICE=WMTS&REQUEST=GetFeatureInfo&VERSION=1.0.0&" +
-                            "LAYER=s2_l2a&STYLE=simple_rgb&" +
-                            "TILEMATRIXSET=WholeWorld_WebMercator&TILEMATRIX=666&" +
-                            "TILEROW=5171&TILECOL=7458&I=102&J=204&INFOFORMAT=application%2Fjson")
+    url = ows_server.url + (
+        "/wmts?SERVICE=WMTS&REQUEST=GetFeatureInfo&VERSION=1.0.0&"
+        + "LAYER=s2_l2a&STYLE=simple_rgb&"
+        + "TILEMATRIXSET=WholeWorld_WebMercator&TILEMATRIX=666&"
+        + "TILEROW=5171&TILECOL=7458&I=102&J=204&INFOFORMAT=application%2Fjson"
+    )
     resp = retrying_requests.get(url)
     assert resp.status_code == 400
     assert "Invalid Tile Matrix" in resp.text
     assert "666" in resp.text
 
-    url = ows_server.url + ("/wmts?SERVICE=WMTS&REQUEST=GetFeatureInfo&VERSION=1.0.0&" +
-                            "LAYER=s2_l2a&STYLE=simple_rgb&" +
-                            "TILEMATRIXSET=WholeWorld_WebMercator&TILEMATRIX=13&" +
-                            "TILEROW=foo&TILECOL=7458&I=102&J=204&INFOFORMAT=application%2Fjson")
+    url = ows_server.url + (
+        "/wmts?SERVICE=WMTS&REQUEST=GetFeatureInfo&VERSION=1.0.0&"
+        + "LAYER=s2_l2a&STYLE=simple_rgb&"
+        + "TILEMATRIXSET=WholeWorld_WebMercator&TILEMATRIX=13&"
+        + "TILEROW=foo&TILECOL=7458&I=102&J=204&INFOFORMAT=application%2Fjson"
+    )
     resp = retrying_requests.get(url)
     assert resp.status_code == 400
     assert "Invalid Tile Row" in resp.text
     assert "foo" in resp.text
 
-    url = ows_server.url + ("/wmts?SERVICE=WMTS&REQUEST=GetFeatureInfo&VERSION=1.0.0&" +
-                            "LAYER=s2_l2a&STYLE=simple_rgb&" +
-                            "TILEMATRIXSET=WholeWorld_WebMercator&TILEMATRIX=13&" +
-                            "TILEROW=5171&TILECOL=foo&I=102&J=204&INFOFORMAT=application%2Fjson")
+    url = ows_server.url + (
+        "/wmts?SERVICE=WMTS&REQUEST=GetFeatureInfo&VERSION=1.0.0&"
+        + "LAYER=s2_l2a&STYLE=simple_rgb&"
+        + "TILEMATRIXSET=WholeWorld_WebMercator&TILEMATRIX=13&"
+        + "TILEROW=5171&TILECOL=foo&I=102&J=204&INFOFORMAT=application%2Fjson"
+    )
     resp = retrying_requests.get(url)
     assert resp.status_code == 400
     assert "Invalid Tile Col" in resp.text
@@ -200,10 +217,12 @@ def test_wmts_arg_errors(ows_server) -> None:
 
 
 def test_wmts_ows_stats(ows_server) -> None:
-    url = ows_server.url + ("/wmts?SERVICE=WMTS&REQUEST=GetTile&VERSION=1.0.0&" +
-                            "LAYER=s2_l2a&STYLE=simple_rgb&" +
-                            "TILEMATRIXSET=WholeWorld_WebMercator&TILEMATRIX=13&" +
-                            "TILEROW=5171&TILECOL=7458&I=102&J=204&FORMAT=image/png&ows_stats=y")
+    url = ows_server.url + (
+        "/wmts?SERVICE=WMTS&REQUEST=GetTile&VERSION=1.0.0&"
+        + "LAYER=s2_l2a&STYLE=simple_rgb&"
+        + "TILEMATRIXSET=WholeWorld_WebMercator&TILEMATRIX=13&"
+        + "TILEROW=5171&TILECOL=7458&I=102&J=204&FORMAT=image/png&ows_stats=y"
+    )
     resp = retrying_requests.get(url)
     assert resp.status_code == 200
     json = resp.json()

--- a/integration_tests/utils.py
+++ b/integration_tests/utils.py
@@ -35,7 +35,11 @@ class WCS20Extent:
         first_time: bool = False,
         multi_time: bool = False,
     ):
-        bbox = self.native_bbox() if crs is None or crs == self.native_crs else self.bbox_crs(crs)
+        bbox = (
+            self.native_bbox()
+            if crs is None or crs == self.native_crs
+            else self.bbox_crs(crs)
+        )
 
         bbox = self.subset_bbox(
             bbox, xstart=xstart, xwidth=xwidth, ystart=ystart, ywidth=ywidth
@@ -71,13 +75,20 @@ class WCS20Extent:
         )
 
     @staticmethod
-    def subcoord(c_min: float, c_max: float, start: float, end: float) -> tuple[float, float]:
+    def subcoord(
+        c_min: float, c_max: float, start: float, end: float
+    ) -> tuple[float, float]:
         diff = c_max - c_min
         return diff * start + c_min, diff * end + c_min
 
     @staticmethod
-    def subset_bbox(bbox: tuple[float, float, float, float], xstart: float = 0.3, xwidth: float = 0.02,
-                    ystart: float = 0.8, ywidth: float = 0.02) -> tuple:
+    def subset_bbox(
+        bbox: tuple[float, float, float, float],
+        xstart: float = 0.3,
+        xwidth: float = 0.02,
+        ystart: float = 0.8,
+        ywidth: float = 0.02,
+    ) -> tuple:
         x = WCS20Extent.subcoord(bbox[0], bbox[2], xstart, xstart + xwidth)
         y = WCS20Extent.subcoord(bbox[1], bbox[3], xstart, xstart + xwidth)
         return x[0], y[0], x[1], y[1]
@@ -102,7 +113,11 @@ def geom_from_bbox(bbox, crs: str = "EPSG:4326") -> Geometry:
 def simplify_geom(geom_in, crs: str = "EPSG:4326") -> Geometry:
     geom = geom_in
     # Pick biggest polygon from multipolygon
-    geom = max(geom.geom.geoms, key=lambda x: x.area) if geom.geom_type == "MultiPolygon" else geom.geom
+    geom = (
+        max(geom.geom.geoms, key=lambda x: x.area)
+        if geom.geom_type == "MultiPolygon"
+        else geom.geom
+    )
     # Triangulate
     rawtriangles = list(triangulate(geom))
     triangles = list(
@@ -132,14 +147,14 @@ class ODCExtent:
             try:
                 if self == self.MIDDLE:
                     i = len(ls) // 2
-                    return ls[i: i + 1]
+                    return ls[i : i + 1]
                 if self == self.FIRST_TWO:
                     return ls[0:1]
                 if self == self.LAST_TWO:
                     return ls[-2:]
                 if self == self.LAST:
                     return ls[-1:]
-                return ls[self.value: self.value + 1]
+                return ls[self.value : self.value + 1]
             except IndexError:
                 return []
 
@@ -290,7 +305,7 @@ class ODCExtent:
         crs_bbox = crs_extent.boundingbox
         return {
             "bbox": f"{min(crs_bbox.left, crs_bbox.right)},{min(crs_bbox.top, crs_bbox.bottom)},"
-                    f"{max(crs_bbox.left, crs_bbox.right)},{max(crs_bbox.top, crs_bbox.bottom)}",
+            f"{max(crs_bbox.left, crs_bbox.right)},{max(crs_bbox.top, crs_bbox.bottom)}",
             "times": ",".join(time_strs),
         }
 
@@ -352,12 +367,12 @@ class ODCExtent:
         ext_times = time.slice(self.layer.ranges.times)
         search_times = [self.layer.search_times(t) for t in ext_times]
         if space.needs_full_extent() and not self.full_extent:
-            self.full_extent = self.layer.ows_index().extent(layer=self.layer, products=self.layer.products)
+            self.full_extent = self.layer.ows_index().extent(
+                layer=self.layer, products=self.layer.products
+            )
         if space.needs_time_extent():
             time_extent = self.layer.ows_index().extent(
-                layer=self.layer,
-                products=self.layer.products,
-                times=search_times,
+                layer=self.layer, products=self.layer.products, times=search_times
             )
         else:
             time_extent = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,6 +111,13 @@ warn_unused_ignores = true
 [tool.pytest.ini_options]
 console_output_style = "times"
 
+[tool.ruff]
+extend-exclude = [
+    "datacube_ows/_version.py",
+    "docs/conf.py",
+    "licenseheaders.py",
+]
+
 [tool.ruff.lint]
 select = [
     "A",  # Don't shadow built-ins
@@ -137,14 +144,10 @@ ignore = [
 ]
 
 [tool.ruff.lint.per-file-ignores]
-# Stay close to the generated file for readthedocs, so ignore some rules.
-"docs/conf.py" = ["A001", "E402"]
 # Using pytest_namespace requires assignment before importing pytest.
 "integration_tests/conftest.py" = ["E402"]
 # Multiline string, no good place for adding a noqa.
 "integration_tests/cfg/ows_test_cfg.py" = ["RUF001"]
-# Third-party software, keep pristine.
-"licenseheaders.py" = ["B", "C", "I", "RET", "SIM", "UP"]
 
 [tool.ruff.lint.pycodestyle]
 max-line-length = 120

--- a/tests/cfg/broken_nested.py
+++ b/tests/cfg/broken_nested.py
@@ -7,8 +7,5 @@
 
 mixed_3 = {
     "test": 2634,
-    "subtest": {
-        "include": "tests.cfg.simple.doesnt_exist",
-        "type": "python"
-    }
+    "subtest": {"include": "tests.cfg.simple.doesnt_exist", "type": "python"},
 }

--- a/tests/cfg/minimal_cfg.py
+++ b/tests/cfg/minimal_cfg.py
@@ -18,18 +18,12 @@ ows_cfg = {
             },
             "EPSG:4326": {  # WGS-84
                 "geographic": True,
-                "vertical_coord_first": True
+                "vertical_coord_first": True,
             },
         },
-        "services": {
-            "wms": True,
-            "wmts": True,
-            "wcs": True
-        },
+        "services": {"wms": True, "wmts": True, "wcs": True},
     },
-
     "wms": {},
-
     "wcs": {
         "formats": {
             "GeoTIFF": {
@@ -39,7 +33,7 @@ ows_cfg = {
                 },
                 "mime": "image/geotiff",
                 "extension": "tif",
-                "multi-time": False
+                "multi-time": False,
             },
             "netCDF": {
                 "renderers": {
@@ -49,10 +43,9 @@ ows_cfg = {
                 "mime": "application/x-netcdf",
                 "extension": "nc",
                 "multi-time": True,
-            }
+            },
         },
         "native_format": "GeoTIFF",
     },
-
     "layers": [],
 }

--- a/tests/cfg/mixed_nested.py
+++ b/tests/cfg/mixed_nested.py
@@ -4,30 +4,18 @@
 # Copyright (c) 2017-2024 OWS Contributors
 # SPDX-License-Identifier: Apache-2.0
 
-mixed_1 = {
-    "include": "tests/cfg/simple.json",
-    "type": "json"
-}
+mixed_1 = {"include": "tests/cfg/simple.json", "type": "json"}
 
 
 mixed_2 = {
     "test": 5224,
-    "subtest": {
-        "include": "tests/cfg/simple.json",
-        "type": "json"
-    }
+    "subtest": {"include": "tests/cfg/simple.json", "type": "json"},
 }
 
 mixed_3 = {
     "test": 2634,
     "subtest": {
-        "test_py": {
-            "include": "tests.cfg.simple.simple",
-            "type": "python"
-        },
-        "test_json": {
-            "include": "tests/cfg/simple.json",
-            "type": "json"
-        }
-    }
+        "test_py": {"include": "tests.cfg.simple.simple", "type": "python"},
+        "test_json": {"include": "tests/cfg/simple.json", "type": "json"},
+    },
 }

--- a/tests/cfg/nested.py
+++ b/tests/cfg/nested.py
@@ -5,110 +5,68 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-
-nested = {
-    "include": "tests.cfg.simple.simple",
-    "type": "python",
-}
+nested = {"include": "tests.cfg.simple.simple", "type": "python"}
 
 nested_1 = {
     "this_test": [
-        {
-            "test": 8888,
-        },
-        {
-            "include": "tests.cfg.simple.simple1",
-            "type": "python"
-        }
+        {"test": 8888},
+        {"include": "tests.cfg.simple.simple1", "type": "python"},
     ]
 }
 
 nested_2 = {
     "test": 3424,
-    "subtest": {
-        "include": "tests.cfg.simple.simple2",
-        "type": "python"
-    }
+    "subtest": {"include": "tests.cfg.simple.simple2", "type": "python"},
 }
 
 nested_3 = {
     "test": 233,
     "things": [
-        {
-            "test": 2562,
-            "thing": None
-        },
+        {"test": 2562, "thing": None},
         {
             "test": 2563,
-            "thing": {
-                "include": "tests.cfg.simple.simple",
-                "type": "python"
-            }
+            "thing": {"include": "tests.cfg.simple.simple", "type": "python"},
         },
         {
             "test": 2564,
-            "thing": {
-                "include": "tests.cfg.simple.simple3",
-                "type": "python"
-            }
+            "thing": {"include": "tests.cfg.simple.simple3", "type": "python"},
         },
-    ]
+    ],
 }
 
 nested_4 = {
     "test": 222,
     "things": [
-        {
-            "test": 2572,
-            "thing": None
-        },
+        {"test": 2572, "thing": None},
         {
             "test": 2573,
-            "thing": {
-                "include": "tests.cfg.simple.simple",
-                "type": "python"
-            }
+            "thing": {"include": "tests.cfg.simple.simple", "type": "python"},
         },
         {
             "test": 2574,
-            "thing": {
-                "include": "tests.cfg.nested.nested_3",
-                "type": "python"
-            }
+            "thing": {"include": "tests.cfg.nested.nested_3", "type": "python"},
         },
-    ]
+    ],
 }
 
-infinite_1 = {
-    "include": "tests.cfg.nested.infinite_1",
-    "type": "python"
-}
+infinite_1 = {"include": "tests.cfg.nested.infinite_1", "type": "python"}
 
 
 infinite_2 = {
     "test": 7777,
-    "subtest": {
-        "include": "tests.cfg.nested.infinite_2a",
-        "type": "python"
-    }
+    "subtest": {"include": "tests.cfg.nested.infinite_2a", "type": "python"},
 }
 
 
 infinite_2a = {
     "test": 7778,
-    "subtest": {
-        "include": "tests.cfg.nested.infinite_2b",
-        "type": "python"
-    }
+    "subtest": {"include": "tests.cfg.nested.infinite_2b", "type": "python"},
 }
 
 
 infinite_2b = {
     "test": 7779,
-    "subtest": {
-        "include": "tests.cfg.nested.infinite_2",
-        "type": "python"
-    }
+    "subtest": {"include": "tests.cfg.nested.infinite_2", "type": "python"},
 }
 
 not_a_dict = ["flash", "bang", "whallop"]

--- a/tests/cfg/simple.py
+++ b/tests/cfg/simple.py
@@ -5,22 +5,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-
-simple = {
-    "test": 123,
-}
+simple = {"test": 123}
 
 
-simple1 = {
-    "test": 1,
-}
+simple1 = {"test": 1}
 
 
-simple2 = {
-    "test": 2,
-}
+simple2 = {"test": 2}
 
 
-simple3 = {
-    "test": 3,
-}
+simple3 = {"test": 3}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,6 +23,7 @@ from tests.utils import coords, dim1_da, dim1_da_time, dummy_da
 def flask_client(monkeypatch) -> Generator[flask.Flask]:
     monkeypatch.setenv("DEFER_CFG_PARSE", "yes")
     from datacube_ows.ogc import app
+
     with app.test_client() as client:
         yield client
 
@@ -31,7 +32,7 @@ def flask_client(monkeypatch) -> Generator[flask.Flask]:
 def minimal_dc():
     dc = MagicMock()
     nb = MagicMock()
-    nb.index = ['band1', 'band2', 'band3', 'band4']
+    nb.index = ["band1", "band2", "band3", "band4"]
     nb.__getitem__.return_value = {
         "band1": -999,
         "band2": -999,
@@ -58,23 +59,23 @@ def minimal_dc():
     dc.index.environment = ODCConfig.get_environment()
 
     def product_by_name(s):
-        if 'lookupfail' in s:
+        if "lookupfail" in s:
             return None
-        mprod  = MagicMock()
+        mprod = MagicMock()
         mprod.name = s
 
         mprod.definition = {"storage": {}}
-        if 'nonativecrs' in s:
+        if "nonativecrs" in s:
             pass
-        elif 'badnativecrs' in s:
+        elif "badnativecrs" in s:
             mprod.definition["storage"]["crs"] = "EPSG:9999"
-        elif 'nativecrs' in s:
+        elif "nativecrs" in s:
             mprod.definition["storage"]["crs"] = "EPSG:4326"
         else:
             mprod.definition["storage"]["crs"] = "EPSG:4326"
-        if 'nonativeres' in s:
+        if "nonativeres" in s:
             pass
-        elif 'nativeres' in s:
+        elif "nativeres" in s:
             mprod.definition["storage"]["resolution"] = {
                 "latitude": -0.001,
                 "longitude": 0.001,
@@ -87,6 +88,7 @@ def minimal_dc():
 
         def lookup_measurements(ls: str | list[str]) -> dict[str, Any]:
             from datacube.model import Measurement
+
             if isinstance(ls, str):
                 ls = [ls]
             out = {}
@@ -108,6 +110,7 @@ def minimal_dc():
 
         mprod.lookup_measurements = lookup_measurements
         return mprod
+
     dc.index.products.get_by_name = product_by_name
     return dc
 
@@ -170,9 +173,7 @@ def minimal_global_cfg(minimal_dc):
             "alias_of": None,
         },
     }
-    global_cfg.folder_index = {
-        "folder.existing_folder": MagicMock(),
-    }
+    global_cfg.folder_index = {"folder.existing_folder": MagicMock()}
     return global_cfg
 
 
@@ -199,9 +200,7 @@ def minimal_layer_cfg() -> CFG_DICT:
             "band3": ["band3", "band_3"],
             "band4": ["band4", "band_4"],
         },
-        "image_processing": {
-            "extent_mask_func": "datacube_ows.ogc_utils.mask_by_val",
-        },
+        "image_processing": {"extent_mask_func": "datacube_ows.ogc_utils.mask_by_val"},
         "styling": {
             "default_style": "band1",
             "styles": [
@@ -214,10 +213,10 @@ def minimal_layer_cfg() -> CFG_DICT:
                         "green": {"band1": 1.0},
                         "blue": {"band1": 1.0},
                     },
-                    "scale_range": [0, 1024]
+                    "scale_range": [0, 1024],
                 }
-            ]
-        }
+            ],
+        },
     }
 
 
@@ -229,9 +228,7 @@ def minimal_multiprod_cfg():
         "name": "a_layer",
         "multi_product": True,
         "product_names": ["foo", "bar"],
-        "image_processing": {
-            "extent_mask_func": "datacube_ows.ogc_utils.mask_by_val",
-        },
+        "image_processing": {"extent_mask_func": "datacube_ows.ogc_utils.mask_by_val"},
         "styling": {
             "default_style": "band1",
             "styles": [
@@ -244,26 +241,31 @@ def minimal_multiprod_cfg():
                         "green": {"band1": 1.0},
                         "blue": {"band1": 1.0},
                     },
-                    "scale_range": [0, 1024]
+                    "scale_range": [0, 1024],
                 }
-            ]
-        }
+            ],
+        },
     }
 
 
 @pytest.fixture
 def mock_range():
     from datacube_ows.index import CoordRange, LayerExtent
-    times = [datetime.date(2010, 1, 1), datetime.date(2010, 1, 2), datetime.date(2010, 1, 3)]
+
+    times = [
+        datetime.date(2010, 1, 1),
+        datetime.date(2010, 1, 2),
+        datetime.date(2010, 1, 3),
+    ]
     return LayerExtent(
         lat=CoordRange(-0.1, 0.1),
         lon=CoordRange(-0.1, 0.1),
         times=times,
         bboxes={
-            "EPSG:4326": {"top": 0.1, "bottom": -0.1, "left": -0.1, "right": 0.1, },
-            "EPSG:3577": {"top": 0.1, "bottom": -0.1, "left": -0.1, "right": 0.1, },
-            "EPSG:3857": {"top": 0.1, "bottom": -0.1, "left": -0.1, "right": 0.1, },
-        }
+            "EPSG:4326": {"top": 0.1, "bottom": -0.1, "left": -0.1, "right": 0.1},
+            "EPSG:3577": {"top": 0.1, "bottom": -0.1, "left": -0.1, "right": 0.1},
+            "EPSG:3857": {"top": 0.1, "bottom": -0.1, "left": -0.1, "right": 0.1},
+        },
     )
 
 
@@ -280,17 +282,17 @@ def minimal_global_raw_cfg() -> CFG_DICT:
             ],
             "published_CRSs": {
                 "EPSG:3857": {  # Web Mercator
-                     "geographic": False,
-                     "horizontal_coord": "x",
-                     "vertical_coord": "y",
+                    "geographic": False,
+                    "horizontal_coord": "x",
+                    "vertical_coord": "y",
                 },
                 "EPSG:4326": {  # WGS-84
                     "geographic": True,
-                    "vertical_coord_first": True
+                    "vertical_coord_first": True,
                 },
             },
         },
-        "layers": []
+        "layers": [],
     }
 
 
@@ -309,7 +311,7 @@ def wcs_global_cfg() -> CFG_DICT:
                 # The file extension to add to the filename.
                 "extension": "tif",
                 # Whether or not the file format supports multiple time slices.
-                "multi-time": False
+                "multi-time": False,
             },
             "netCDF": {
                 "renderers": {
@@ -319,7 +321,7 @@ def wcs_global_cfg() -> CFG_DICT:
                 "mime": "application/x-netcdf",
                 "extension": "nc",
                 "multi-time": True,
-            }
+            },
         },
         "native_format": "GeoTIFF",
     }
@@ -327,13 +329,15 @@ def wcs_global_cfg() -> CFG_DICT:
 
 @pytest.fixture
 def dummy_raw_data() -> xr.Dataset:
-    return xr.Dataset({
-        "ir": dummy_da(3, "ir", coords),
-        "red": dummy_da(5, "red", coords),
-        "green": dummy_da(7, "green", coords),
-        "blue": dummy_da(2, "blue", coords),
-        "uv": dummy_da(-1, "uv", coords),
-    })
+    return xr.Dataset(
+        {
+            "ir": dummy_da(3, "ir", coords),
+            "red": dummy_da(5, "red", coords),
+            "green": dummy_da(7, "green", coords),
+            "blue": dummy_da(2, "blue", coords),
+            "uv": dummy_da(-1, "uv", coords),
+        }
+    )
 
 
 @pytest.fixture
@@ -344,42 +348,39 @@ def null_mask() -> xr.DataArray:
 @pytest.fixture
 def dummy_raw_calc_data() -> xr.Dataset:
     dim_coords = [-2.0, -1.0, 0.0, -1.0, -2.0, -3.0]
-    return xr.Dataset({
-        "ir": dim1_da("ir", [800, 100, 1000, 600, 200, 1000], dim_coords),
-        "red": dim1_da("red", [200, 500, 0, 200, 200, 700], dim_coords),
-        "green": dim1_da("green", [100, 500, 0, 400, 300, 200], dim_coords),
-        "blue": dim1_da("blue", [200, 500, 1000, 600, 100, 700], dim_coords),
-        "uv": dim1_da("uv", [400, 600, 900, 200, 400, 100], dim_coords),
-        "pq": dim1_da("pq", [0b000, 0b001, 0b010, 0b011, 0b100, 0b111], dim_coords,
-                      attrs={
-                                "flags_definition": {
-                                    "splodgy": {
-                                        "bits": 2,
-                                        "values": {
-                                            '0': "Splodgeless",
-                                            '1': "Splodgy",
-                                        },
-                                        "description": "All splodgy looking"
-                                    },
-                                    "ugly": {
-                                        "bits": 1,
-                                        "values": {
-                                            '0': False,
-                                            '1': True
-                                        },
-                                        "description": "Real, real ugly",
-                                    },
-                                    "impossible": {
-                                        "bits": 0,
-                                        "values": {
-                                            '0': False,
-                                            '1': "Woah!"
-                                        },
-                                        "description": "Won't happen. Can't happen. Might happen.",
-                                    },
-                                }
-                            })
-    })
+    return xr.Dataset(
+        {
+            "ir": dim1_da("ir", [800, 100, 1000, 600, 200, 1000], dim_coords),
+            "red": dim1_da("red", [200, 500, 0, 200, 200, 700], dim_coords),
+            "green": dim1_da("green", [100, 500, 0, 400, 300, 200], dim_coords),
+            "blue": dim1_da("blue", [200, 500, 1000, 600, 100, 700], dim_coords),
+            "uv": dim1_da("uv", [400, 600, 900, 200, 400, 100], dim_coords),
+            "pq": dim1_da(
+                "pq",
+                [0b000, 0b001, 0b010, 0b011, 0b100, 0b111],
+                dim_coords,
+                attrs={
+                    "flags_definition": {
+                        "splodgy": {
+                            "bits": 2,
+                            "values": {"0": "Splodgeless", "1": "Splodgy"},
+                            "description": "All splodgy looking",
+                        },
+                        "ugly": {
+                            "bits": 1,
+                            "values": {"0": False, "1": True},
+                            "description": "Real, real ugly",
+                        },
+                        "impossible": {
+                            "bits": 0,
+                            "values": {"0": False, "1": "Woah!"},
+                            "description": "Won't happen. Can't happen. Might happen.",
+                        },
+                    }
+                },
+            ),
+        }
+    )
 
 
 def dim1_null_mask(coords) -> xr.DataArray:
@@ -391,52 +392,40 @@ def raw_calc_null_mask() -> xr.DataArray:
     dim_coords = [-2.0, -1.0, 0.0, -1.0, -2.0, -3.0]
     return dim1_da("mask", [True] * len(dim_coords), dim_coords)
 
+
 @pytest.fixture
 def timed_raw_calc_null_mask():
     dim_coords = [-2.0, -1.0, 0.0, -1.0, -2.0, -3.0]
     dates = [datetime.datetime(2000, 1, 1), datetime.datetime(2020, 1, 1)]
-    return dim1_da_time("mask", [[True] * len(dates)] * len(dim_coords), dates, dim_coords)
+    return dim1_da_time(
+        "mask", [[True] * len(dates)] * len(dim_coords), dates, dim_coords
+    )
 
 
 flags_def: CFG_DICT = {
     "joviality": {
         "bits": 4,
-        "values": {
-            '0': "Melancholic",
-            '1': "Joyous",
-        },
-        "description": "All splodgy looking"
+        "values": {"0": "Melancholic", "1": "Joyous"},
+        "description": "All splodgy looking",
     },
     "flavour": {
         "bits": 3,
-        "values": {
-            '0': "Bland",
-            '1': "Tasty",
-        },
-        "description": "All splodgy looking"
+        "values": {"0": "Bland", "1": "Tasty"},
+        "description": "All splodgy looking",
     },
     "splodgy": {
         "bits": 2,
-        "values": {
-            '0': "Splodgeless",
-            '1': "Splodgy",
-        },
-        "description": "All splodgy looking"
+        "values": {"0": "Splodgeless", "1": "Splodgy"},
+        "description": "All splodgy looking",
     },
     "ugly": {
         "bits": 1,
-        "values": {
-            '0': False,
-            '1': True
-        },
+        "values": {"0": False, "1": True},
         "description": "Real, real ugly",
     },
     "impossible": {
         "bits": 0,
-        "values": {
-            '0': False,
-            '1': "Woah!"
-        },
+        "values": {"0": False, "1": "Woah!"},
         "description": "Won't happen. Can't happen. Might happen.",
     },
 }
@@ -445,137 +434,130 @@ flags_def: CFG_DICT = {
 @pytest.fixture
 def dummy_col_map_data() -> xr.Dataset:
     dim_coords = [-2.0, -1.0, 0.0, -1.0, -2.0, -3.0]
-    return xr.Dataset({
-        "pq": dim1_da("pq", [0b01000, 0b11001, 0b00010, 0b10011, 0b00100, 0b10001], dim_coords,
-                      attrs={
-                          "flags_definition": flags_def
-                      })
-    })
+    return xr.Dataset(
+        {
+            "pq": dim1_da(
+                "pq",
+                [0b01000, 0b11001, 0b00010, 0b10011, 0b00100, 0b10001],
+                dim_coords,
+                attrs={"flags_definition": flags_def},
+            )
+        }
+    )
+
 
 @pytest.fixture
 def dummy_col_map_time_data() -> xr.Dataset:
     dim_coords = [-2.0, -1.0, 0.0, -1.0, -2.0, -3.0]
     dates = [datetime.datetime(2000, 1, 1), datetime.datetime(2020, 1, 1)]
-    return xr.Dataset({
-        "pq": dim1_da_time("pq", [
-                [0b01000, 0b11110],
-                [0b11001, 0b10001],
-                [0b01010, 0b01101],
-                [0b10011, 0b01110],
-                [0b00100, 0b11011],
-                [0b10111, 0b11000],
-                            ],
-                            dates, dim_coords,
-                            attrs={
-                      "flags_definition": flags_def
-                  })
-    })
+    return xr.Dataset(
+        {
+            "pq": dim1_da_time(
+                "pq",
+                [
+                    [0b01000, 0b11110],
+                    [0b11001, 0b10001],
+                    [0b01010, 0b01101],
+                    [0b10011, 0b01110],
+                    [0b00100, 0b11011],
+                    [0b10111, 0b11000],
+                ],
+                dates,
+                dim_coords,
+                attrs={"flags_definition": flags_def},
+            )
+        }
+    )
 
 
 @pytest.fixture
 def dummy_raw_ls_data() -> xr.Dataset:
-    return xr.Dataset({
-        "red": dummy_da(5, "red", coords, dtype=np.int16),
-        "green": dummy_da(7, "green", coords, dtype=np.int16),
-        "blue": dummy_da(2, "blue", coords, dtype=np.int16),
-        "nir": dummy_da(101, "nir", coords, dtype=np.int16),
-        "swir1": dummy_da(1051, "swir1", coords, dtype=np.int16),
-        "swir2": dummy_da(1051, "swir2", coords, dtype=np.int16),
-    })
+    return xr.Dataset(
+        {
+            "red": dummy_da(5, "red", coords, dtype=np.int16),
+            "green": dummy_da(7, "green", coords, dtype=np.int16),
+            "blue": dummy_da(2, "blue", coords, dtype=np.int16),
+            "nir": dummy_da(101, "nir", coords, dtype=np.int16),
+            "swir1": dummy_da(1051, "swir1", coords, dtype=np.int16),
+            "swir2": dummy_da(1051, "swir2", coords, dtype=np.int16),
+        }
+    )
 
 
 @pytest.fixture
 def dummy_raw_wo_data() -> xr.Dataset:
-    return xr.Dataset({
-        "water": dummy_da(0b101,
-                        "red",
-                        coords,
-                        dtype=np.uint8,
-                        attrs = {
-                                "flags_definition": {
-                                    "nodata": {
-                                        "bits": 0,
-                                        "description": "No data",
-                                        "values": {
-                                            '0': False,
-                                            '1': True
-                                        },
-                                    },
-                                    "noncontiguous": {
-                                        "description": "At least one EO band is missing or saturated",
-                                        "bits": 1,
-                                        "values": {
-                                            '0': False,
-                                            '1': True
-                                        },
-                                    },
-                                    "low_solar_angle": {
-                                        "description": "Low solar incidence angle",
-                                        "bits": 2,
-                                        "values": {
-                                            '0': False,
-                                            '1': True
-                                        },
-                                    },
-                                    "terrain_shadow": {
-                                        "description": "Terrain shadow",
-                                        "bits": 3,
-                                        "values": {
-                                            '0': False,
-                                            '1': True
-                                        },
-                                    },
-                                    "high_slope": {
-                                        "description": "High slope",
-                                        "bits": 4,
-                                        "values": {
-                                            '0': False,
-                                            '1': True
-                                        }
-                                    },
-                                    "cloud_shadow": {
-                                        "description": "Cloud shadow",
-                                        "bits": 5,
-                                        "values": {
-                                            '0': False,
-                                            '1': True
-                                        },
-                                    },
-                                    "cloud": {
-                                        "description": "Cloudy",
-                                        "bits": 6,
-                                        "values": {
-                                            '0': False,
-                                            '1': True
-                                        },
-                                    },
-                                    "water_observed": {
-                                        "description": "Classified as water by the decision tree",
-                                        "bits": 7,
-                                        "values": {
-                                            '0': False,
-                                            '1': True
-                                        },
-                                    },
-                                }
-                            })
-    })
+    return xr.Dataset(
+        {
+            "water": dummy_da(
+                0b101,
+                "red",
+                coords,
+                dtype=np.uint8,
+                attrs={
+                    "flags_definition": {
+                        "nodata": {
+                            "bits": 0,
+                            "description": "No data",
+                            "values": {"0": False, "1": True},
+                        },
+                        "noncontiguous": {
+                            "description": "At least one EO band is missing or saturated",
+                            "bits": 1,
+                            "values": {"0": False, "1": True},
+                        },
+                        "low_solar_angle": {
+                            "description": "Low solar incidence angle",
+                            "bits": 2,
+                            "values": {"0": False, "1": True},
+                        },
+                        "terrain_shadow": {
+                            "description": "Terrain shadow",
+                            "bits": 3,
+                            "values": {"0": False, "1": True},
+                        },
+                        "high_slope": {
+                            "description": "High slope",
+                            "bits": 4,
+                            "values": {"0": False, "1": True},
+                        },
+                        "cloud_shadow": {
+                            "description": "Cloud shadow",
+                            "bits": 5,
+                            "values": {"0": False, "1": True},
+                        },
+                        "cloud": {
+                            "description": "Cloudy",
+                            "bits": 6,
+                            "values": {"0": False, "1": True},
+                        },
+                        "water_observed": {
+                            "description": "Classified as water by the decision tree",
+                            "bits": 7,
+                            "values": {"0": False, "1": True},
+                        },
+                    }
+                },
+            )
+        }
+    )
 
 
 @pytest.fixture
 def dummy_raw_fc_data() -> xr.Dataset:
-    return xr.Dataset({
-        "bs": dummy_da(546, "bs", coords, dtype=np.int16),
-        "pv": dummy_da(723, "pv", coords, dtype=np.int16),
-        "npv": dummy_da(209, "npv", coords, dtype=np.int16),
-    })
+    return xr.Dataset(
+        {
+            "bs": dummy_da(546, "bs", coords, dtype=np.int16),
+            "pv": dummy_da(723, "pv", coords, dtype=np.int16),
+            "npv": dummy_da(209, "npv", coords, dtype=np.int16),
+        }
+    )
 
 
 @pytest.fixture
-def dummy_raw_fc_plus_wo(dummy_raw_fc_data, dummy_raw_wo_data) -> xr.DataArray | xr.Dataset:
-    return xr.combine_by_coords(
-            [dummy_raw_fc_data, dummy_raw_wo_data],
-            join="exact")
+def dummy_raw_fc_plus_wo(
+    dummy_raw_fc_data, dummy_raw_wo_data
+) -> xr.DataArray | xr.Dataset:
+    return xr.combine_by_coords([dummy_raw_fc_data, dummy_raw_wo_data], join="exact")
 
 
 @pytest.fixture
@@ -620,25 +602,14 @@ def configs_for_landsat() -> list:
         },
         {
             "components": {
-                "red": {
-                    "red": 0.333,
-                    "green": 0.333,
-                    "blue": 0.333,
-                },
+                "red": {"red": 0.333, "green": 0.333, "blue": 0.333},
                 "green": {"nir": 1.0},
-                "blue": {
-                    "swir1": 0.5,
-                    "swir2": 0.5,
-                },
+                "blue": {"swir1": 0.5, "swir2": 0.5},
             },
             "scale_range": (50, 3000),
         },
         {
-            "components": {
-                "red": {"red": 1.0},
-                "green": {},
-                "blue": {},
-            },
+            "components": {"red": {"red": 1.0}, "green": {}, "blue": {}},
             "scale_range": (50, 3000),
         },
         {
@@ -667,24 +638,14 @@ def configs_for_landsat() -> list:
         },
         {
             "components": {
-                "red": {
-                    "swir1": 1.0,
-                    "scale_range": (1500, 3700),
-                },
-                "green": {
-                    "nir": 1.0,
-                    "scale_range": (1600, 3200),
-                },
+                "red": {"swir1": 1.0, "scale_range": (1500, 3700)},
+                "green": {"nir": 1.0, "scale_range": (1600, 3200)},
                 "blue": {"green": 1.0},
             },
             "scale_range": (200, 1900),
         },
         {
-            "components": {
-                "red": {"red": 1.0},
-                "green": ndvi,
-                "blue": {"blue": 1.0},
-            },
+            "components": {"red": {"red": 1.0}, "green": ndvi, "blue": {"blue": 1.0}},
             "scale_range": (50, 3000),
         },
         {
@@ -692,10 +653,7 @@ def configs_for_landsat() -> list:
                 "red": {"red": 1.0},
                 "green": {
                     "function": scaled_ndvi,
-                    "kwargs": {
-                        "scale_from": (0.0, 1.0),
-                        "scale_to": (0, 255)
-                    }
+                    "kwargs": {"scale_from": (0.0, 1.0), "scale_to": (0, 255)},
                 },
                 "blue": {"blue": 1.0},
             },
@@ -710,8 +668,8 @@ def configs_for_landsat() -> list:
                         "band1": "nir",
                         "band2": "red",
                         "scale_from": (0.0, 1.0),
-                        "scale_to": (0, 255)
-                    }
+                        "scale_to": (0, 255),
+                    },
                 },
                 "blue": {
                     "function": "datacube_ows.band_utils.norm_diff",
@@ -719,8 +677,8 @@ def configs_for_landsat() -> list:
                         "band1": "green",
                         "band2": "nir",
                         "scale_from": (0.0, 1.0),
-                        "scale_to": (0, 255)
-                    }
+                        "scale_to": (0, 255),
+                    },
                 },
             },
             "scale_range": (50, 3000),
@@ -732,7 +690,7 @@ def configs_for_landsat() -> list:
                 "kwargs": {"band1": "nir", "band2": "red"},
             },
             "mpl_ramp": "RdYlGn",
-            "range": [-1.0, 1.0]
+            "range": [-1.0, 1.0],
         },
         {
             "index_function": {
@@ -740,7 +698,7 @@ def configs_for_landsat() -> list:
                 "kwargs": {"band1": "nir", "band2": "red"},
             },
             "mpl_ramp": "ocean_r",
-            "range": [0.0, 1.0]
+            "range": [0.0, 1.0],
         },
         {
             "index_function": {
@@ -749,14 +707,14 @@ def configs_for_landsat() -> list:
             },
             "color_ramp": [
                 {"value": -1.0, "color": "#0000FF"},
-                {"value": -0.2, "color": "#005050", },
-                {"value": -0.1, "color": "#505050", },
-                {"value": -0.01, "color": "#303030", },
-                {"value": 0.0, "color": "black", },
-                {"value": 0.01, "color": "#303000", },
-                {"value": 0.5, "color": "#707030", },
-                {"value": 1.0, "color": "#FF9090", },
-            ]
+                {"value": -0.2, "color": "#005050"},
+                {"value": -0.1, "color": "#505050"},
+                {"value": -0.01, "color": "#303030"},
+                {"value": 0.0, "color": "black"},
+                {"value": 0.01, "color": "#303000"},
+                {"value": 0.5, "color": "#707030"},
+                {"value": 1.0, "color": "#FF9090"},
+            ],
         },
         {
             "index_function": {
@@ -764,34 +722,13 @@ def configs_for_landsat() -> list:
                 "kwargs": {"band1": "nir", "band2": "red"},
             },
             "color_ramp": [
-                {
-                    "value": -1.0,
-                    "color": "#000000",
-                    "alpha": 0.0,
-                },
-                {
-                    "value": 0.0,
-                    "color": "#000000",
-                    "alpha": 0.0,
-                },
-                {
-                    "value": 0.1,
-                    "color": "#000030",
-                    "alpha": 1.0,
-                },
-                {
-                    "value": 0.3,
-                    "color": "#703070",
-                },
-                {
-                    "value": 0.6,
-                    "color": "#e0e070",
-                },
-                {
-                    "value": 1.0,
-                    "color": "#90FF90",
-                }
-            ]
+                {"value": -1.0, "color": "#000000", "alpha": 0.0},
+                {"value": 0.0, "color": "#000000", "alpha": 0.0},
+                {"value": 0.1, "color": "#000030", "alpha": 1.0},
+                {"value": 0.3, "color": "#703070"},
+                {"value": 0.6, "color": "#e0e070"},
+                {"value": 1.0, "color": "#90FF90"},
+            ],
         },
         {
             "components": {
@@ -804,8 +741,8 @@ def configs_for_landsat() -> list:
                         "band1": "nir",
                         "band2": "red",
                         "scale_from": (0.0, 0.5),
-                        "scale_to": (0, 255)
-                    }
+                        "scale_to": (0, 255),
+                    },
                 },
             },
             "scale_range": (50, 3000),
@@ -855,7 +792,7 @@ def configs_for_wofs() -> list:
                         "color": "Brown",
                     },
                 ]
-            }
+            },
         },
         {
             "name": "observations",
@@ -903,7 +840,7 @@ def configs_for_wofs() -> list:
                         "color": "SaddleBrown",
                     },
                 ]
-            }
+            },
         },
         {
             "value_map": {
@@ -912,45 +849,27 @@ def configs_for_wofs() -> list:
                         # Make noncontiguous data transparent
                         "title": "",
                         "abstract": "",
-                        "flags": {
-                            "or": {
-                                "noncontiguous": True,
-                                "nodata": True,
-                            },
-                        },
+                        "flags": {"or": {"noncontiguous": True, "nodata": True}},
                         "alpha": 0.0,
                         "color": "#ffffff",
                     },
                     {
                         "title": "Cloudy Steep Terrain",
                         "abstract": "",
-                        "flags": {
-                            "and": {
-                                "high_slope": True,
-                                "cloud": True
-                            }
-                        },
+                        "flags": {"and": {"high_slope": True, "cloud": True}},
                         "color": "#f2dcb4",
                     },
                     {
                         "title": "Cloudy Water",
                         "abstract": "",
-                        "flags": {
-                            "and": {
-                                "water_observed": True,
-                                "cloud": True
-                            }
-                        },
+                        "flags": {"and": {"water_observed": True, "cloud": True}},
                         "color": "#bad4f2",
                     },
                     {
                         "title": "Shaded Water",
                         "abstract": "",
                         "flags": {
-                            "and": {
-                                "water_observed": True,
-                                "cloud_shadow": True
-                            }
+                            "and": {"water_observed": True, "cloud_shadow": True}
                         },
                         "color": "#335277",
                     },
@@ -970,10 +889,7 @@ def configs_for_wofs() -> list:
                         "title": "Terrain Shadow or Low Sun Angle",
                         "abstract": "",
                         "flags": {
-                            "or": {
-                                "terrain_shadow": True,
-                                "low_solar_angle": True
-                            },
+                            "or": {"terrain_shadow": True, "low_solar_angle": True}
                         },
                         "color": "#2f2922",
                     },
@@ -986,9 +902,7 @@ def configs_for_wofs() -> list:
                     {
                         "title": "Water",
                         "abstract": "",
-                        "flags": {
-                            "water_observed": True,
-                        },
+                        "flags": {"water_observed": True},
                         "color": "#4f81bd",
                     },
                     {
@@ -998,7 +912,7 @@ def configs_for_wofs() -> list:
                         "color": "#96966e",
                     },
                 ]
-            },
+            }
         },
     ]
 
@@ -1010,14 +924,15 @@ def configs_for_combined_fc_wofs() -> list:
             "components": {
                 "red": {"bs": 1.0},
                 "green": {"pv": 1.0},
-                "blue": {"npv": 1.0}},
+                "blue": {"npv": 1.0},
+            },
             "scale_range": [0.0, 100.0],
         },
         {
             "components": {
                 "red": {"bs": 1.0},
                 "green": {"pv": 1.0},
-                "blue": {"npv": 1.0}
+                "blue": {"npv": 1.0},
             },
             "scale_range": [0.0, 100.0],
             "pq_masks": [
@@ -1032,44 +947,33 @@ def configs_for_combined_fc_wofs() -> list:
                         "cloud_shadow": False,
                         "cloud": False,
                         "water_observed": False,
-                    }
+                    },
                 }
-            ]
+            ],
         },
         {
             "components": {
                 "red": {"bs": 1.0},
                 "green": {"pv": 1.0},
-                "blue": {"npv": 1.0}
+                "blue": {"npv": 1.0},
             },
             "scale_range": [0.0, 100.0],
-            "pq_masks": [
-                {
-                    "band": "water",
-                    "values": [1],
-                }
-            ]
+            "pq_masks": [{"band": "water", "values": [1]}],
         },
         {
             "components": {
                 "red": {"bs": 1.0},
                 "green": {"pv": 1.0},
-                "blue": {"npv": 1.0}
+                "blue": {"npv": 1.0},
             },
             "scale_range": [0.0, 100.0],
-            "pq_masks": [
-                {
-                    "band": "water",
-                    "values": [1],
-                    "invert": True,
-                }
-            ]
+            "pq_masks": [{"band": "water", "values": [1], "invert": True}],
         },
         {
             "components": {
                 "red": {"bs": 1.0},
                 "green": {"pv": 1.0},
-                "blue": {"npv": 1.0}
+                "blue": {"npv": 1.0},
             },
             "scale_range": [0.0, 100.0],
             "pq_masks": [
@@ -1087,71 +991,71 @@ def configs_for_combined_fc_wofs() -> list:
                         "low_solar_angle": False,
                         "high_slope": False,
                         "cloud_shadow": False,
-                    }
+                    },
                 },
                 {
                     # Mask out pixels with cloud AND no water observed
                     "band": "water",
-                    "flags": {
-                        "cloud": True,
-                        "water_observed": False,
-                    },
+                    "flags": {"cloud": True, "water_observed": False},
                     "invert": True,
                 },
-            ]
-        }
+            ],
+        },
     ]
+
 
 @pytest.fixture
 def multi_date_cfg() -> CFG_DICT:
-   return  {
-       "index_function": {
-           "function": "datacube_ows.band_utils.norm_diff",
-           "kwargs": {"band1": "nir", "band2": "red"},
-       },
-       "color_ramp": [
-           {"value": -1.0, "color": "#0000FF"},
-           {"value": -0.2, "color": "#005050", },
-           {"value": -0.1, "color": "#505050", },
-           {"value": -0.01, "color": "#303030", },
-           {"value": 0.0, "color": "black", },
-           {"value": 0.01, "color": "#303000", },
-           {"value": 0.5, "color": "#707030", },
-           {"value": 1.0, "color": "#FF9090", },
-       ],
-       "multi_date": [
-           {
-               "allowed_count_range": [2, 2],
-               "preserve_user_date_order": True,
-               "aggregator_function": {
-                   "function": "datacube_ows.band_utils.multi_date_delta"
-               },
-               "mpl_ramp": "RdYlBu",
-               "range": [-1.0, 1.0],
-           }
-       ]
-   }
+    return {
+        "index_function": {
+            "function": "datacube_ows.band_utils.norm_diff",
+            "kwargs": {"band1": "nir", "band2": "red"},
+        },
+        "color_ramp": [
+            {"value": -1.0, "color": "#0000FF"},
+            {"value": -0.2, "color": "#005050"},
+            {"value": -0.1, "color": "#505050"},
+            {"value": -0.01, "color": "#303030"},
+            {"value": 0.0, "color": "black"},
+            {"value": 0.01, "color": "#303000"},
+            {"value": 0.5, "color": "#707030"},
+            {"value": 1.0, "color": "#FF9090"},
+        ],
+        "multi_date": [
+            {
+                "allowed_count_range": [2, 2],
+                "preserve_user_date_order": True,
+                "aggregator_function": {
+                    "function": "datacube_ows.band_utils.multi_date_delta"
+                },
+                "mpl_ramp": "RdYlBu",
+                "range": [-1.0, 1.0],
+            }
+        ],
+    }
+
 
 xyt_coords = [
     ("x", [-1.0, -0.5, 0.0, 0.5, 1.0]),
     ("y", [-1.0, -0.5, 0.0, 0.5, 1.0]),
-    ("time", [
-                datetime.datetime(2021, 1, 1, 22, 44, 5),
-                datetime.datetime.now()
-              ])
+    ("time", [datetime.datetime(2021, 1, 1, 22, 44, 5), datetime.datetime.now()]),
 ]
+
 
 @pytest.fixture
 def xyt_dummydata() -> xr.Dataset:
-    return xr.Dataset({
+    return xr.Dataset(
+        {
             "red": dummy_da(1400, "red", xyt_coords, dtype="int16"),
             "green": dummy_da(700, "green", xyt_coords, dtype="int16"),
             "blue": dummy_da(1500, "blue", xyt_coords, dtype="int16"),
             "nir": dummy_da(2000, "nir", xyt_coords, dtype="int16"),
-        })
+        }
+    )
 
 
 @pytest.fixture
 def empty_driver_cache() -> None:
     from datacube_ows.index.driver import OWSIndexDriverCache
+
     OWSIndexDriverCache._instance = None

--- a/tests/test_band_utils.py
+++ b/tests/test_band_utils.py
@@ -4,8 +4,8 @@
 # Copyright (c) 2017-2024 OWS Contributors
 # SPDX-License-Identifier: Apache-2.0
 
-"""Test band math utilities
-"""
+"""Test band math utilities"""
+
 from collections.abc import Callable, Sequence
 from typing import Literal
 
@@ -73,12 +73,7 @@ def dummy_layer() -> OWSProductLayer:
 
 @pytest.fixture
 def band_mapper() -> Callable[[Literal["b1", "b2", "b1a", "b2a"]], str]:
-    idx = {
-        "b1": "b1",
-        "b2": "b2",
-        "b1a": "b1",
-        "b2a": "b2",
-    }
+    idx = {"b1": "b1", "b2": "b2", "b1a": "b1", "b2a": "b2"}
     return lambda b: idx[b]
 
 
@@ -126,7 +121,8 @@ def test_pre_scaled_norm_diff(band_mapper) -> None:
     assert (
         pre_scaled_norm_diff(
             TEST_XARR, "b1a", "b2", band_mapper=band_mapper, scale_from=[0, 1]
-        ) is not None
+        )
+        is not None
     )
     assert np.array_equal(
         pre_scaled_norm_diff(TEST_XARR2, "b3", "b2", 2.0, 0.0, 6.0, 0.0).values,
@@ -176,18 +172,32 @@ def test_single_band_offset_log(band_mapper) -> None:
     assert single_band_offset_log(TEST_XARR, "b1", offset=0.5) is not None
     assert single_band_offset_log(TEST_XARR, "b1", scale=100) is not None
     assert single_band_offset_log(TEST_XARR, "b1", scale_from=[0.0, 4.0]) is not None
-    assert single_band_offset_log(TEST_XARR, "b1", scale_from=[0.0, 4.0], scale_to=[0, 1024]) is not None
+    assert (
+        single_band_offset_log(
+            TEST_XARR, "b1", scale_from=[0.0, 4.0], scale_to=[0, 1024]
+        )
+        is not None
+    )
     assert single_band_offset_log(TEST_XARR, "b1", band_mapper=band_mapper) is not None
-    assert single_band_offset_log(TEST_XARR, "b1", mult_band="b2", band_mapper=band_mapper) is not None
+    assert (
+        single_band_offset_log(TEST_XARR, "b1", mult_band="b2", band_mapper=band_mapper)
+        is not None
+    )
 
 
 def test_single_band_arcsec(band_mapper) -> None:
     assert single_band_arcsec(TEST_XARR, "b1") is not None
     assert single_band_arcsec(TEST_XARR, "b1", scale_from=[0.0, 0.8]) is not None
-    assert single_band_arcsec(TEST_XARR, "b1", scale_from=[0.0, 0.8], scale_to=[0, 1024]) is not None
+    assert (
+        single_band_arcsec(TEST_XARR, "b1", scale_from=[0.0, 0.8], scale_to=[0, 1024])
+        is not None
+    )
     assert single_band_arcsec(TEST_XARR, "b1", band_mapper=band_mapper) is not None
 
 
 def test_rvi(band_mapper) -> None:
     assert radar_vegetation_index(TEST_XARR, "b1", "b2") is not None
-    assert radar_vegetation_index(TEST_XARR, "b1", "b2", band_mapper=band_mapper) is not None
+    assert (
+        radar_vegetation_index(TEST_XARR, "b1", "b2", band_mapper=band_mapper)
+        is not None
+    )

--- a/tests/test_cfg_bandidx.py
+++ b/tests/test_cfg_bandidx.py
@@ -52,9 +52,7 @@ def test_bidx_p_minimal(minimal_prod) -> None:
 
 
 def test_bidx_p_unready(minimal_prod) -> None:
-    bidx = BandIndex(minimal_prod, {
-        "foo": ["foo"]
-    })
+    bidx = BandIndex(minimal_prod, {"foo": ["foo"]})
     with pytest.raises(OWSConfigNotReady) as excinfo:
         _ = bidx.measurements
     assert "measurements" in str(excinfo.value)
@@ -68,25 +66,17 @@ def test_bidx_p_unready(minimal_prod) -> None:
 
 def test_bidx_p_duplicates(minimal_prod) -> None:
     with pytest.raises(ConfigException) as excinfo:
-        _ = BandIndex(minimal_prod, {
-            "foo": ["bar"],
-            "bar": ["baz"]
-        })
+        _ = BandIndex(minimal_prod, {"foo": ["bar"], "bar": ["baz"]})
     assert "Duplicate band name/alias" in str(excinfo.value)
     assert "bar" in str(excinfo.value)
     with pytest.raises(ConfigException) as excinfo:
-       _ = BandIndex(minimal_prod, {
-            "foo": ["bar"],
-            "boo": ["bar"]
-        })
+        _ = BandIndex(minimal_prod, {"foo": ["bar"], "boo": ["bar"]})
     assert "Duplicate band name/alias" in str(excinfo.value)
     assert "bar" in str(excinfo.value)
 
 
 def test_bidx_p_band(minimal_prod) -> None:
-    bidx = BandIndex(minimal_prod, {
-        "foo": ["bar", "baz"],
-    })
+    bidx = BandIndex(minimal_prod, {"foo": ["bar", "baz"]})
     assert bidx.band("foo") == "foo"
     assert bidx.band("bar") == "foo"
     assert bidx.band("baz") == "foo"
@@ -97,11 +87,10 @@ def test_bidx_p_band(minimal_prod) -> None:
 
 
 def test_bidx_p_band_labels(minimal_prod) -> None:
-    bidx = BandIndex(minimal_prod, {
-        "foo": ["bar", "foo", "baz"],
-        "zing": ["pow", "splat"],
-        "oof": [],
-    })
+    bidx = BandIndex(
+        minimal_prod,
+        {"foo": ["bar", "foo", "baz"], "zing": ["pow", "splat"], "oof": []},
+    )
     bls = bidx.band_labels()
     assert "bar" in bls
     assert "pow" in bls
@@ -110,9 +99,7 @@ def test_bidx_p_band_labels(minimal_prod) -> None:
 
 
 def test_bidx_p_label(minimal_prod) -> None:
-    bidx = BandIndex(minimal_prod, {
-        "foo": ["bar", "baz"],
-    })
+    bidx = BandIndex(minimal_prod, {"foo": ["bar", "baz"]})
     assert bidx.band_label("foo") == "bar"
     assert bidx.band_label("bar") == "bar"
     assert bidx.band_label("baz") == "bar"
@@ -123,12 +110,15 @@ def test_bidx_p_label(minimal_prod) -> None:
 
 
 def test_bidx_makeready(minimal_prod) -> None:
-    bidx = BandIndex(minimal_prod, {
-        "band1": [],
-        "band2": ["alias2"],
-        "band3": ["alias3", "band3"],
-        "band4": ["band4", "alias4"]
-    })
+    bidx = BandIndex(
+        minimal_prod,
+        {
+            "band1": [],
+            "band2": ["alias2"],
+            "band3": ["alias3", "band3"],
+            "band4": ["band4", "alias4"],
+        },
+    )
     bidx.make_ready()
     assert bidx.ready
     assert bidx.band("band1") == "band1"
@@ -139,6 +129,7 @@ def test_bidx_makeready(minimal_prod) -> None:
 
 def test_bidx_makeready_default(minimal_prod) -> None:
     import numpy as np
+
     bidx = BandIndex(minimal_prod, {})
     bidx.make_ready()
     assert bidx.ready
@@ -155,10 +146,7 @@ def test_bidx_makeready_default(minimal_prod) -> None:
 
 
 def test_bidx_makeready_invalid_band(minimal_prod) -> None:
-    bidx = BandIndex(minimal_prod, {
-        "band1": ["band1", "valid"],
-        "bandx": ["invalid"]
-    })
+    bidx = BandIndex(minimal_prod, {"band1": ["band1", "valid"], "bandx": ["invalid"]})
     assert bidx.band("valid") == "band1"
     assert bidx.band("invalid") == "bandx"
     with pytest.raises(ConfigException) as excinfo:

--- a/tests/test_cfg_cache_ctrl.py
+++ b/tests/test_cfg_cache_ctrl.py
@@ -38,10 +38,11 @@ def test_never_cache(ccr_min_layer) -> None:
 
 
 def test_complex_case(ccr_min_layer) -> None:
-    ccr = CacheControlRules([
-        {"min_datasets": 3, "max_age": 10000},
-        {"min_datasets": 8, "max_age": 20000},
-    ], ccr_min_layer, 12)
+    ccr = CacheControlRules(
+        [{"min_datasets": 3, "max_age": 10000}, {"min_datasets": 8, "max_age": 20000}],
+        ccr_min_layer,
+        12,
+    )
     assert ccr.use_caching
     assert ccr.cache_headers(0) == {"cache-control": "no-cache"}
     assert ccr.cache_headers(2) == {"cache-control": "no-cache"}
@@ -54,9 +55,7 @@ def test_complex_case(ccr_min_layer) -> None:
 
 def test_no_min_datasets_element() -> None:
     with pytest.raises(ConfigException) as e:
-        _ = CacheControlRules([
-            {"max_age": 20000},
-        ], "Layer a_layer", 12)
+        _ = CacheControlRules([{"max_age": 20000}], "Layer a_layer", 12)
     assert "Dataset cache rule does not contain" in str(e.value)
     assert "min_datasets" in str(e.value)
     assert "a_layer" in str(e.value)
@@ -64,9 +63,7 @@ def test_no_min_datasets_element() -> None:
 
 def test_no_max_age_element() -> None:
     with pytest.raises(ConfigException) as e:
-        _ = CacheControlRules([
-            {"min_datasets": 2},
-        ], "layer a_layer", 12)
+        _ = CacheControlRules([{"min_datasets": 2}], "layer a_layer", 12)
     assert "Dataset cache rule does not contain" in str(e.value)
     assert "max_age" in str(e.value)
     assert "a_layer" in str(e.value)
@@ -74,9 +71,9 @@ def test_no_max_age_element() -> None:
 
 def test_nonint_min_ds() -> None:
     with pytest.raises(ConfigException) as e:
-        _ = CacheControlRules([
-            {"min_datasets": "2", "max_age": 2000},
-        ], "layer a_layer", 12)
+        _ = CacheControlRules(
+            [{"min_datasets": "2", "max_age": 2000}], "layer a_layer", 12
+        )
     assert "Dataset cache rule" in str(e.value)
     assert "min_datasets" in str(e.value)
     assert "non-integer" in str(e.value)
@@ -85,9 +82,9 @@ def test_nonint_min_ds() -> None:
 
 def test_nonint_max_age() -> None:
     with pytest.raises(ConfigException) as e:
-        _ = CacheControlRules([
-            {"min_datasets": 2, "max_age": 2000.5},
-        ], "layer a_layer", 12)
+        _ = CacheControlRules(
+            [{"min_datasets": 2, "max_age": 2000.5}], "layer a_layer", 12
+        )
     assert "Dataset cache rule" in str(e.value)
     assert "max_age" in str(e.value)
     assert "non-integer" in str(e.value)
@@ -96,9 +93,9 @@ def test_nonint_max_age() -> None:
 
 def test_negative_min_datasets() -> None:
     with pytest.raises(ConfigException) as e:
-        _ = CacheControlRules([
-            {"min_datasets": -2, "max_age": 2000},
-        ], "layer a_layer", 12)
+        _ = CacheControlRules(
+            [{"min_datasets": -2, "max_age": 2000}], "layer a_layer", 12
+        )
     assert "Invalid dataset cache rule" in str(e.value)
     assert "min_datasets" in str(e.value)
     assert "must be greater than zero" in str(e.value)
@@ -107,10 +104,14 @@ def test_negative_min_datasets() -> None:
 
 def test_unsorted_min_datasets() -> None:
     with pytest.raises(ConfigException) as e:
-        _ = CacheControlRules([
-            {"min_datasets": 4, "max_age": 2000},
-            {"min_datasets": 2, "max_age": 4000},
-        ], "layer a_layer", 12)
+        _ = CacheControlRules(
+            [
+                {"min_datasets": 4, "max_age": 2000},
+                {"min_datasets": 2, "max_age": 4000},
+            ],
+            "layer a_layer",
+            12,
+        )
     assert "Dataset cache rules must be sorted" in str(e.value)
     assert "ascending" in str(e.value)
     assert "min_datasets" in str(e.value)
@@ -119,10 +120,14 @@ def test_unsorted_min_datasets() -> None:
 
 def test_min_datasets_max_datasets() -> None:
     with pytest.raises(ConfigException) as e:
-        _ = CacheControlRules([
-            {"min_datasets": 2, "max_age": 2000},
-            {"min_datasets": 4, "max_age": 4000},
-        ], "layer a_layer", 2)
+        _ = CacheControlRules(
+            [
+                {"min_datasets": 2, "max_age": 2000},
+                {"min_datasets": 4, "max_age": 4000},
+            ],
+            "layer a_layer",
+            2,
+        )
     assert "Dataset cache rule" in str(e.value)
     assert "min_datasets" in str(e.value)
     assert "exceeds the max_datasets limit" in str(e.value)
@@ -131,9 +136,7 @@ def test_min_datasets_max_datasets() -> None:
 
 def test_non_negative_max_age() -> None:
     with pytest.raises(ConfigException) as e:
-        _ = CacheControlRules([
-            {"min_datasets": 2, "max_age": -2},
-        ], "layer a_layer", 12)
+        _ = CacheControlRules([{"min_datasets": 2, "max_age": -2}], "layer a_layer", 12)
     assert "Dataset cache rule" in str(e.value)
     assert "max_age" in str(e.value)
     assert "must be greater than zero" in str(e.value)
@@ -142,10 +145,14 @@ def test_non_negative_max_age() -> None:
 
 def test_unsorted_max_age() -> None:
     with pytest.raises(ConfigException) as e:
-        _ = CacheControlRules([
-            {"min_datasets": 2, "max_age": 4000},
-            {"min_datasets": 4, "max_age": 2000},
-        ], "layer a_layer", 12)
+        _ = CacheControlRules(
+            [
+                {"min_datasets": 2, "max_age": 4000},
+                {"min_datasets": 4, "max_age": 2000},
+            ],
+            "layer a_layer",
+            12,
+        )
     assert "dataset cache rules" in str(e.value)
     assert "must increase monotonically" in str(e.value)
     assert "max_age" in str(e.value)

--- a/tests/test_cfg_global.py
+++ b/tests/test_cfg_global.py
@@ -13,6 +13,7 @@ from datacube_ows.ows_configuration import ContactInfo, OWSConfig
 def test_minimal_global(monkeypatch, minimal_global_raw_cfg, minimal_dc) -> None:
     def fake_dc(*args, **kwargs):
         return minimal_dc
+
     monkeypatch.setattr("datacube_ows.ows_configuration.Datacube", fake_dc)
     OWSConfig._instance = None
     cfg = OWSConfig(cfg=minimal_global_raw_cfg)
@@ -20,7 +21,7 @@ def test_minimal_global(monkeypatch, minimal_global_raw_cfg, minimal_dc) -> None
     assert cfg.ready
     assert cfg.initialised
     assert not cfg.wcs_tiff_statistics
-    assert cfg.default_geographic_CRS == "" # No WCS
+    assert cfg.default_geographic_CRS == ""  # No WCS
 
 
 def test_global_no_title(minimal_global_raw_cfg) -> None:
@@ -31,9 +32,12 @@ def test_global_no_title(minimal_global_raw_cfg) -> None:
     assert "Entity global has no title" in str(excinfo.value)
 
 
-def test_wcs_only(monkeypatch, minimal_global_raw_cfg, wcs_global_cfg, minimal_dc) -> None:
+def test_wcs_only(
+    monkeypatch, minimal_global_raw_cfg, wcs_global_cfg, minimal_dc
+) -> None:
     def fake_dc(*args, **kwargs):
         return minimal_dc
+
     monkeypatch.setattr("datacube_ows.ows_configuration.Datacube", fake_dc)
     OWSConfig._instance = None
     minimal_global_raw_cfg["global"]["services"] = {
@@ -51,9 +55,13 @@ def test_wcs_only(monkeypatch, minimal_global_raw_cfg, wcs_global_cfg, minimal_d
     assert cfg.wcs_tiff_statistics
     assert cfg.default_geographic_CRS == "urn:ogc:def:crs:OGC:1.3:CRS84"
 
-def test_geog_crs(minimal_global_raw_cfg, wcs_global_cfg, minimal_dc, monkeypatch) -> None:
+
+def test_geog_crs(
+    minimal_global_raw_cfg, wcs_global_cfg, minimal_dc, monkeypatch
+) -> None:
     def fake_dc(*args, **kwargs):
         return minimal_dc
+
     monkeypatch.setattr("datacube_ows.ows_configuration.Datacube", fake_dc)
     OWSConfig._instance = None
     minimal_global_raw_cfg["global"]["services"] = {
@@ -67,7 +75,7 @@ def test_geog_crs(minimal_global_raw_cfg, wcs_global_cfg, minimal_dc, monkeypatc
             "geographic": False,
             "horizontal_coord": "x",
             "vertical_coord": "y",
-        },
+        }
     }
     with pytest.raises(ConfigException) as e:
         cfg = OWSConfig(cfg=minimal_global_raw_cfg)
@@ -117,10 +125,7 @@ def test_wcs_no_native_format(minimal_global_raw_cfg, wcs_global_cfg) -> None:
 
 def test_no_services(minimal_global_raw_cfg) -> None:
     OWSConfig._instance = None
-    minimal_global_raw_cfg["global"]["services"] = {
-        "wms": False,
-        "wmts": False,
-    }
+    minimal_global_raw_cfg["global"]["services"] = {"wms": False, "wmts": False}
     with pytest.raises(ConfigException) as excinfo:
         _ = OWSConfig(cfg=minimal_global_raw_cfg)
     assert "At least one service must be active" in str(excinfo.value)
@@ -138,7 +143,7 @@ def test_bad_geographic_crs(minimal_global_raw_cfg) -> None:
     OWSConfig._instance = None
     minimal_global_raw_cfg["global"]["published_CRSs"]["EPSG:7777"] = {
         "geographic": True,
-        "horizontal_coord": "x"
+        "horizontal_coord": "x",
     }
     with pytest.raises(ConfigException) as excinfo:
         _ = OWSConfig(cfg=minimal_global_raw_cfg)
@@ -149,7 +154,7 @@ def test_bad_geographic_crs(minimal_global_raw_cfg) -> None:
     OWSConfig._instance = None
     minimal_global_raw_cfg["global"]["published_CRSs"]["EPSG:7777"] = {
         "geographic": True,
-        "vertical_coord": "y"
+        "vertical_coord": "y",
     }
     with pytest.raises(ConfigException) as excinfo:
         _ = OWSConfig(cfg=minimal_global_raw_cfg)
@@ -162,7 +167,7 @@ def test_bad_geographic_crs(minimal_global_raw_cfg) -> None:
 def test_bad_crs_alias(minimal_global_raw_cfg) -> None:
     OWSConfig._instance = None
     minimal_global_raw_cfg["global"]["published_CRSs"]["EPSG:7777"] = {
-        "alias": "EPSG:6666",
+        "alias": "EPSG:6666"
     }
     cfg = OWSConfig(cfg=minimal_global_raw_cfg)
     assert "EPSG:7777" not in cfg.published_CRSs
@@ -180,9 +185,7 @@ def test_no_wcs(minimal_global_raw_cfg) -> None:
 def test_no_wcs_formats(minimal_global_raw_cfg) -> None:
     OWSConfig._instance = None
     minimal_global_raw_cfg["global"]["services"] = {"wcs": True}
-    minimal_global_raw_cfg["wcs"] = {
-        "formats": {}
-    }
+    minimal_global_raw_cfg["wcs"] = {"formats": {}}
     with pytest.raises(ConfigException) as excinfo:
         _ = OWSConfig(cfg=minimal_global_raw_cfg)
     assert "Must configure at least one wcs format" in str(excinfo.value)
@@ -208,9 +211,11 @@ def test_tiff_stats(minimal_global_raw_cfg, wcs_global_cfg) -> None:
     cfg = OWSConfig(cfg=minimal_global_raw_cfg)
     assert not cfg.wcs_tiff_statistics
 
+
 def test_crs_lookup_fail(monkeypatch, minimal_global_raw_cfg, minimal_dc) -> None:
     def fake_dc(*args, **kwargs):
         return minimal_dc
+
     monkeypatch.setattr("datacube_ows.ows_configuration.Datacube", fake_dc)
     OWSConfig._instance = None
     cfg = OWSConfig(cfg=minimal_global_raw_cfg)
@@ -233,7 +238,7 @@ def test_two_langs(minimal_global_raw_cfg, minimal_dc) -> None:
     minimal_global_raw_cfg["global"]["supported_languages"] = ["fr", "en"]
     cfg = OWSConfig(cfg=minimal_global_raw_cfg)
 
-    assert cfg.global_config().default_locale == 'fr'
+    assert cfg.global_config().default_locale == "fr"
     assert len(cfg.global_config().locales) == 2
     assert not cfg.global_config().internationalised
 
@@ -242,7 +247,9 @@ def test_internationalised(minimal_global_raw_cfg, minimal_dc) -> None:
     OWSConfig._instance = None
 
     minimal_global_raw_cfg["global"]["supported_languages"] = ["fr", "en"]
-    minimal_global_raw_cfg["global"]["translations_directory"] = "/integration_tests/cfg/translations" # no need to be valid
+    minimal_global_raw_cfg["global"]["translations_directory"] = (
+        "/integration_tests/cfg/translations"  # no need to be valid
+    )
     cfg = OWSConfig(cfg=minimal_global_raw_cfg)
     assert cfg.global_config().internationalised
 
@@ -259,7 +266,9 @@ def test_bad_integers_in_wms_section(minimal_global_raw_cfg) -> None:
     with pytest.raises(ConfigException) as e:
         OWSConfig._instance = None
         _ = OWSConfig(cfg=minimal_global_raw_cfg)
-    assert "max_width and max_height in wms section must be positive integers" in str(e.value)
+    assert "max_width and max_height in wms section must be positive integers" in str(
+        e.value
+    )
     assert "0" in str(e.value)
     minimal_global_raw_cfg["wms"]["max_width"] = 256
     minimal_global_raw_cfg["wms"]["caps_cache_maxage"] = "forever"

--- a/tests/test_cfg_inclusion.py
+++ b/tests/test_cfg_inclusion.py
@@ -16,6 +16,7 @@ src_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 if src_dir not in sys.path:
     sys.path.append(src_dir)
 
+
 def test_get_file_loc(monkeypatch) -> None:
     monkeypatch.setenv("DATACUBE_OWS_CFG_ALLOW_S3", "YES")
     cwd = os.getcwd()
@@ -25,7 +26,10 @@ def test_get_file_loc(monkeypatch) -> None:
     assert get_file_loc("baz/foo.bar") == os.path.join(cwd, "baz")
     assert get_file_loc("/etc/conf/foo.bar") == "/etc/conf"
     assert get_file_loc("s3://testbucket/foo.bar") == "s3://testbucket"
-    assert get_file_loc("s3://testbucket/frobnicate/biz/baz.bar") == "s3://testbucket/frobnicate/biz"
+    assert (
+        get_file_loc("s3://testbucket/frobnicate/biz/baz.bar")
+        == "s3://testbucket/frobnicate/biz"
+    )
 
 
 def test_get_file_loc_s3_disable(monkeypatch) -> None:
@@ -57,7 +61,10 @@ def test_get_file_loc_s3_enable(monkeypatch) -> None:
     assert get_file_loc("s3://testbucket/dir/foo.bar") == "s3://testbucket/dir"
 
     monkeypatch.setenv("DATACUBE_OWS_CFG_ALLOW_S3", "1")
-    assert get_file_loc("s3://testbucket/nested/dir/foo.bar") == "s3://testbucket/nested/dir"
+    assert (
+        get_file_loc("s3://testbucket/nested/dir/foo.bar")
+        == "s3://testbucket/nested/dir"
+    )
 
     monkeypatch.setenv("DATACUBE_OWS_CFG_ALLOW_S3", "Y")
     assert get_file_loc("s3://testbucket/foo.bar") == "s3://testbucket"
@@ -79,11 +86,11 @@ def test_cfg_inject() -> None:
 
 def test_cfg_not_a_dict(monkeypatch) -> None:
     with pytest.raises(ConfigException):
-        read_config('nested.not_a_dict')
+        read_config("nested.not_a_dict")
 
 
 def test_cfg_direct(monkeypatch) -> None:
-    monkeypatch.setenv("DATACUBE_OWS_CFG", "{\"test\": 12345}")
+    monkeypatch.setenv("DATACUBE_OWS_CFG", '{"test": 12345}')
     cfg = read_config()
 
     assert cfg["test"] == 12345

--- a/tests/test_cfg_layer.py
+++ b/tests/test_cfg_layer.py
@@ -18,29 +18,23 @@ from datacube_ows.resource_limits import ResourceLimited
 
 def test_missing_title(minimal_global_cfg) -> None:
     with pytest.raises(ConfigException) as excinfo:
-        _ = OWSFolder({
-            "abstract": "The Abstract"
-        },
-            global_cfg=minimal_global_cfg)
+        _ = OWSFolder({"abstract": "The Abstract"}, global_cfg=minimal_global_cfg)
     assert "Entity folder.0 has no title" in str(excinfo.value)
 
 
 def test_inherit_no_abstract(minimal_global_cfg) -> None:
-    lyr = OWSFolder({
-            "title": "The Title",
-            "layers": [],
-        },
-        global_cfg=minimal_global_cfg)
+    lyr = OWSFolder({"title": "The Title", "layers": []}, global_cfg=minimal_global_cfg)
     assert lyr.abstract == "Global Abstract"
     assert lyr.is_inherited("abstract")
 
+
 def test_inherit_parent(minimal_global_cfg, minimal_parent) -> None:
-    lyr = OWSLayer({
-            "title": "The Title",
-    },
+    lyr = OWSLayer(
+        {"title": "The Title"},
         object_label="foo",
         parent_layer=minimal_parent,
-        global_cfg=minimal_global_cfg)
+        global_cfg=minimal_global_cfg,
+    )
     assert lyr.abstract == "Parent Abstract"
     assert lyr.attribution.title == "Parent Attribution"
     assert "global" in lyr.keywords
@@ -48,15 +42,17 @@ def test_inherit_parent(minimal_global_cfg, minimal_parent) -> None:
 
 
 def test_override_parent(minimal_global_cfg, minimal_parent) -> None:
-    lyr = OWSLayer({
-        "title": "The Title",
-        "attribution": {},
-        "abstract": "The Abstract",
-        "keywords": ["merged"]
-    },
+    lyr = OWSLayer(
+        {
+            "title": "The Title",
+            "attribution": {},
+            "abstract": "The Abstract",
+            "keywords": ["merged"],
+        },
         object_label="foo",
         parent_layer=minimal_parent,
-        global_cfg=minimal_global_cfg)
+        global_cfg=minimal_global_cfg,
+    )
     assert lyr.abstract == "The Abstract"
     assert lyr.attribution is None
     assert "global" in lyr.keywords
@@ -66,11 +62,10 @@ def test_override_parent(minimal_global_cfg, minimal_parent) -> None:
 
 
 def test_minimal_folder(minimal_global_cfg) -> None:
-    lyr = OWSFolder({
-        "title": "The Title",
-        "abstract": "The Abstract",
-        "layers": []
-    }, global_cfg=minimal_global_cfg)
+    lyr = OWSFolder(
+        {"title": "The Title", "abstract": "The Abstract", "layers": []},
+        global_cfg=minimal_global_cfg,
+    )
     assert lyr.child_layers == []
     assert lyr.layer_count() == 0
     assert lyr.unready_layer_count() == 0
@@ -78,20 +73,19 @@ def test_minimal_folder(minimal_global_cfg) -> None:
 
 def test_folder_nolayers(minimal_global_cfg) -> None:
     with pytest.raises(ConfigException) as excinfo:
-        _ = OWSFolder({
-            "title": "The Title",
-            "abstract": "The Abstract",
-        }, global_cfg=minimal_global_cfg)
+        _ = OWSFolder(
+            {"title": "The Title", "abstract": "The Abstract"},
+            global_cfg=minimal_global_cfg,
+        )
     assert "No layers section" in str(excinfo.value)
     assert "The Title" in str(excinfo.value)
 
 
 def test_folder_counts(minimal_global_cfg) -> None:
-    lyr = OWSFolder({
-        "title": "The Title",
-        "abstract": "The Abstract",
-        "layers": []
-    }, global_cfg=minimal_global_cfg)
+    lyr = OWSFolder(
+        {"title": "The Title", "abstract": "The Abstract", "layers": []},
+        global_cfg=minimal_global_cfg,
+    )
     l1 = MagicMock()
     l2 = MagicMock()
     l3 = MagicMock()
@@ -107,60 +101,59 @@ def test_folder_counts(minimal_global_cfg) -> None:
 
 
 def test_catch_invalid_folder_layers(minimal_global_cfg) -> None:
-    lyr = OWSFolder({
-        "title": "The Title",
-        "abstract": "The Abstract",
-        "layers": [
-            {"invalid": "config"}
-        ]
-    }, global_cfg=minimal_global_cfg)
+    lyr = OWSFolder(
+        {
+            "title": "The Title",
+            "abstract": "The Abstract",
+            "layers": [{"invalid": "config"}],
+        },
+        global_cfg=minimal_global_cfg,
+    )
     assert len(lyr.unready_layers) == 0
 
 
 def test_catch_folder_as_list(minimal_global_cfg) -> None:
-    lyr = OWSFolder({
-        "title": "The Title",
-        "abstract": "The Abstract",
-        "layers": [
-            [{"title": "wrong", "abstract": "wrong", "layers": []}]
-        ]
-    }, global_cfg=minimal_global_cfg)
+    lyr = OWSFolder(
+        {
+            "title": "The Title",
+            "abstract": "The Abstract",
+            "layers": [[{"title": "wrong", "abstract": "wrong", "layers": []}]],
+        },
+        global_cfg=minimal_global_cfg,
+    )
     assert len(lyr.unready_layers) == 0
 
 
 def test_duplicate_folder_label(minimal_global_cfg) -> None:
     with pytest.raises(ConfigException) as e:
-        _ = OWSFolder({
-            "title": "The Title",
-            "abstract": "The Abstract",
-            "label": "existing_folder",
-            "layers": [
-                {"invalid": "config"}
-            ]
-        }, global_cfg=minimal_global_cfg)
+        _ = OWSFolder(
+            {
+                "title": "The Title",
+                "abstract": "The Abstract",
+                "label": "existing_folder",
+                "layers": [{"invalid": "config"}],
+            },
+            global_cfg=minimal_global_cfg,
+        )
     assert "Duplicate folder label" in str(e.value)
     assert "existing_folder" in str(e.value)
 
 
 def test_make_ready_empty(minimal_global_cfg, minimal_dc) -> None:
-    lyr = OWSFolder({
-        "title": "The Title",
-        "abstract": "The Abstract",
-        "layers": [
-        ]
-    }, global_cfg=minimal_global_cfg)
+    lyr = OWSFolder(
+        {"title": "The Title", "abstract": "The Abstract", "layers": []},
+        global_cfg=minimal_global_cfg,
+    )
     lyr.make_ready(minimal_dc)
     assert len(lyr.unready_layers) == 0
     assert lyr.ready
 
 
 def test_make_ready_catch_errors(minimal_global_cfg, minimal_dc) -> None:
-    lyr = OWSFolder({
-        "title": "The Title",
-        "abstract": "The Abstract",
-        "layers": [
-        ]
-    }, global_cfg=minimal_global_cfg)
+    lyr = OWSFolder(
+        {"title": "The Title", "abstract": "The Abstract", "layers": []},
+        global_cfg=minimal_global_cfg,
+    )
     testchild = MagicMock()
     testchild.make_ready.side_effect = ConfigException("KerPow!")
     lyr.unready_layers.append(testchild)
@@ -171,8 +164,7 @@ def test_make_ready_catch_errors(minimal_global_cfg, minimal_dc) -> None:
 
 
 def test_minimal_named_layer(minimal_layer_cfg, minimal_global_cfg, mock_range) -> None:
-    lyr = parse_ows_layer(minimal_layer_cfg,
-                          global_cfg=minimal_global_cfg)
+    lyr = parse_ows_layer(minimal_layer_cfg, global_cfg=minimal_global_cfg)
     assert lyr.name == "a_layer"
     assert not lyr.ready
     with patch("datacube_ows.index.postgres.api.get_ranges_impl") as get_rng:
@@ -186,23 +178,22 @@ def test_minimal_named_layer(minimal_layer_cfg, minimal_global_cfg, mock_range) 
     assert lyr.mosaic_date_func is None
 
 
-def test_duplicate_named_layer(minimal_layer_cfg, minimal_global_cfg, mock_range) -> None:
-    lyr = parse_ows_layer(minimal_layer_cfg,
-                          global_cfg=minimal_global_cfg)
+def test_duplicate_named_layer(
+    minimal_layer_cfg, minimal_global_cfg, mock_range
+) -> None:
+    lyr = parse_ows_layer(minimal_layer_cfg, global_cfg=minimal_global_cfg)
     with patch("datacube_ows.index.postgres.api.get_ranges_impl") as get_rng:
         get_rng.return_value = mock_range
         lyr.make_ready()
     with pytest.raises(ConfigException) as e:
-        lyr = parse_ows_layer(minimal_layer_cfg,
-                              global_cfg=minimal_global_cfg)
+        lyr = parse_ows_layer(minimal_layer_cfg, global_cfg=minimal_global_cfg)
     assert "a_layer" in str(e.value)
     assert "Duplicate layer name" in str(e.value)
 
 
 def test_lowres_named_layer(minimal_layer_cfg, minimal_global_cfg) -> None:
     minimal_layer_cfg["low_res_product_name"] = "smol_foo"
-    lyr = parse_ows_layer(minimal_layer_cfg,
-                          global_cfg=minimal_global_cfg)
+    lyr = parse_ows_layer(minimal_layer_cfg, global_cfg=minimal_global_cfg)
     lyr.make_ready()
     assert len(lyr.low_res_products) == 1
 
@@ -210,16 +201,14 @@ def test_lowres_named_layer(minimal_layer_cfg, minimal_global_cfg) -> None:
 def test_double_underscore_product_name(minimal_layer_cfg, minimal_global_cfg) -> None:
     minimal_layer_cfg["product_name"] = "no__double__underscores"
     with pytest.raises(ConfigException) as excinfo:
-        _ = parse_ows_layer(minimal_layer_cfg,
-                              global_cfg=minimal_global_cfg)
+        _ = parse_ows_layer(minimal_layer_cfg, global_cfg=minimal_global_cfg)
     assert "double underscore" in str(excinfo.value)
 
 
 def test_no_product_name(minimal_layer_cfg, minimal_global_cfg) -> None:
     del minimal_layer_cfg["product_name"]
     with pytest.raises(ConfigException) as excinfo:
-        _ = parse_ows_layer(minimal_layer_cfg,
-                              global_cfg=minimal_global_cfg)
+        _ = parse_ows_layer(minimal_layer_cfg, global_cfg=minimal_global_cfg)
     assert "product names" in str(excinfo.value)
     assert "a_layer" in str(excinfo.value)
 
@@ -227,8 +216,7 @@ def test_no_product_name(minimal_layer_cfg, minimal_global_cfg) -> None:
 def test_bad_product_name(minimal_layer_cfg, minimal_global_cfg, minimal_dc) -> None:
     minimal_layer_cfg["product_name"] = "foolookupfail"
     minimal_dc.index.products.get_by_name.return_value = None
-    lyr = parse_ows_layer(minimal_layer_cfg,
-                          global_cfg=minimal_global_cfg)
+    lyr = parse_ows_layer(minimal_layer_cfg, global_cfg=minimal_global_cfg)
     with pytest.raises(ConfigException) as excinfo:
         lyr.make_ready(dc=minimal_dc)
     assert "Could not find product" in str(excinfo.value)
@@ -236,10 +224,11 @@ def test_bad_product_name(minimal_layer_cfg, minimal_global_cfg, minimal_dc) -> 
     assert "a_layer" in str(excinfo.value)
 
 
-def test_bad_lowres_product_name(minimal_layer_cfg, minimal_global_cfg, minimal_dc) -> None:
+def test_bad_lowres_product_name(
+    minimal_layer_cfg, minimal_global_cfg, minimal_dc
+) -> None:
     minimal_layer_cfg["low_res_product_name"] = "smolfoolookupfail"
-    lyr = parse_ows_layer(minimal_layer_cfg,
-                          global_cfg=minimal_global_cfg)
+    lyr = parse_ows_layer(minimal_layer_cfg, global_cfg=minimal_global_cfg)
     with pytest.raises(ConfigException) as excinfo:
         lyr.make_ready(dc=minimal_dc)
     assert "Could not find product" in str(excinfo.value)
@@ -250,38 +239,38 @@ def test_bad_lowres_product_name(minimal_layer_cfg, minimal_global_cfg, minimal_
 def test_plural_in_nonmultiproduct(minimal_layer_cfg, minimal_global_cfg) -> None:
     minimal_layer_cfg["low_res_product_names"] = "smolfoolookupfail"
     with pytest.raises(ConfigException) as excinfo:
-        _ = parse_ows_layer(minimal_layer_cfg,
-                              global_cfg=minimal_global_cfg)
+        _ = parse_ows_layer(minimal_layer_cfg, global_cfg=minimal_global_cfg)
     assert "a_layer" in str(excinfo.value)
-    assert "'low_res_product_names' entry in non-multi-product layer" in str(excinfo.value)
+    assert "'low_res_product_names' entry in non-multi-product layer" in str(
+        excinfo.value
+    )
     assert "use 'low_res_product_name' only" in str(excinfo.value)
     del minimal_layer_cfg["low_res_product_names"]
     minimal_layer_cfg["product_names"] = ["foo", "bar"]
     with pytest.raises(ConfigException) as excinfo:
-        _ = parse_ows_layer(minimal_layer_cfg,
-                              global_cfg=minimal_global_cfg)
+        _ = parse_ows_layer(minimal_layer_cfg, global_cfg=minimal_global_cfg)
     assert "a_layer" in str(excinfo.value)
     assert "'product_names' entry in non-multi-product layer" in str(excinfo.value)
     assert "use 'product_name' only" in str(excinfo.value)
 
 
 def test_flag_plural_in_nonmultiproduct(minimal_layer_cfg, minimal_global_cfg) -> None:
-    minimal_layer_cfg["flags"] = {
-        "band": "foo",
-        "products": ["prod1", "prod2"],
-    }
+    minimal_layer_cfg["flags"] = {"band": "foo", "products": ["prod1", "prod2"]}
     with pytest.raises(ConfigException) as excinfo:
-        _ = parse_ows_layer(minimal_layer_cfg,
-                              global_cfg=minimal_global_cfg)
+        _ = parse_ows_layer(minimal_layer_cfg, global_cfg=minimal_global_cfg)
     assert "a_layer" in str(excinfo.value)
-    assert "'products' entry in flags section of non-multi-product layer" in str(excinfo.value)
+    assert "'products' entry in flags section of non-multi-product layer" in str(
+        excinfo.value
+    )
     assert "use 'product' only" in str(excinfo.value)
     del minimal_layer_cfg["flags"]["products"]
     minimal_layer_cfg["flags"]["low_res_products"] = ["smolfoo", "smolbar"]
     with pytest.raises(ConfigException) as excinfo:
-        _ = parse_ows_layer(minimal_layer_cfg,
-                              global_cfg=minimal_global_cfg)
-    assert "'low_res_products' entry in flags section of non-multi-product layer" in str(excinfo.value)
+        _ = parse_ows_layer(minimal_layer_cfg, global_cfg=minimal_global_cfg)
+    assert (
+        "'low_res_products' entry in flags section of non-multi-product layer"
+        in str(excinfo.value)
+    )
     assert "use 'low_res_product' only" in str(excinfo.value)
     assert "a_layer" in str(excinfo.value)
 
@@ -289,55 +278,56 @@ def test_flag_plural_in_nonmultiproduct(minimal_layer_cfg, minimal_global_cfg) -
 def test_singular_in_multiproduct(minimal_multiprod_cfg, minimal_global_cfg) -> None:
     minimal_multiprod_cfg["low_res_product_name"] = "smolfoolookupfail"
     with pytest.raises(ConfigException) as excinfo:
-        _ = parse_ows_layer(minimal_multiprod_cfg,
-                              global_cfg=minimal_global_cfg)
+        _ = parse_ows_layer(minimal_multiprod_cfg, global_cfg=minimal_global_cfg)
     assert "'low_res_product_name' entry in multi-product layer" in str(excinfo.value)
     assert "use 'low_res_product_names' only" in str(excinfo.value)
     assert "a_layer" in str(excinfo.value)
     del minimal_multiprod_cfg["low_res_product_name"]
     minimal_multiprod_cfg["product_name"] = "foo"
     with pytest.raises(ConfigException) as excinfo:
-        _ = parse_ows_layer(minimal_multiprod_cfg,
-                              global_cfg=minimal_global_cfg)
+        _ = parse_ows_layer(minimal_multiprod_cfg, global_cfg=minimal_global_cfg)
     assert "'product_name' entry in multi-product layer" in str(excinfo.value)
     assert "use 'product_names' only" in str(excinfo.value)
     assert "a_layer" in str(excinfo.value)
 
 
-def test_flag_singular_in_multiproduct(minimal_multiprod_cfg, minimal_global_cfg) -> None:
-    minimal_multiprod_cfg["flags"] = {
-        "band": "foo",
-        "product": "goo",
-    }
+def test_flag_singular_in_multiproduct(
+    minimal_multiprod_cfg, minimal_global_cfg
+) -> None:
+    minimal_multiprod_cfg["flags"] = {"band": "foo", "product": "goo"}
     with pytest.raises(ConfigException) as excinfo:
-        _ = parse_ows_layer(minimal_multiprod_cfg,
-                          global_cfg=minimal_global_cfg)
-    assert "'product' entry in flags section of multi-product layer" in str(excinfo.value)
+        _ = parse_ows_layer(minimal_multiprod_cfg, global_cfg=minimal_global_cfg)
+    assert "'product' entry in flags section of multi-product layer" in str(
+        excinfo.value
+    )
     assert "use 'products' only" in str(excinfo.value)
     assert "a_layer" in str(excinfo.value)
     del minimal_multiprod_cfg["flags"]["product"]
     minimal_multiprod_cfg["flags"]["low_res_product"] = "smolfoo"
     with pytest.raises(ConfigException) as excinfo:
-        _ = parse_ows_layer(minimal_multiprod_cfg,
-                              global_cfg=minimal_global_cfg)
-    assert "'low_res_product' entry in flags section of multi-product layer" in str(excinfo.value)
+        _ = parse_ows_layer(minimal_multiprod_cfg, global_cfg=minimal_global_cfg)
+    assert "'low_res_product' entry in flags section of multi-product layer" in str(
+        excinfo.value
+    )
     assert "use 'low_res_products' only" in str(excinfo.value)
     assert "a_layer" in str(excinfo.value)
 
 
-def test_noprod_multiproduct(minimal_multiprod_cfg, minimal_global_cfg, minimal_dc) -> None:
+def test_noprod_multiproduct(
+    minimal_multiprod_cfg, minimal_global_cfg, minimal_dc
+) -> None:
     minimal_multiprod_cfg["product_names"] = []
     with pytest.raises(ConfigException) as excinfo:
-        _ = parse_ows_layer(minimal_multiprod_cfg,
-                          global_cfg=minimal_global_cfg)
+        _ = parse_ows_layer(minimal_multiprod_cfg, global_cfg=minimal_global_cfg)
 
     assert "a_layer" in str(excinfo.value)
     assert "No products declared" in str(excinfo.value)
 
 
-def test_minimal_multiproduct(minimal_multiprod_cfg, minimal_global_cfg, minimal_dc, mock_range) -> None:
-    lyr = parse_ows_layer(minimal_multiprod_cfg,
-                          global_cfg=minimal_global_cfg)
+def test_minimal_multiproduct(
+    minimal_multiprod_cfg, minimal_global_cfg, minimal_dc, mock_range
+) -> None:
+    lyr = parse_ows_layer(minimal_multiprod_cfg, global_cfg=minimal_global_cfg)
     assert lyr.name == "a_layer"
     assert not lyr.ready
     with patch("datacube_ows.index.postgres.api.get_ranges_impl") as get_rng:
@@ -348,30 +338,31 @@ def test_minimal_multiproduct(minimal_multiprod_cfg, minimal_global_cfg, minimal
     assert "a_layer" in str(lyr)
 
 
-def test_multi_product_lowres(minimal_multiprod_cfg, minimal_global_cfg, minimal_dc) -> None:
+def test_multi_product_lowres(
+    minimal_multiprod_cfg, minimal_global_cfg, minimal_dc
+) -> None:
     minimal_multiprod_cfg["low_res_product_names"] = ["smol_foo", "smol_bar"]
-    lyr = parse_ows_layer(minimal_multiprod_cfg,
-                          global_cfg=minimal_global_cfg)
+    lyr = parse_ows_layer(minimal_multiprod_cfg, global_cfg=minimal_global_cfg)
     lyr.make_ready(minimal_dc)
     assert len(lyr.products) == 2
     assert len(lyr.low_res_products) == 2
 
 
-def test_multi_product_pq(minimal_multiprod_cfg, minimal_global_cfg, minimal_dc) -> None:
+def test_multi_product_pq(
+    minimal_multiprod_cfg, minimal_global_cfg, minimal_dc
+) -> None:
     minimal_multiprod_cfg["flags"] = [
-        {
-            "products": ["flag_foo", "flag_bar"],
-            "band": "band4",
-        }
+        {"products": ["flag_foo", "flag_bar"], "band": "band4"}
     ]
-    lyr = parse_ows_layer(minimal_multiprod_cfg,
-                          global_cfg=minimal_global_cfg)
+    lyr = parse_ows_layer(minimal_multiprod_cfg, global_cfg=minimal_global_cfg)
     lyr.make_ready(minimal_dc)
     assert len(lyr.products) == 2
     assert len(lyr.flag_bands["band4"].pq_products) == 2
 
 
-def test_multi_product_lrpq(minimal_multiprod_cfg, minimal_global_cfg, minimal_dc) -> None:
+def test_multi_product_lrpq(
+    minimal_multiprod_cfg, minimal_global_cfg, minimal_dc
+) -> None:
     minimal_multiprod_cfg["flags"] = [
         {
             "products": ["flag_foo", "flag_bar"],
@@ -379,8 +370,7 @@ def test_multi_product_lrpq(minimal_multiprod_cfg, minimal_global_cfg, minimal_d
             "band": "band4",
         }
     ]
-    lyr = parse_ows_layer(minimal_multiprod_cfg,
-                              global_cfg=minimal_global_cfg)
+    lyr = parse_ows_layer(minimal_multiprod_cfg, global_cfg=minimal_global_cfg)
     lyr.make_ready(minimal_dc)
     assert len(lyr.products) == 2
     assert len(lyr.flag_bands["band4"].pq_products) == 2
@@ -390,8 +380,7 @@ def test_multi_product_lrpq(minimal_multiprod_cfg, minimal_global_cfg, minimal_d
 def test_multi_product_name_mismatch(minimal_multiprod_cfg, minimal_global_cfg) -> None:
     minimal_multiprod_cfg["low_res_product_names"] = ["smol_foo"]
     with pytest.raises(ConfigException) as excinfo:
-        _ = parse_ows_layer(minimal_multiprod_cfg,
-                              global_cfg=minimal_global_cfg)
+        _ = parse_ows_layer(minimal_multiprod_cfg, global_cfg=minimal_global_cfg)
     assert "low_res_product_names" in str(excinfo.value)
     assert "a_layer" in str(excinfo.value)
 
@@ -400,14 +389,12 @@ def test_resource_limit_zoomfill(minimal_layer_cfg, minimal_global_cfg) -> None:
     minimal_layer_cfg["resource_limits"] = {
         "wms": {"zoomed_out_fill_colour": [128, 128, 128]}
     }
-    lyr = parse_ows_layer(minimal_layer_cfg,
-                          global_cfg=minimal_global_cfg)
+    lyr = parse_ows_layer(minimal_layer_cfg, global_cfg=minimal_global_cfg)
     assert len(lyr.resource_limits.zoom_fill) == 4
     assert lyr.resource_limits.zoom_fill[3] == 255
     minimal_layer_cfg["resource_limits"]["wms"]["zoomed_out_fill_colour"] = [13, 254]
     with pytest.raises(ConfigException) as excinfo:
-        _ = parse_ows_layer(minimal_layer_cfg,
-                              global_cfg=minimal_global_cfg)
+        _ = parse_ows_layer(minimal_layer_cfg, global_cfg=minimal_global_cfg)
     assert "zoomed_out_fill_colour must have 3 or 4 elements" in str(excinfo.value)
 
 
@@ -416,18 +403,21 @@ def test_resource_limit_checks(minimal_layer_cfg, minimal_global_cfg) -> None:
         "wms": {"min_zoom_factor": 300.0, "max_datasets": 8},
         "wcs": {"max_datasets": 8, "max_image_size": 100 * 100 * 32},
     }
-    lyr = parse_ows_layer(minimal_layer_cfg,
-                          global_cfg=minimal_global_cfg)
+    lyr = parse_ows_layer(minimal_layer_cfg, global_cfg=minimal_global_cfg)
     mock_req_scale = MagicMock()
     mock_req_scale.load_adjusted_zoom_level = 4.8
     with pytest.raises(ResourceLimited) as e:
-        lyr.resource_limits.check_wms(n_datasets=9, zoom_factor=400.0, request_scale=mock_req_scale)
+        lyr.resource_limits.check_wms(
+            n_datasets=9, zoom_factor=400.0, request_scale=mock_req_scale
+        )
     assert "too much data" not in str(e.value)
     assert "too many datasets" in str(e.value)
     assert "zoomed out too far" not in str(e.value)
     assert "too much projected resource requirements" not in str(e.value)
     with pytest.raises(ResourceLimited) as e:
-        lyr.resource_limits.check_wcs(n_datasets=9, width=640, height=480, pixel_size=64, n_dates=1)
+        lyr.resource_limits.check_wcs(
+            n_datasets=9, width=640, height=480, pixel_size=64, n_dates=1
+        )
     assert "too much data" in str(e.value)
     assert "too many datasets" in str(e.value)
     assert "zoomed out too far" not in str(e.value)
@@ -435,61 +425,48 @@ def test_resource_limit_checks(minimal_layer_cfg, minimal_global_cfg) -> None:
     assert e.value.wcs_hard
     minimal_layer_cfg["resource_limits"]["wms"]["min_zoom_level"] = 5
     minimal_global_cfg.layer_index = {}
-    lyr = parse_ows_layer(minimal_layer_cfg,
-                          global_cfg=minimal_global_cfg)
+    lyr = parse_ows_layer(minimal_layer_cfg, global_cfg=minimal_global_cfg)
     with pytest.raises(ResourceLimited) as e:
-        lyr.resource_limits.check_wms(n_datasets=9, zoom_factor=100.0, request_scale=mock_req_scale)
+        lyr.resource_limits.check_wms(
+            n_datasets=9, zoom_factor=100.0, request_scale=mock_req_scale
+        )
     assert "too many datasets" in str(e.value)
     assert "zoomed out too far" in str(e.value)
     assert "too much projected resource requirements" in str(e.value)
 
 
-
 def test_manual_merge(minimal_layer_cfg, minimal_global_cfg) -> None:
     minimal_layer_cfg["image_processing"]["manual_merge"] = True
     minimal_layer_cfg["image_processing"]["apply_solar_corrections"] = False
-    lyr = parse_ows_layer(minimal_layer_cfg,
-                          global_cfg=minimal_global_cfg)
+    lyr = parse_ows_layer(minimal_layer_cfg, global_cfg=minimal_global_cfg)
     assert not lyr.ready
     minimal_layer_cfg["image_processing"]["manual_merge"] = False
     minimal_layer_cfg["image_processing"]["apply_solar_corrections"] = True
     with pytest.raises(ConfigException) as excinfo:
-        lyr = parse_ows_layer(minimal_layer_cfg,
-                              global_cfg=minimal_global_cfg)
+        lyr = parse_ows_layer(minimal_layer_cfg, global_cfg=minimal_global_cfg)
     assert "Solar correction requires manual_merge" in str(excinfo.value)
 
 
 def test_bad_timeres(minimal_layer_cfg, minimal_global_cfg) -> None:
     minimal_layer_cfg["time_resolution"] = "prime_ministers"
     with pytest.raises(ConfigException) as excinfo:
-        _ = parse_ows_layer(minimal_layer_cfg,
-                              global_cfg=minimal_global_cfg)
+        _ = parse_ows_layer(minimal_layer_cfg, global_cfg=minimal_global_cfg)
     assert "Invalid time resolution" in str(excinfo.value)
     assert "prime_ministers" in str(excinfo.value)
 
 
 def test_flag_no_band(minimal_layer_cfg, minimal_global_cfg) -> None:
-    minimal_layer_cfg["flags"] = {
-        "external": {
-            "product": "foo",
-        }
-    }
+    minimal_layer_cfg["flags"] = {"external": {"product": "foo"}}
 
     with pytest.raises(ConfigException) as excinfo:
-        _ = parse_ows_layer(minimal_layer_cfg,
-                              global_cfg=minimal_global_cfg)
+        _ = parse_ows_layer(minimal_layer_cfg, global_cfg=minimal_global_cfg)
     assert "required" in str(excinfo.value)
     assert "a_layer" in str(excinfo.value)
     assert "band" in str(excinfo.value)
 
 
 def test_flag_bad_prod(minimal_layer_cfg, minimal_global_cfg, minimal_dc) -> None:
-    minimal_layer_cfg["flags"] = [
-        {
-            "product": "foolookupfail",
-            "band": "band1"
-        }
-    ]
+    minimal_layer_cfg["flags"] = [{"product": "foolookupfail", "band": "band1"}]
     lyr = parse_ows_layer(minimal_layer_cfg, global_cfg=minimal_global_cfg)
     with pytest.raises(ConfigException) as excinfo:
         lyr.make_ready(dc=minimal_dc)
@@ -499,11 +476,7 @@ def test_flag_bad_prod(minimal_layer_cfg, minimal_global_cfg, minimal_dc) -> Non
 
 def test_flag_bad_lrprod(minimal_layer_cfg, minimal_global_cfg, minimal_dc) -> None:
     minimal_layer_cfg["flags"] = [
-        {
-            "product": "foo",
-            "low_res_product": "foolookupfail",
-            "band": "band1"
-        }
+        {"product": "foo", "low_res_product": "foolookupfail", "band": "band1"}
     ]
     lyr = parse_ows_layer(minimal_layer_cfg, global_cfg=minimal_global_cfg)
     with pytest.raises(ConfigException) as excinfo:
@@ -514,11 +487,7 @@ def test_flag_bad_lrprod(minimal_layer_cfg, minimal_global_cfg, minimal_dc) -> N
 
 def test_flag_info_mask(minimal_layer_cfg, minimal_global_cfg, minimal_dc) -> None:
     minimal_layer_cfg["flags"] = [
-        {
-            "product": "foo",
-            "band": "band4",
-            "ignore_info_flags": ["moo", "blat", "zap"]
-        }
+        {"product": "foo", "band": "band4", "ignore_info_flags": ["moo", "blat", "zap"]}
     ]
     lyr = parse_ows_layer(minimal_layer_cfg, global_cfg=minimal_global_cfg)
     lyr.make_ready(dc=minimal_dc)
@@ -533,21 +502,16 @@ def test_flag_info_mask(minimal_layer_cfg, minimal_global_cfg, minimal_dc) -> No
 def test_img_proc_no_extent_func(minimal_layer_cfg, minimal_global_cfg) -> None:
     del minimal_layer_cfg["image_processing"]["extent_mask_func"]
     with pytest.raises(ConfigException) as excinfo:
-        _ = parse_ows_layer(minimal_layer_cfg,
-                              global_cfg=minimal_global_cfg)
+        _ = parse_ows_layer(minimal_layer_cfg, global_cfg=minimal_global_cfg)
     assert "required" in str(excinfo.value)
     assert "a_layer" in str(excinfo.value)
     assert "extent_mask_func" in str(excinfo.value)
 
 
 def test_id_badauth(minimal_layer_cfg, minimal_global_cfg) -> None:
-    minimal_layer_cfg["identifiers"] = {
-        "auth0": "5318008",
-        "authn": "mnnnmnnh"
-    }
+    minimal_layer_cfg["identifiers"] = {"auth0": "5318008", "authn": "mnnnmnnh"}
     with pytest.raises(ConfigException) as excinfo:
-        _ = parse_ows_layer(minimal_layer_cfg,
-                              global_cfg=minimal_global_cfg)
+        _ = parse_ows_layer(minimal_layer_cfg, global_cfg=minimal_global_cfg)
     assert "non-declared authority" in str(excinfo.value)
     assert "authn" in str(excinfo.value)
     assert "a_layer" in str(excinfo.value)
@@ -556,8 +520,7 @@ def test_id_badauth(minimal_layer_cfg, minimal_global_cfg) -> None:
 def test_no_styles(minimal_layer_cfg, minimal_global_cfg) -> None:
     del minimal_layer_cfg["styling"]["styles"]
     with pytest.raises(ConfigException) as excinfo:
-        _ = parse_ows_layer(minimal_layer_cfg,
-                              global_cfg=minimal_global_cfg)
+        _ = parse_ows_layer(minimal_layer_cfg, global_cfg=minimal_global_cfg)
     assert "Missing required" in str(excinfo.value)
     assert "styles" in str(excinfo.value)
     assert "a_layer" in str(excinfo.value)
@@ -566,8 +529,7 @@ def test_no_styles(minimal_layer_cfg, minimal_global_cfg) -> None:
 def test_bad_default_style(minimal_layer_cfg, minimal_global_cfg) -> None:
     minimal_layer_cfg["styling"]["default_style"] = "nonexistent"
     with pytest.raises(ConfigException) as excinfo:
-        _ = parse_ows_layer(minimal_layer_cfg,
-                              global_cfg=minimal_global_cfg)
+        _ = parse_ows_layer(minimal_layer_cfg, global_cfg=minimal_global_cfg)
     assert "not in the 'styles'" in str(excinfo.value)
     assert "nonexistent" in str(excinfo.value)
     assert "a_layer" in str(excinfo.value)
@@ -575,19 +537,15 @@ def test_bad_default_style(minimal_layer_cfg, minimal_global_cfg) -> None:
 
 def test_no_default_style(minimal_layer_cfg, minimal_global_cfg) -> None:
     del minimal_layer_cfg["styling"]["default_style"]
-    lyr = parse_ows_layer(minimal_layer_cfg,
-                      global_cfg=minimal_global_cfg)
-    assert lyr.default_style.name == 'band1'
+    lyr = parse_ows_layer(minimal_layer_cfg, global_cfg=minimal_global_cfg)
+    assert lyr.default_style.name == "band1"
 
 
 def test_invalid_native_format(minimal_layer_cfg, minimal_global_cfg) -> None:
     minimal_global_cfg.wcs = True
-    minimal_layer_cfg["wcs"] = {
-        "native_format": "geosplunge"
-    }
+    minimal_layer_cfg["wcs"] = {"native_format": "geosplunge"}
     with pytest.raises(ConfigException) as excinfo:
-        _ = parse_ows_layer(minimal_layer_cfg,
-                              global_cfg=minimal_global_cfg)
+        _ = parse_ows_layer(minimal_layer_cfg, global_cfg=minimal_global_cfg)
     assert "a_layer" in str(excinfo.value)
     assert "geosplunge" in str(excinfo.value)
 
@@ -597,13 +555,13 @@ def test_time_range_irreg(minimal_layer_cfg, minimal_global_cfg) -> None:
     ranges = LayerExtent(
         lat=CoordRange(-0.1, 0.1),
         lon=CoordRange(-0.1, 0.1),
-        times= [
+        times=[
             datetime.date(2021, 1, 5),
             datetime.date(2021, 1, 6),
             datetime.date(2021, 1, 7),
             datetime.date(2021, 1, 8),
         ],
-        bboxes={}
+        bboxes={},
     )
     start, end = lyr.time_range(ranges)
     assert start == datetime.date(2021, 1, 5)
@@ -611,20 +569,18 @@ def test_time_range_irreg(minimal_layer_cfg, minimal_global_cfg) -> None:
 
 
 def test_time_range_reg_default(minimal_layer_cfg, minimal_global_cfg) -> None:
-    minimal_layer_cfg["time_axis"] = {
-        "time_interval": 1
-    }
+    minimal_layer_cfg["time_axis"] = {"time_interval": 1}
     lyr = parse_ows_layer(minimal_layer_cfg, global_cfg=minimal_global_cfg)
     ranges = LayerExtent(
         lat=CoordRange(-0.1, 0.1),
         lon=CoordRange(-0.1, 0.1),
-        times= [
+        times=[
             datetime.date(2021, 1, 5),
             datetime.date(2021, 1, 6),
             datetime.date(2021, 1, 7),
             datetime.date(2021, 1, 8),
         ],
-        bboxes={}
+        bboxes={},
     )
     start, end = lyr.time_range(ranges)
     assert start == datetime.date(2021, 1, 5)
@@ -658,12 +614,7 @@ def test_time_axis_representation_irreg(minimal_layer_cfg, minimal_global_cfg) -
         "end_date": "2021-01-10",
     }
     lyr = parse_ows_layer(minimal_layer_cfg, global_cfg=minimal_global_cfg)
-    lyr._ranges = {
-        "times": [
-            datetime.date(2021, 1, 7),
-            datetime.date(2021, 1, 8),
-        ]
-    }
+    lyr._ranges = {"times": [datetime.date(2021, 1, 7), datetime.date(2021, 1, 8)]}
     assert lyr.time_axis_representation() == "2021-01-01/2021-01-10/P1D"
 
 
@@ -708,13 +659,17 @@ def test_time_axis_errors(minimal_layer_cfg, minimal_global_cfg) -> None:
     }
     with pytest.raises(ConfigException) as e:
         _ = parse_ows_layer(minimal_layer_cfg, global_cfg=minimal_global_cfg)
-    assert "time_axis end_date must be greater than or equal to the start_date if both are provided" in str(e.value)
+    assert (
+        "time_axis end_date must be greater than or equal to the start_date if both are provided"
+        in str(e.value)
+    )
 
 
-def test_earliest_default_time(minimal_layer_cfg, minimal_global_cfg, minimal_dc, mock_range) -> None:
+def test_earliest_default_time(
+    minimal_layer_cfg, minimal_global_cfg, minimal_dc, mock_range
+) -> None:
     minimal_layer_cfg["default_time"] = "earliest"
-    lyr = parse_ows_layer(minimal_layer_cfg,
-                          global_cfg=minimal_global_cfg)
+    lyr = parse_ows_layer(minimal_layer_cfg, global_cfg=minimal_global_cfg)
     assert lyr.name == "a_layer"
     assert not lyr.ready
     with patch("datacube_ows.index.postgres.api.get_ranges_impl") as get_rng:
@@ -726,10 +681,12 @@ def test_earliest_default_time(minimal_layer_cfg, minimal_global_cfg, minimal_dc
     assert "a_layer" in str(lyr)
     assert len(lyr.low_res_products) == 0
 
-def test_latest_default_time(minimal_layer_cfg, minimal_global_cfg, minimal_dc, mock_range) -> None:
+
+def test_latest_default_time(
+    minimal_layer_cfg, minimal_global_cfg, minimal_dc, mock_range
+) -> None:
     minimal_layer_cfg["default_time"] = "latest"
-    lyr = parse_ows_layer(minimal_layer_cfg,
-                          global_cfg=minimal_global_cfg)
+    lyr = parse_ows_layer(minimal_layer_cfg, global_cfg=minimal_global_cfg)
     assert lyr.name == "a_layer"
     assert not lyr.ready
     with patch("datacube_ows.index.postgres.api.get_ranges_impl") as get_rng:
@@ -741,10 +698,12 @@ def test_latest_default_time(minimal_layer_cfg, minimal_global_cfg, minimal_dc, 
     assert "a_layer" in str(lyr)
     assert len(lyr.low_res_products) == 0
 
-def test_valid_default_time(minimal_layer_cfg, minimal_global_cfg, minimal_dc, mock_range) -> None:
+
+def test_valid_default_time(
+    minimal_layer_cfg, minimal_global_cfg, minimal_dc, mock_range
+) -> None:
     minimal_layer_cfg["default_time"] = "2010-01-02"
-    lyr = parse_ows_layer(minimal_layer_cfg,
-                          global_cfg=minimal_global_cfg)
+    lyr = parse_ows_layer(minimal_layer_cfg, global_cfg=minimal_global_cfg)
     assert lyr.name == "a_layer"
     assert not lyr.ready
     with patch("datacube_ows.index.postgres.api.get_ranges_impl") as get_rng:
@@ -756,7 +715,10 @@ def test_valid_default_time(minimal_layer_cfg, minimal_global_cfg, minimal_dc, m
     assert "a_layer" in str(lyr)
     assert len(lyr.low_res_products) == 0
 
-def test_missing_default_time(minimal_layer_cfg, minimal_global_cfg, minimal_dc, mock_range) -> None:
+
+def test_missing_default_time(
+    minimal_layer_cfg, minimal_global_cfg, minimal_dc, mock_range
+) -> None:
     minimal_layer_cfg["default_time"] = "2020-01-22"
     lyr = parse_ows_layer(minimal_layer_cfg, global_cfg=minimal_global_cfg)
     assert lyr.name == "a_layer"
@@ -770,11 +732,13 @@ def test_missing_default_time(minimal_layer_cfg, minimal_global_cfg, minimal_dc,
     assert "a_layer" in str(lyr)
     assert len(lyr.low_res_products) == 0
 
-def test_invalid_default_time(minimal_layer_cfg, minimal_global_cfg, minimal_dc, mock_range) -> None:
+
+def test_invalid_default_time(
+    minimal_layer_cfg, minimal_global_cfg, minimal_dc, mock_range
+) -> None:
     minimal_layer_cfg["default_time"] = "Not-a-date"
     with pytest.raises(ConfigException) as e:
-        _ = parse_ows_layer(minimal_layer_cfg,
-                          global_cfg=minimal_global_cfg)
+        _ = parse_ows_layer(minimal_layer_cfg, global_cfg=minimal_global_cfg)
     assert "a_layer" in str(e.value)
     assert "Not-a-date" in str(e.value)
     assert "Invalid default_time value" in str(e.value)
@@ -783,22 +747,19 @@ def test_invalid_default_time(minimal_layer_cfg, minimal_global_cfg, minimal_dc,
 def test_native_crs_mismatch(minimal_global_cfg, minimal_layer_cfg, minimal_dc) -> None:
     minimal_layer_cfg["native_crs"] = "EPSG:1234"
     minimal_layer_cfg["product_name"] = "foo_nativecrs"
-    lyr = parse_ows_layer(minimal_layer_cfg,
-                          global_cfg=minimal_global_cfg)
+    lyr = parse_ows_layer(minimal_layer_cfg, global_cfg=minimal_global_cfg)
     lyr.extract_bboxes = MagicMock()
     lyr.extract_bboxes.return_value = {
-        "EPSG": {
-            "top": 1,
-            "bottom": -1,
-            "left": -1,
-            "right": 1,
-        }
+        "EPSG": {"top": 1, "bottom": -1, "left": -1, "right": 1}
     }
     lyr.make_ready(minimal_dc)
     assert lyr.native_CRS == "EPSG:4326"
 
+
 # NOTE: retire when native res/crs in wcs section support removed.
-def test_native_crs_res_wcs_mismatch(minimal_global_cfg, minimal_layer_cfg, minimal_dc) -> None:
+def test_native_crs_res_wcs_mismatch(
+    minimal_global_cfg, minimal_layer_cfg, minimal_dc
+) -> None:
     minimal_layer_cfg["native_crs"] = "EPSG:4326"
     minimal_layer_cfg["product_name"] = "foo_nativecrs"
     minimal_global_cfg.wcs = True
@@ -807,25 +768,20 @@ def test_native_crs_res_wcs_mismatch(minimal_global_cfg, minimal_layer_cfg, mini
         "native_resolution": [0.123, 0.123],
     }
 
-    lyr = parse_ows_layer(minimal_layer_cfg,
-                          global_cfg=minimal_global_cfg)
+    lyr = parse_ows_layer(minimal_layer_cfg, global_cfg=minimal_global_cfg)
     lyr.extract_bboxes = MagicMock()
     lyr.extract_bboxes.return_value = {
-        "EPSG": {
-            "top": 1,
-            "bottom": -1,
-            "left": -1,
-            "right": 1,
-        }
+        "EPSG": {"top": 1, "bottom": -1, "left": -1, "right": 1}
     }
     lyr.make_ready(minimal_dc)
     assert lyr.native_CRS == "EPSG:4326"
 
 
-def test_native_crs_none(minimal_global_cfg, minimal_layer_cfg, minimal_dc, mock_range) -> None:
+def test_native_crs_none(
+    minimal_global_cfg, minimal_layer_cfg, minimal_dc, mock_range
+) -> None:
     minimal_layer_cfg["product_name"] = "foo_nonativecrs"
-    lyr = parse_ows_layer(minimal_layer_cfg,
-                          global_cfg=minimal_global_cfg)
+    lyr = parse_ows_layer(minimal_layer_cfg, global_cfg=minimal_global_cfg)
     with patch("datacube_ows.index.postgres.api.get_ranges_impl") as get_rng:
         get_rng.return_value = mock_range
         with pytest.raises(ConfigException) as excinfo:
@@ -834,18 +790,14 @@ def test_native_crs_none(minimal_global_cfg, minimal_layer_cfg, minimal_dc, mock
     assert "No native CRS" in str(excinfo.value)
 
 
-def test_native_crs_unpublished(minimal_global_cfg, minimal_layer_cfg, minimal_dc) -> None:
+def test_native_crs_unpublished(
+    minimal_global_cfg, minimal_layer_cfg, minimal_dc
+) -> None:
     minimal_layer_cfg["product_name"] = "foo_badnativecrs"
-    lyr = parse_ows_layer(minimal_layer_cfg,
-                          global_cfg=minimal_global_cfg)
+    lyr = parse_ows_layer(minimal_layer_cfg, global_cfg=minimal_global_cfg)
     lyr.extract_bboxes = MagicMock()
     lyr.extract_bboxes.return_value = {
-        "EPSG": {
-            "top": 1,
-            "bottom": -1,
-            "left": -1,
-            "right": 1,
-        }
+        "EPSG": {"top": 1, "bottom": -1, "left": -1, "right": 1}
     }
     with pytest.raises(ConfigException) as excinfo:
         lyr.make_ready(minimal_dc)
@@ -854,11 +806,12 @@ def test_native_crs_unpublished(minimal_global_cfg, minimal_layer_cfg, minimal_d
     assert "not in published CRSs" in str(excinfo.value)
 
 
-def test_no_native_resolution(minimal_global_cfg, minimal_layer_cfg, minimal_dc, mock_range) -> None:
-    minimal_layer_cfg["native_crs"] = "EPSG:4326",
+def test_no_native_resolution(
+    minimal_global_cfg, minimal_layer_cfg, minimal_dc, mock_range
+) -> None:
+    minimal_layer_cfg["native_crs"] = ("EPSG:4326",)
     minimal_layer_cfg["product_name"] = "foo_nonativeres"
-    lyr = parse_ows_layer(minimal_layer_cfg,
-                          global_cfg=minimal_global_cfg)
+    lyr = parse_ows_layer(minimal_layer_cfg, global_cfg=minimal_global_cfg)
     with patch("datacube_ows.index.postgres.api.get_ranges_impl") as get_rng:
         get_rng.return_value = mock_range
         with pytest.raises(ConfigException) as excinfo:
@@ -867,12 +820,13 @@ def test_no_native_resolution(minimal_global_cfg, minimal_layer_cfg, minimal_dc,
     assert "No native resolution" in str(excinfo.value)
 
 
-def test_no_native_resolution_noniter(minimal_global_cfg, minimal_layer_cfg, minimal_dc, mock_range) -> None:
+def test_no_native_resolution_noniter(
+    minimal_global_cfg, minimal_layer_cfg, minimal_dc, mock_range
+) -> None:
     minimal_layer_cfg["native_crs"] = "EPSG:4326"
     minimal_layer_cfg["native_resolution"] = 45
     minimal_layer_cfg["product_name"] = "foo_nonativeres"
-    lyr = parse_ows_layer(minimal_layer_cfg,
-                          global_cfg=minimal_global_cfg)
+    lyr = parse_ows_layer(minimal_layer_cfg, global_cfg=minimal_global_cfg)
     with patch("datacube_ows.index.postgres.api.get_ranges_impl") as get_rng:
         get_rng.return_value = mock_range
         with pytest.raises(ConfigException) as excinfo:
@@ -881,12 +835,13 @@ def test_no_native_resolution_noniter(minimal_global_cfg, minimal_layer_cfg, min
     assert "Invalid native resolution" in str(excinfo.value)
 
 
-def test_no_native_resolution_badlen(minimal_global_cfg, minimal_layer_cfg, minimal_dc, mock_range) -> None:
-    minimal_layer_cfg["native_crs"] = "EPSG:4326",
+def test_no_native_resolution_badlen(
+    minimal_global_cfg, minimal_layer_cfg, minimal_dc, mock_range
+) -> None:
+    minimal_layer_cfg["native_crs"] = ("EPSG:4326",)
     minimal_layer_cfg["native_resolution"] = [33, 45, 2234]
     minimal_layer_cfg["product_name"] = "foo_nonativeres"
-    lyr = parse_ows_layer(minimal_layer_cfg,
-                          global_cfg=minimal_global_cfg)
+    lyr = parse_ows_layer(minimal_layer_cfg, global_cfg=minimal_global_cfg)
     with patch("datacube_ows.index.postgres.api.get_ranges_impl") as get_rng:
         get_rng.return_value = mock_range
         with pytest.raises(ConfigException) as excinfo:
@@ -895,12 +850,13 @@ def test_no_native_resolution_badlen(minimal_global_cfg, minimal_layer_cfg, mini
     assert "Invalid native resolution" in str(excinfo.value)
 
 
-def test_native_resolution_mismatch(minimal_global_cfg, minimal_layer_cfg, minimal_dc, mock_range) -> None:
+def test_native_resolution_mismatch(
+    minimal_global_cfg, minimal_layer_cfg, minimal_dc, mock_range
+) -> None:
     minimal_layer_cfg["native_crs"] = "EPSG:4326"
     minimal_layer_cfg["native_resolution"] = [0.1, -0.1]
     minimal_layer_cfg["product_name"] = "foo_nativeres"
-    lyr = parse_ows_layer(minimal_layer_cfg,
-                          global_cfg=minimal_global_cfg)
+    lyr = parse_ows_layer(minimal_layer_cfg, global_cfg=minimal_global_cfg)
     with patch("datacube_ows.index.postgres.api.get_ranges_impl") as get_rng:
         get_rng.return_value = mock_range
         lyr.make_ready(minimal_dc)

--- a/tests/test_cfg_metadata_types.py
+++ b/tests/test_cfg_metadata_types.py
@@ -16,17 +16,20 @@ def test_cfg_attrib_empty(minimal_owner) -> None:
     attrib = AttributionCfg.parse({}, minimal_owner)
     assert attrib is None
 
+
 @pytest.fixture
 def minimal_owner():
     owner = MagicMock()
     owner.attribution_title = None
     return owner
 
+
 @pytest.fixture
 def owner_w_attrib_title():
     owner = MagicMock()
     owner.attribution_title = "Sir"
     return owner
+
 
 def test_cfg_attrib_emptyfail(minimal_owner) -> None:
     with pytest.raises(ConfigException) as excinfo:
@@ -35,9 +38,7 @@ def test_cfg_attrib_emptyfail(minimal_owner) -> None:
 
 
 def test_cfg_attrib_title_only(owner_w_attrib_title) -> None:
-    attrib = AttributionCfg.parse({
-        "title": "Sir"
-    }, owner_w_attrib_title)
+    attrib = AttributionCfg.parse({"title": "Sir"}, owner_w_attrib_title)
     assert attrib.title == "Sir"
     assert attrib.get("title") == "Sir"
     assert attrib.logo_width is None
@@ -45,21 +46,17 @@ def test_cfg_attrib_title_only(owner_w_attrib_title) -> None:
 
 
 def test_cfg_attrib_url_only(minimal_owner) -> None:
-    attrib = AttributionCfg.parse({
-        "url": "http://test.url/path/name",
-    }, minimal_owner)
+    attrib = AttributionCfg.parse({"url": "http://test.url/path/name"}, minimal_owner)
     assert attrib.title is None
     assert attrib.logo_width is None
     assert attrib.url == "http://test.url/path/name"
 
 
 def test_cfg_attrib_minimal_logo_only(minimal_owner) -> None:
-    attrib = AttributionCfg.parse({
-        "logo": {
-            "url": "http://test.url/path/img.png",
-            "format": "image/png"
-        }
-    }, minimal_owner)
+    attrib = AttributionCfg.parse(
+        {"logo": {"url": "http://test.url/path/img.png", "format": "image/png"}},
+        minimal_owner,
+    )
     assert attrib.title is None
     assert attrib.url is None
     assert attrib.logo_url == "http://test.url/path/img.png"
@@ -69,55 +66,58 @@ def test_cfg_attrib_minimal_logo_only(minimal_owner) -> None:
 
 def test_cfg_attrib_logo_requirements(minimal_owner) -> None:
     with pytest.raises(ConfigException) as excinfo:
-        _ = AttributionCfg.parse({
-            "logo": {
-                "url": "http://test.url/path/img.png",
-            }
-        }, minimal_owner)
+        _ = AttributionCfg.parse(
+            {"logo": {"url": "http://test.url/path/img.png"}}, minimal_owner
+        )
     assert "url and format" in str(excinfo.value)
     with pytest.raises(ConfigException) as excinfo:
-        _ = AttributionCfg.parse({
-            "logo": {
-                "format": "image/png"
-            }
-        }, minimal_owner)
+        _ = AttributionCfg.parse({"logo": {"format": "image/png"}}, minimal_owner)
     assert "url and format" in str(excinfo.value)
 
 
 def test_cfg_attrib_logo_options(minimal_owner) -> None:
-    attrib = AttributionCfg.parse({
-        "logo": {
-            "url": "http://test.url/path/img.png",
-            "format": "image/png",
-            "width": 200
-        }
-    }, minimal_owner)
+    attrib = AttributionCfg.parse(
+        {
+            "logo": {
+                "url": "http://test.url/path/img.png",
+                "format": "image/png",
+                "width": 200,
+            }
+        },
+        minimal_owner,
+    )
     assert attrib.logo_url == "http://test.url/path/img.png"
     assert attrib.logo_fmt == "image/png"
     assert attrib.logo_width == 200
     assert attrib.logo_height is None
-    attrib = AttributionCfg.parse({
-        "logo": {
-            "url": "http://test.url/path/img.png",
-            "format": "image/png",
-            "width": 200,
-            "height": 300
-        }
-    }, minimal_owner)
+    attrib = AttributionCfg.parse(
+        {
+            "logo": {
+                "url": "http://test.url/path/img.png",
+                "format": "image/png",
+                "width": 200,
+                "height": 300,
+            }
+        },
+        minimal_owner,
+    )
     assert attrib.logo_height == 300
 
 
 def test_cfg_attrib_all_flds(minimal_dc, owner_w_attrib_title) -> None:
-    attrib = AttributionCfg.parse({
-        "title": "Sir",
-        "url": "http://test.url/path",
-        "logo": {
-            "url": "http://test.url/path/img.png",
-            "format": "image/png",
-            "width": 200,
-            "height": 150,
-        }
-    }, owner_w_attrib_title)
+    attrib = AttributionCfg.parse(
+        {
+            "title": "Sir",
+            "url": "http://test.url/path",
+            "logo": {
+                "url": "http://test.url/path/img.png",
+                "format": "image/png",
+                "width": 200,
+                "height": 150,
+            },
+        },
+        owner_w_attrib_title,
+    )
     assert attrib.title == "Sir"
     assert attrib.url == "http://test.url/path"
     assert attrib.logo_url == "http://test.url/path/img.png"
@@ -137,33 +137,21 @@ def test_surl_empty() -> None:
 
 def test_surl_no_url() -> None:
     with pytest.raises(KeyError):
-        _ = SuppURL.parse_list([
-            {
-                "format": "text/html"
-            }
-        ])
+        _ = SuppURL.parse_list([{"format": "text/html"}])
 
 
 def test_surl_no_format() -> None:
     with pytest.raises(KeyError):
-        _ = SuppURL.parse_list([
-            {
-                "url": "http://test.url/path"
-            }
-        ])
+        _ = SuppURL.parse_list([{"url": "http://test.url/path"}])
 
 
 def test_surl_full(minimal_dc) -> None:
-    supps = SuppURL.parse_list([
-        {
-            "url": "http://test.url/path",
-            "format": "text/html"
-        },
-        {
-            "url": "http://test.url/another_path",
-            "format": "text/plain"
-        },
-    ])
+    supps = SuppURL.parse_list(
+        [
+            {"url": "http://test.url/path", "format": "text/html"},
+            {"url": "http://test.url/another_path", "format": "text/plain"},
+        ]
+    )
     assert len(supps) == 2
     assert supps[0].url == "http://test.url/path"
     assert supps[1].url == "http://test.url/another_path"

--- a/tests/test_cfg_tile_matrix_set.py
+++ b/tests/test_cfg_tile_matrix_set.py
@@ -21,28 +21,28 @@ def wwwm_tms_cfg() -> CFG_DICT:
 def tmsmin_global_cfg():
     gcfg = MagicMock()
     gcfg.published_CRSs = {
-            "EPSG:3857": {  # Web Mercator
-                "geographic": False,
-                "horizontal_coord": "x",
-                "vertical_coord": "y",
-                "vertical_coord_first": False
-            },
-            "I:CANT:BELIEVE:ITS:NOT:EPSG:3857": {  # I Can't Believe It's Not Web Mercator
-                "geographic": False,
-                "horizontal_coord": "x",
-                "vertical_coord": "y",
-                "vertical_coord_first": True
-            },
-            "EPSG:4326": {  # WGS-84
-                "geographic": True,
-                "vertical_coord_first": True
-            },
-            "EPSG:3111": {  # VicGrid94 for delwp.vic.gov.au
-                "geographic": False,
-                "horizontal_coord": "x",
-                "vertical_coord": "y",
-                "vertical_coord_first": False
-            },
+        "EPSG:3857": {  # Web Mercator
+            "geographic": False,
+            "horizontal_coord": "x",
+            "vertical_coord": "y",
+            "vertical_coord_first": False,
+        },
+        "I:CANT:BELIEVE:ITS:NOT:EPSG:3857": {  # I Can't Believe It's Not Web Mercator
+            "geographic": False,
+            "horizontal_coord": "x",
+            "vertical_coord": "y",
+            "vertical_coord_first": True,
+        },
+        "EPSG:4326": {  # WGS-84
+            "geographic": True,
+            "vertical_coord_first": True,
+        },
+        "EPSG:3111": {  # VicGrid94 for delwp.vic.gov.au
+            "geographic": False,
+            "horizontal_coord": "x",
+            "vertical_coord": "y",
+            "vertical_coord_first": False,
+        },
     }
     return gcfg
 

--- a/tests/test_cfg_wcs.py
+++ b/tests/test_cfg_wcs.py
@@ -12,15 +12,18 @@ from datacube_ows.config_utils import ConfigException
 from datacube_ows.ows_configuration import WCSFormat, parse_ows_layer
 
 
-def test_zero_grid(minimal_global_cfg, minimal_layer_cfg, minimal_dc, mock_range, empty_driver_cache) -> None:
+def test_zero_grid(
+    minimal_global_cfg, minimal_layer_cfg, minimal_dc, mock_range, empty_driver_cache
+) -> None:
     minimal_global_cfg.wcs = True
     minimal_layer_cfg["native_crs"] = "EPSG:4326"
     minimal_layer_cfg["product_name"] = "foo_nativeres"
-    lyr = parse_ows_layer(minimal_layer_cfg,
-                          global_cfg=minimal_global_cfg)
+    lyr = parse_ows_layer(minimal_layer_cfg, global_cfg=minimal_global_cfg)
     mock_range.bboxes["EPSG:4326"] = {
-        "top": 0.1, "bottom": 0.1,
-        "left": -0.1, "right": 0.1,
+        "top": 0.1,
+        "bottom": 0.1,
+        "left": -0.1,
+        "right": 0.1,
     }
     assert mock_range.bboxes["EPSG:4326"]["bottom"] > 0
     assert not lyr.ready
@@ -34,11 +37,12 @@ def test_zero_grid(minimal_global_cfg, minimal_layer_cfg, minimal_dc, mock_range
     assert "a_layer" in str(excinfo.value)
     assert "EPSG:4326" in str(excinfo.value)
     minimal_global_cfg.layer_index = {}
-    lyr = parse_ows_layer(minimal_layer_cfg,
-                          global_cfg=minimal_global_cfg)
+    lyr = parse_ows_layer(minimal_layer_cfg, global_cfg=minimal_global_cfg)
     mock_range.bboxes["EPSG:4326"] = {
-        "top": 0.1, "bottom": -0.1,
-        "left": -0.1, "right": -0.1,
+        "top": 0.1,
+        "bottom": -0.1,
+        "left": -0.1,
+        "right": -0.1,
     }
     with patch("datacube_ows.index.postgres.api.get_ranges_impl") as get_rng:
         get_rng.return_value = mock_range
@@ -58,7 +62,7 @@ def test_wcs_renderer_detection() -> None:
             "1": "datacube_ows.wcs1_utils.get_tiff",
             "2": "datacube_ows.wcs2_utils.get_tiff",
         },
-        False
+        False,
     )
     r = fmt.renderer("2.1.0")
     assert r == fmt.renderers[2]

--- a/tests/test_config_toolkit.py
+++ b/tests/test_config_toolkit.py
@@ -8,17 +8,11 @@ from datacube_ows.config_toolkit import deepinherit
 
 
 def test_deepinherit_shallow() -> None:
-    parent = {
-        "a": 72,
-        "b": "eagle",
-        "c": False
-    }
+    parent = {"a": 72, "b": "eagle", "c": False}
 
-    child = {
-        "a": 365
-    }
+    child = {"a": 365}
     child = deepinherit(parent, child)
-    assert child['a'] == 365
+    assert child["a"] == 365
     assert child["b"] == "eagle"
     assert not child["c"]
 
@@ -32,21 +26,16 @@ def test_deepinherit_deep() -> None:
             "cake": "chocolate",
             "y": ["some", "body", "once"],
             "z": [44, 42, 53],
-            "c": {
-                "foo": "bar",
-                "wing": "wang"
-            }
-        }
+            "c": {"foo": "bar", "wing": "wang"},
+        },
     }
 
     child = {
         "b": {
             "spice": "nutmeg",
-            "c": {
-                "wing": "chicken"
-            },
+            "c": {"wing": "chicken"},
             "y": ["told", "me"],
-            "z": [11]
+            "z": [11],
         }
     }
     child = deepinherit(parent, child)
@@ -65,19 +54,9 @@ def test_array_inheritance() -> None:
         "ding": "dong",
         "bing": "bang",
         "wham": ["a-lam", "a-bing", "bong"],
-        "king": {
-            "tide": "oceanography",
-            "crab": "crustacean",
-            "Sick-Nasty": "Spades",
-        }
+        "king": {"tide": "oceanography", "crab": "crustacean", "Sick-Nasty": "Spades"},
     }
-    inherit_to = {
-        "foo": "baz",
-        "wham": [],
-        "king": {
-            "Penguin": "Antarctica"
-        }
-    }
+    inherit_to = {"foo": "baz", "wham": [], "king": {"Penguin": "Antarctica"}}
     inherited = deepinherit(inherit_from, inherit_to)
     assert inherited["foo"] == "baz"
     assert inherited["wham"] == []

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -28,17 +28,19 @@ def s3_url_datasets():
             self.uris = uris
 
     datasets = []
-    d1 = TestDataset([
+    d1 = TestDataset(
+        [
             "s3://test-bucket/hello_world/data.yaml",
-            "s3://test-bucket/hello_world/data.yaml"
-    ])
-    d2 = TestDataset([
-        "s3://test-bucket/hello.word/foo.bar/hello.test.yaml",
-        "s3://test-bucket/hello.word/foo.bar/hello-test.yaml"
-    ])
-    d3 = TestDataset([
-            "s3://test-bucket/this.is/from.stac/hello.test.json",
-    ])
+            "s3://test-bucket/hello_world/data.yaml",
+        ]
+    )
+    d2 = TestDataset(
+        [
+            "s3://test-bucket/hello.word/foo.bar/hello.test.yaml",
+            "s3://test-bucket/hello.word/foo.bar/hello-test.yaml",
+        ]
+    )
+    d3 = TestDataset(["s3://test-bucket/this.is/from.stac/hello.test.json"])
 
     datasets.append(d1)
     datasets.append(d2)
@@ -54,6 +56,7 @@ def s3_url_datasets():
 
                 def item(self):
                     return self.datasets
+
             self.values = InnerMock(datasets)
 
     class PBQMock:
@@ -73,9 +76,19 @@ def s3_url_datasets():
 def test_s3_browser_uris(s3_url_datasets) -> None:
     uris = get_s3_browser_uris(s3_url_datasets)
 
-    assert "http://test-bucket.s3-website-ap-southeast-2.amazonaws.com/?prefix=hello_world" in uris
-    assert "http://test-bucket.s3-website-ap-southeast-2.amazonaws.com/?prefix=hello.word/foo.bar" in uris
-    assert "http://test-bucket.s3-website-ap-southeast-2.amazonaws.com/?prefix=this.is/from.stac" in uris
+    assert (
+        "http://test-bucket.s3-website-ap-southeast-2.amazonaws.com/?prefix=hello_world"
+        in uris
+    )
+    assert (
+        "http://test-bucket.s3-website-ap-southeast-2.amazonaws.com/?prefix=hello.word/foo.bar"
+        in uris
+    )
+    assert (
+        "http://test-bucket.s3-website-ap-southeast-2.amazonaws.com/?prefix=this.is/from.stac"
+        in uris
+    )
+
 
 # TODO: read_data is now a method of the DataStacker class. This test needs a rewrite.
 # @patch('xarray.Dataset')
@@ -140,11 +153,11 @@ def test_make_derived_band_dict_nan() -> None:
             self.needed_bands = ["test"]
             self.index_function = lambda x: fake_data()
 
-    style_dict = {
-        "fake": fake_style()
-    }
+    style_dict = {"fake": fake_style()}
 
-    band_dict = datacube_ows.feature_info._make_derived_band_dict(fake_dataset(), style_dict)
+    band_dict = datacube_ows.feature_info._make_derived_band_dict(
+        fake_dataset(), style_dict
+    )
     assert band_dict["fake"] == "n/a"
 
 
@@ -167,15 +180,15 @@ def test_make_derived_band_dict_not_nan() -> None:
             self.needed_bands = ["test"]
             self.index_function = lambda x: fake_data()
 
-    style_dict = {
-        "fake": fake_style()
-    }
+    style_dict = {"fake": fake_style()}
 
-    band_dict = datacube_ows.feature_info._make_derived_band_dict(fake_dataset(), style_dict)
+    band_dict = datacube_ows.feature_info._make_derived_band_dict(
+        fake_dataset(), style_dict
+    )
     assert band_dict["fake"] == 10.10
 
 
-def test_make_band_dict_nan(product_layer) -> None: # noqa: F811
+def test_make_band_dict_nan(product_layer) -> None:  # noqa: F811
     class fake_data:
         def __init__(self) -> None:
             self.nodata = np.nan
@@ -186,9 +199,7 @@ def test_make_band_dict_nan(product_layer) -> None: # noqa: F811
 
     class fake_dataset:
         def __init__(self) -> None:
-            self.data_vars = {
-                "fake": "fake_band"
-            }
+            self.data_vars = {"fake": "fake_band"}
 
         def __getitem__(self, key):
             return fake_data()
@@ -197,8 +208,9 @@ def test_make_band_dict_nan(product_layer) -> None: # noqa: F811
     assert band_dict["fake"] == "n/a"
 
 
-def test_make_band_dict_float(product_layer) -> None: # noqa: F811
+def test_make_band_dict_float(product_layer) -> None:  # noqa: F811
     import yaml
+
     flags_yaml = """
     flags_definition:
         category:
@@ -222,9 +234,7 @@ def test_make_band_dict_float(product_layer) -> None: # noqa: F811
 
     class int_dataset:
         def __init__(self) -> None:
-            self.data_vars = {
-                "fake": "fake_band"
-            }
+            self.data_vars = {"fake": "fake_band"}
 
         def __getitem__(self, key):
             return int_data()
@@ -242,30 +252,34 @@ def test_make_band_dict_float(product_layer) -> None: # noqa: F811
     band_dict = datacube_ows.feature_info._make_band_dict(product_layer, int_dataset())
     assert isinstance(band_dict["fake"], dict)
     assert band_dict["fake"] == {
-        "Mask image as provided by JAXA - Ocean and water, lay over, shadowing, land.": 'lay_over'
+        "Mask image as provided by JAXA - Ocean and water, lay over, shadowing, land.": "lay_over"
     }
 
-    band_dict = datacube_ows.feature_info._make_band_dict(product_layer, float_dataset())
+    band_dict = datacube_ows.feature_info._make_band_dict(
+        product_layer, float_dataset()
+    )
     assert isinstance(band_dict["fake"], dict)
     assert band_dict["fake"] == {
-        "Mask image as provided by JAXA - Ocean and water, lay over, shadowing, land.": 'lay_over'
+        "Mask image as provided by JAXA - Ocean and water, lay over, shadowing, land.": "lay_over"
     }
 
 
-def test_pbq_ctor_simple(product_layer) -> None: # noqa: F811
+def test_pbq_ctor_simple(product_layer) -> None:  # noqa: F811
     pbq = ProductBandQuery.simple_layer_query(product_layer, {"red", "green"})
     assert str(pbq) in (
         "Query bands {'red', 'green'} from products [FakeODCProduct(test_odc_product)]",
-        "Query bands {'green', 'red'} from products [FakeODCProduct(test_odc_product)]"
+        "Query bands {'green', 'red'} from products [FakeODCProduct(test_odc_product)]",
     )
-    pbq = ProductBandQuery.simple_layer_query(product_layer, {"red", "green"}, resource_limited=True)
+    pbq = ProductBandQuery.simple_layer_query(
+        product_layer, {"red", "green"}, resource_limited=True
+    )
     assert str(pbq) in (
         "Query bands {'red', 'green'} from products [FakeODCProduct(test_odc_summary_product)]",
-        "Query bands {'green', 'red'} from products [FakeODCProduct(test_odc_summary_product)]"
+        "Query bands {'green', 'red'} from products [FakeODCProduct(test_odc_summary_product)]",
     )
 
 
-def test_pbq_ctor_full(product_layer) -> None: # noqa: F811
+def test_pbq_ctor_full(product_layer) -> None:  # noqa: F811
     pbqs = ProductBandQuery.full_layer_queries(product_layer)
     assert len(pbqs) == 2
     assert "red" in str(pbqs[0])
@@ -273,7 +287,7 @@ def test_pbq_ctor_full(product_layer) -> None: # noqa: F811
     assert "blue" in str(pbqs[0])
     assert "fake" in str(pbqs[0])
     assert "Query bands {" in str(pbqs[0])
-    assert "} from products [FakeODCProduct(test_odc_product)]"  in str(pbqs[0])
+    assert "} from products [FakeODCProduct(test_odc_product)]" in str(pbqs[0])
     assert str(pbqs[1]) in (
         "Query bands {'wongle', 'pq'} from products [FakeODCProduct(test_masking_product)]",
         "Query bands {'pq', 'wongle'} from products [FakeODCProduct(test_masking_product)]",
@@ -286,13 +300,15 @@ def test_user_date_sorter() -> None:
     minx, maxx = 140, 141
     miny, maxy = -35, -34
     crs = "EPSG:4326"
-    geom = polygon([(minx, maxy), (minx, miny), (maxx, miny), (maxx, maxy), (minx, maxy)], crs)
+    geom = polygon(
+        [(minx, maxy), (minx, miny), (maxx, miny), (maxx, maxy), (minx, maxy)], crs
+    )
 
-    odc_dates =  [
+    odc_dates = [
         np.datetime64(datetime.datetime(2018, 12, 31, 20, 0, 0), "ns"),
         np.datetime64(datetime.datetime(2019, 12, 31, 20, 0, 0), "ns"),
         np.datetime64(datetime.datetime(2020, 12, 31, 20, 0, 0), "ns"),
-     ]
+    ]
 
     user_dates = [
         datetime.date(2021, 1, 1),
@@ -310,17 +326,14 @@ def test_create_nodata(dummy_raw_calc_data) -> None:
     ds = DataStacker.__new__(DataStacker)
     data_in = dummy_raw_calc_data
     prod = MagicMock()
-    prod.measurements = {
-        "flagband": MagicMock()
-    }
+    prod.measurements = {"flagband": MagicMock()}
     prod.measurements["flagband"].nodata = 1
-    pbq = ProductBandQuery(
-                    [prod],
-                    ["flagband"],
-                    False)
+    pbq = ProductBandQuery([prod], ["flagband"], False)
     data_out = ds.create_nodata_filled_flag_bands(data_in, pbq)
     assert data_out["flagband"][0] == 1
     assert data_out["flagband"][5] == 1
     with pytest.raises(WMSException) as e:
         data_out = ds.create_nodata_filled_flag_bands(Dataset(), pbq)
-    assert "Cannot add default flag data as there is no non-flag data available" in str(e.value)
+    assert "Cannot add default flag data as there is no non-flag data available" in str(
+        e.value
+    )

--- a/tests/test_driver_cache.py
+++ b/tests/test_driver_cache.py
@@ -7,9 +7,11 @@
 
 def test_index_driver_cache() -> None:
     from datacube_ows.index.driver import ows_index_drivers
+
     a = 2
     a = a + 1
     assert "postgres" in ows_index_drivers()
     assert "postgis" in ows_index_drivers()
     from datacube_ows.index.driver import ows_index_driver_by_name
+
     assert ows_index_driver_by_name("postgres") is not None

--- a/tests/test_legend_generator.py
+++ b/tests/test_legend_generator.py
@@ -30,8 +30,9 @@ def prelegend_colorramp_style() -> StyleDefBase:
     return style
 
 
-def test_create_legend_for_style(dummy_layer) -> None: # noqa: F811
+def test_create_legend_for_style(dummy_layer) -> None:  # noqa: F811
     from datacube_ows.legend_generator import create_legend_for_style
+
     assert create_legend_for_style(dummy_layer, "stylish_steve") is None
 
 
@@ -55,13 +56,10 @@ def test_image_from_bad_image_url(bad_image_url) -> None:
     with pytest.raises(WMSException):
         _ = get_image_from_url(bad_image_url)
 
+
 def test_parse_colorramp_defaults() -> None:
     legend = ColorRampDef.Legend(MagicMock(), {})
-    _ = ColorRamp(MagicMock(),
-                     {
-                        "range": [0.0, 1.0],
-                     },
-                     legend)
+    _ = ColorRamp(MagicMock(), {"range": [0.0, 1.0]}, legend)
     assert legend.begin == Decimal("0.0")
     assert legend.end == Decimal("1.0")
     assert legend.ticks == [Decimal("0.0"), Decimal("1.0")]
@@ -73,9 +71,6 @@ def test_parse_colorramp_defaults() -> None:
 
 
 def test_parse_colorramp_legend_beginend() -> None:
-    legend = ColorRampDef.Legend(MagicMock(), {
-        "begin": "0.0",
-        "end": "2.0"
-    })
+    legend = ColorRampDef.Legend(MagicMock(), {"begin": "0.0", "end": "2.0"})
     assert legend.begin == Decimal("0.0")
     assert legend.end == Decimal("2.0")

--- a/tests/test_mpl_cmaps.py
+++ b/tests/test_mpl_cmaps.py
@@ -7,12 +7,13 @@
 """
 Test creation of colour maps from matplotlib
 """
+
 from datacube_ows.ows_cfg_example import style_deform
 from datacube_ows.styles.ramp import read_mpl_ramp
 
 
 def test_get_mpl_cmap() -> None:
-    matplotlib_ramp_name = style_deform['mpl_ramp']
+    matplotlib_ramp_name = style_deform["mpl_ramp"]
     assert matplotlib_ramp_name
     ows_ramp_dict = read_mpl_ramp(matplotlib_ramp_name)
     assert len(ows_ramp_dict) == 11

--- a/tests/test_multidate_handler.py
+++ b/tests/test_multidate_handler.py
@@ -71,21 +71,21 @@ def test_multidate_handler() -> None:
 
     with pytest.raises(ConfigException) as excinfo:
         _ = StyleDefBase.MultiDateHandler(
-            FakeMdhStyle(), {"allowed_count_range": [0, 5, 10], }
+            FakeMdhStyle(), {"allowed_count_range": [0, 5, 10]}
         )
 
     assert "allowed_count_range must have 2" in str(excinfo.value)
 
     with pytest.raises(ConfigException) as excinfo:
         _ = StyleDefBase.MultiDateHandler(
-            FakeMdhStyle(), {"allowed_count_range": [10, 5], }
+            FakeMdhStyle(), {"allowed_count_range": [10, 5]}
         )
 
     assert "minimum must be less than equal to maximum" in str(excinfo.value)
 
     with pytest.raises(ConfigException) as excinfo:
         _ = StyleDefBase.MultiDateHandler(
-            FakeMdhStyle(), {"allowed_count_range": [0, 10], }
+            FakeMdhStyle(), {"allowed_count_range": [0, 10]}
         )
 
     assert "Aggregator function is required" in str(excinfo.value)

--- a/tests/test_mv_selopts.py
+++ b/tests/test_mv_selopts.py
@@ -22,6 +22,7 @@ def test_ids_datasets() -> None:
         def __init__(self, id_) -> None:
             self.id = id_
             self.c = self
+
     stv = MockSTV(42)
     assert MVSelectOpts.IDS.sel(stv) == [42]
     assert MVSelectOpts.DATASETS.sel(stv) == [42]
@@ -35,6 +36,7 @@ def test_extent() -> None:
 
 def test_count() -> None:
     from sqlalchemy import text
+
     stv = MockSTV(id_=text("foo"))
     sel = MVSelectOpts.COUNT.sel(stv)
     assert len(sel) == 1

--- a/tests/test_no_db_routes.py
+++ b/tests/test_no_db_routes.py
@@ -4,8 +4,8 @@
 # Copyright (c) 2017-2024 OWS Contributors
 # SPDX-License-Identifier: Apache-2.0
 
-"""Run with no DB to simulate connection failure
-"""
+"""Run with no DB to simulate connection failure"""
+
 import os
 import sys
 
@@ -18,6 +18,7 @@ if src_dir not in sys.path:
 
 def reset_global_config() -> None:
     from datacube_ows.ows_configuration import OWSConfig
+
     OWSConfig._instance = None
 
 
@@ -31,25 +32,25 @@ def no_db(monkeypatch):
 
 def test_db_connect_fail(no_db, flask_client) -> None:
     """Start with a database connection"""
-    rv = flask_client.get('/ping')
+    rv = flask_client.get("/ping")
     assert rv.status_code == 500
 
 
 def test_wcs_fail(no_db, flask_client) -> None:
     """WCS endpoint fails"""
-    rv = flask_client.get('/wcs')
+    rv = flask_client.get("/wcs")
     assert rv.status_code == 400
 
 
 def test_wms_fail(no_db, flask_client) -> None:
     """WMS endpoint fails"""
-    rv = flask_client.get('/wms')
+    rv = flask_client.get("/wms")
     assert rv.status_code == 400
 
 
 def test_wmts_fail(no_db, flask_client) -> None:
     """WMTS endpoint fails"""
-    rv = flask_client.get('/wmts')
+    rv = flask_client.get("/wmts")
     assert rv.status_code == 400
 
 
@@ -62,5 +63,5 @@ def test_legend_fail(no_db, flask_client) -> None:
 def test_index_fail(no_db, flask_client) -> None:
     """Base index endpoint fails"""
     # Should actually be 200 TODO
-    rv = flask_client.get('/')
+    rv = flask_client.get("/")
     assert rv.status_code == 500

--- a/tests/test_ogc_utils.py
+++ b/tests/test_ogc_utils.py
@@ -30,20 +30,14 @@ def test_dataset_center_time() -> None:
     dct = datacube_ows.time_utils.dataset_center_time
     ds = DSCT({})
     assert dct(ds).year == 1970
-    ds = DSCT({
-        "properties": {
-            "dtr:start_datetime": "1980-01-01T00:00:00"
-        },
-    })
+    ds = DSCT({"properties": {"dtr:start_datetime": "1980-01-01T00:00:00"}})
     assert dct(ds).year == 1980
-    ds = DSCT({
-        "extent": {
-            "center_dt": "1990-01-01T00:00:00"
-        },
-        "properties": {
-            "dtr:start_datetime": "1980-01-01T00:00:00"
-        },
-    })
+    ds = DSCT(
+        {
+            "extent": {"center_dt": "1990-01-01T00:00:00"},
+            "properties": {"dtr:start_datetime": "1980-01-01T00:00:00"},
+        }
+    )
     assert dct(ds).year == 1990
 
 
@@ -58,11 +52,12 @@ def dummy_ds():
             (149.0, -35.4),
             (149.0, -35.3),
         ],
-        crs="EPSG:4326"
+        crs="EPSG:4326",
     )
     ds.center_time = datetime.datetime(2020, 12, 25, 15, 11, 11, tzinfo=timezone.utc)
     ds.metadata_doc = {}
     return ds
+
 
 def test_tz_for_dataset(dummy_ds) -> None:
     ret = datacube_ows.time_utils.tz_for_dataset(dummy_ds)
@@ -92,7 +87,6 @@ def test_month_date_range_wrap() -> None:
 
 
 def test_get_service_base_url() -> None:
-
     # not a list
     allowed_urls = "https://foo.hello.world"
     request_url = "https://foo.bar.baz"
@@ -106,7 +100,11 @@ def test_get_service_base_url() -> None:
     assert ret == "https://foo.hello.world"
 
     # Value in list
-    allowed_urls = ["https://foo.hello.world", "https://foo.bar.baz", "https://alice.bob.eve"]
+    allowed_urls = [
+        "https://foo.hello.world",
+        "https://foo.bar.baz",
+        "https://alice.bob.eve",
+    ]
     request_url = "https://foo.bar.baz"
     ret = datacube_ows.http_utils.get_service_base_url(allowed_urls, request_url)
     assert ret == "https://foo.bar.baz"
@@ -137,34 +135,34 @@ def test_parse_for_base_url() -> None:
 
 
 def test_create_geobox() -> None:
-    geobox = datacube_ows.ogc_utils.create_geobox("EPSG:4326",
-                                                  140.7184, 145.6924, -16.1144, -13.4938,
-                                                  1182, 668)
-    geobox_ho = datacube_ows.ogc_utils.create_geobox("EPSG:4326",
-                                                  140.7184, 145.6924, -16.1144, -13.4938,
-                                                  height=668)
-    geobox_wo = datacube_ows.ogc_utils.create_geobox("EPSG:4326",
-                              140.7184, 145.6924, -16.1144, -13.4938,
-                              width=1182)
+    geobox = datacube_ows.ogc_utils.create_geobox(
+        "EPSG:4326", 140.7184, 145.6924, -16.1144, -13.4938, 1182, 668
+    )
+    geobox_ho = datacube_ows.ogc_utils.create_geobox(
+        "EPSG:4326", 140.7184, 145.6924, -16.1144, -13.4938, height=668
+    )
+    geobox_wo = datacube_ows.ogc_utils.create_geobox(
+        "EPSG:4326", 140.7184, 145.6924, -16.1144, -13.4938, width=1182
+    )
     for _ in (geobox, geobox_ho, geobox_wo):
         assert geobox.width == 1182
         assert geobox.height == 668
     with pytest.raises(Exception) as excinfo:
-        _ = datacube_ows.ogc_utils.create_geobox("EPSG:4326",
-                                                         140.7184, 145.6924, -16.1144, -13.4938)
+        _ = datacube_ows.ogc_utils.create_geobox(
+            "EPSG:4326", 140.7184, 145.6924, -16.1144, -13.4938
+        )
     assert "Must supply at least a width or height" in str(excinfo.value)
 
 
-
-coords = [
-    ("x", [-1.0, -0.5, 0.0, 0.5, 1.0]),
-]
+coords = [("x", [-1.0, -0.5, 0.0, 0.5, 1.0])]
 
 
 def test_mask_by_val() -> None:
     data = {
         "match": dummy_da(-999, "match", coords, attrs={"nodata": -999}, dtype="int16"),
-        "dont_match": dummy_da(679, "dont_match", coords, attrs={"nodata": -999}, dtype="int16"),
+        "dont_match": dummy_da(
+            679, "dont_match", coords, attrs={"nodata": -999}, dtype="int16"
+        ),
     }
     mask = datacube_ows.ogc_utils.mask_by_val(data, "match")
     assert not mask.values[0]
@@ -179,7 +177,9 @@ def test_mask_by_val() -> None:
 def test_mask_by_val2() -> None:
     data = {
         "match": dummy_da(-999, "match", coords, attrs={"nodata": -999}, dtype="int16"),
-        "dont_match": dummy_da(679, "dont_match", coords, attrs={"nodata": -999}, dtype="int16"),
+        "dont_match": dummy_da(
+            679, "dont_match", coords, attrs={"nodata": -999}, dtype="int16"
+        ),
     }
     mask = datacube_ows.ogc_utils.mask_by_val2(data, "match")
     assert not mask.values[0]
@@ -190,7 +190,9 @@ def test_mask_by_val2() -> None:
 def test_mask_by_bitflag() -> None:
     data = {
         "match": dummy_da(128, "match", coords, attrs={"nodata": 128}, dtype="uint8"),
-        "dont_match": dummy_da(63, "dont_match", coords, attrs={"nodata": 128}, dtype="uint8"),
+        "dont_match": dummy_da(
+            63, "dont_match", coords, attrs={"nodata": 128}, dtype="uint8"
+        ),
     }
     mask = datacube_ows.ogc_utils.mask_by_bitflag(data, "match")
     assert not mask.values[0]
@@ -201,18 +203,24 @@ def test_mask_by_bitflag() -> None:
 def test_mask_by_val_in_band() -> None:
     data = {
         "match": dummy_da(-999, "match", coords, attrs={"nodata": -999}, dtype="int16"),
-        "dont_match": dummy_da(679, "dont_match", coords, attrs={"nodata": -999}, dtype="int16"),
+        "dont_match": dummy_da(
+            679, "dont_match", coords, attrs={"nodata": -999}, dtype="int16"
+        ),
         "dband": dummy_da(0.77, "dband", coords, dtype="float128"),
     }
     mask = datacube_ows.ogc_utils.mask_by_val_in_band(data, "dband", mask_band="match")
     assert not mask.values[0]
-    mask = datacube_ows.ogc_utils.mask_by_val_in_band(data, "dband", mask_band="dont_match", val=679)
+    mask = datacube_ows.ogc_utils.mask_by_val_in_band(
+        data, "dband", mask_band="dont_match", val=679
+    )
     assert not mask.values[0]
 
 
 def test_mask_by_quality() -> None:
     data = {
-        "quality": dummy_da(-999, "match", coords, attrs={"nodata": -999}, dtype="int16"),
+        "quality": dummy_da(
+            -999, "match", coords, attrs={"nodata": -999}, dtype="int16"
+        ),
         "dband": dummy_da(0.77, "dband", coords, dtype="float128"),
     }
     mask = datacube_ows.ogc_utils.mask_by_quality(data, "dband")
@@ -233,7 +241,9 @@ def test_mask_by_extent_flag() -> None:
 
 def test_mask_by_extent_val() -> None:
     data = {
-        "extent": dummy_da(-999, "match", coords, attrs={"nodata": -999}, dtype="int16"),
+        "extent": dummy_da(
+            -999, "match", coords, attrs={"nodata": -999}, dtype="int16"
+        ),
         "dband": dummy_da(0.77, "dband", coords, dtype="float128"),
     }
     mask = datacube_ows.ogc_utils.mask_by_extent_val(data, "dband")
@@ -257,6 +267,7 @@ def test_rolling_window() -> None:
     class DummyLayer:
         def search_times(self, d):
             return d, d
+
     lyr = DummyLayer()
 
     start, end = rolling_window_ndays(
@@ -270,70 +281,79 @@ def test_rolling_window() -> None:
             datetime.datetime(2020, 6, 17),
             datetime.datetime(2020, 6, 18),
         ],
-        layer_cfg = lyr,
-        ndays = 6
+        layer_cfg=lyr,
+        ndays=6,
     )
     assert start == datetime.datetime(2020, 6, 9)
     assert end == datetime.datetime(2020, 6, 18)
 
 
 def test_day_summary_date_range() -> None:
-    start, end = datacube_ows.time_utils.day_summary_date_range(datetime.date(2015, 5, 12))
+    start, end = datacube_ows.time_utils.day_summary_date_range(
+        datetime.date(2015, 5, 12)
+    )
     assert start == datetime.datetime(2015, 5, 12, 0, 0, 0, tzinfo=timezone.utc)
     assert end == datetime.datetime(2015, 5, 12, 23, 59, 59, tzinfo=timezone.utc)
 
-xy_coords = [
-    ("x", [-1.0, -0.5, 0.0, 0.5, 1.0]),
-    ("y", [-1.0, -0.5]),
-]
+
+xy_coords = [("x", [-1.0, -0.5, 0.0, 0.5, 1.0]), ("y", [-1.0, -0.5])]
 
 xyt_coords = [
     ("x", [-1.0, -0.5, 0.0, 0.5, 1.0]),
     ("y", [-1.0, -0.5, 0.0, 0.5, 1.0]),
-    ("time", [
-                datetime.datetime(2021, 1, 1, 22, 44, 5),
-                datetime.datetime.now()
-              ])
+    ("time", [datetime.datetime(2021, 1, 1, 22, 44, 5), datetime.datetime.now()]),
 ]
 
+
 def test_png_loop_over() -> None:
-    data = xarray.Dataset({
+    data = xarray.Dataset(
+        {
             "red": dummy_da(100, "red", xyt_coords, dtype="uint8"),
             "green": dummy_da(70, "green", xyt_coords, dtype="uint8"),
             "blue": dummy_da(150, "blue", xyt_coords, dtype="uint8"),
             "alpha": dummy_da(200, "alpha", xyt_coords, dtype="uint8"),
-        })
+        }
+    )
     imgs = datacube_ows.ogc_utils.xarray_image_as_png(data, loop_over="time")
     assert len(imgs) == 2
     assert len(imgs[0]) == 78
     assert imgs[0].find(b"\x89PNG") == 0
 
+
 def test_png_loop_over_anim() -> None:
-    data = xarray.Dataset({
-        "red": dummy_da(100, "red", xyt_coords, dtype="uint8"),
-        "green": dummy_da(70, "green", xyt_coords, dtype="uint8"),
-        "blue": dummy_da(150, "blue", xyt_coords, dtype="uint8"),
-        "alpha": dummy_da(200, "alpha", xyt_coords, dtype="uint8"),
-    })
-    imgs = datacube_ows.ogc_utils.xarray_image_as_png(data, loop_over="time", animate=True)
+    data = xarray.Dataset(
+        {
+            "red": dummy_da(100, "red", xyt_coords, dtype="uint8"),
+            "green": dummy_da(70, "green", xyt_coords, dtype="uint8"),
+            "blue": dummy_da(150, "blue", xyt_coords, dtype="uint8"),
+            "alpha": dummy_da(200, "alpha", xyt_coords, dtype="uint8"),
+        }
+    )
+    imgs = datacube_ows.ogc_utils.xarray_image_as_png(
+        data, loop_over="time", animate=True
+    )
     assert len(imgs) == 173
     assert imgs.find(b"\x89PNG") == 0
 
 
 def test_render_frame() -> None:
-    data = xarray.Dataset({
-        "red": dummy_da(100, "red", xy_coords, dtype="uint8"),
-        "green": dummy_da(70, "green", xy_coords, dtype="uint8"),
-        "blue": dummy_da(150, "blue", xy_coords, dtype="uint8"),
-        "alpha": dummy_da(200, "alpha", xy_coords, dtype="uint8"),
-    })
+    data = xarray.Dataset(
+        {
+            "red": dummy_da(100, "red", xy_coords, dtype="uint8"),
+            "green": dummy_da(70, "green", xy_coords, dtype="uint8"),
+            "blue": dummy_da(150, "blue", xy_coords, dtype="uint8"),
+            "alpha": dummy_da(200, "alpha", xy_coords, dtype="uint8"),
+        }
+    )
     png = datacube_ows.ogc_utils.render_frame(data, 5, 2)
     assert png.shape == (2, 5, 4)
-    data = xarray.Dataset({
-        "red": dummy_da(100, "red", xy_coords, dtype="uint8"),
-        "green": dummy_da(70, "green", xy_coords, dtype="uint8"),
-        "blue": dummy_da(150, "blue", xy_coords, dtype="uint8"),
-    })
+    data = xarray.Dataset(
+        {
+            "red": dummy_da(100, "red", xy_coords, dtype="uint8"),
+            "green": dummy_da(70, "green", xy_coords, dtype="uint8"),
+            "blue": dummy_da(150, "blue", xy_coords, dtype="uint8"),
+        }
+    )
     png = datacube_ows.ogc_utils.render_frame(data, 5, 2)
     assert png.shape == (2, 5, 4)
 

--- a/tests/test_ows_configuration.py
+++ b/tests/test_ows_configuration.py
@@ -21,17 +21,12 @@ def test_function_wrapper_lyr() -> None:
     assert f(7)[0] == "a7  b2  c3"
     assert f(5, c=4)[0] == "a5  b2  c4"
     assert f.band_mapper is None
-    func_cfg = {
-        "function": "tests.utils.a_function",
-    }
+    func_cfg = {"function": "tests.utils.a_function"}
     f = datacube_ows.config_utils.FunctionWrapper(lyr, func_cfg)
     assert f(7, 8)[0] == "a7  b8  c3"
     func_cfg = {
         "function": "tests.utils.a_function",
-        "kwargs": {
-            "foo": "bar",
-            "c": "ouple"
-        }
+        "kwargs": {"foo": "bar", "c": "ouple"},
     }
     f = datacube_ows.config_utils.FunctionWrapper(lyr, func_cfg)
     result = f("pple", "eagle")
@@ -43,10 +38,7 @@ def test_function_wrapper_lyr() -> None:
     assert result[0] == "apple  beagle  couple"
     assert result[1]["foo"] == "bar"
     assert "a" not in f._kwargs
-    func_cfg = {
-        "function": "tests.utils.a_function",
-        "args": ["bar", "ouple"]
-    }
+    func_cfg = {"function": "tests.utils.a_function", "args": ["bar", "ouple"]}
     f = datacube_ows.config_utils.FunctionWrapper(lyr, func_cfg)
     result = f("pple")
     assert result[0] == "apple  bbar  couple"
@@ -55,28 +47,28 @@ def test_function_wrapper_lyr() -> None:
     result = f()
     assert result[0] == "abar  bouple  c3"
     assert f.band_mapper is None
-    func_cfg = {
-        "function": "so_fake.not_real.not_a_function",
-        "args": ["bar", "ouple"]
-    }
+    func_cfg = {"function": "so_fake.not_real.not_a_function", "args": ["bar", "ouple"]}
     with pytest.raises(datacube_ows.config_utils.ConfigException) as e:
         f = datacube_ows.config_utils.FunctionWrapper(lyr, func_cfg)
     assert "Could not import python object" in str(e.value)
     assert "so_fake.not_real.not_a_function" in str(e.value)
 
+
 def test_func_naked() -> None:
     lyr = MagicMock()
     with pytest.raises(datacube_ows.config_utils.ConfigException):
-        _ = datacube_ows.config_utils.FunctionWrapper(lyr, {
-            "function": a_function,
-        })
-    assert "Directly including callable objects in configuration is no longer supported."
+        _ = datacube_ows.config_utils.FunctionWrapper(lyr, {"function": a_function})
+    assert (
+        "Directly including callable objects in configuration is no longer supported."
+    )
     with pytest.raises(datacube_ows.config_utils.ConfigException):
         _ = datacube_ows.config_utils.FunctionWrapper(lyr, a_function)
-    assert "Directly including callable objects in configuration is no longer supported."
-    f = datacube_ows.config_utils.FunctionWrapper(lyr, {
-        "function": a_function,
-    }, stand_alone=True)
+    assert (
+        "Directly including callable objects in configuration is no longer supported."
+    )
+    f = datacube_ows.config_utils.FunctionWrapper(
+        lyr, {"function": a_function}, stand_alone=True
+    )
     assert f("ardvark", "bllbbll")[0] == "aardvark  bbllbbll  c3"
     f = datacube_ows.config_utils.FunctionWrapper(lyr, a_function, stand_alone=True)
     assert f("ardvark", "bllbbll")[0] == "aardvark  bbllbbll  c3"
@@ -100,6 +92,7 @@ def test_base_class_unready() -> None:
     with pytest.raises(datacube_ows.config_utils.ConfigException) as e:
         cfg.declare_unready("woah")
     assert "Cannot declare woah as unready on a ready object" in str(e.value)
+
 
 def test_base_class_get() -> None:
     cfg = datacube_ows.config_utils.OWSConfigEntry({"foo": "bar", "pot": "noodle"})

--- a/tests/test_protocol_versions.py
+++ b/tests/test_protocol_versions.py
@@ -14,19 +14,32 @@ from datacube_ows.protocol_versions import SupportedSvc
 class DummyException1(OGCException):
     pass
 
+
 class DummyException2(OGCException):
     pass
+
 
 def fake_router(*args, **kwargs) -> None:
     return None
 
+
 @pytest.fixture
 def supported_service() -> SupportedSvc:
-    return datacube_ows.protocol_versions.SupportedSvc([
-        datacube_ows.protocol_versions.SupportedSvcVersion("wxs", "1.2.7", fake_router, DummyException1),
-        datacube_ows.protocol_versions.SupportedSvcVersion("wxs", "1.13.0", fake_router, DummyException1),
-        datacube_ows.protocol_versions.SupportedSvcVersion("wxs", "2.0.0", fake_router, DummyException1),
-    ], DummyException2)
+    return datacube_ows.protocol_versions.SupportedSvc(
+        [
+            datacube_ows.protocol_versions.SupportedSvcVersion(
+                "wxs", "1.2.7", fake_router, DummyException1
+            ),
+            datacube_ows.protocol_versions.SupportedSvcVersion(
+                "wxs", "1.13.0", fake_router, DummyException1
+            ),
+            datacube_ows.protocol_versions.SupportedSvcVersion(
+                "wxs", "2.0.0", fake_router, DummyException1
+            ),
+        ],
+        DummyException2,
+    )
+
 
 def test_default_exception(supported_service: SupportedSvc) -> None:
     assert supported_service.default_exception_class == DummyException2
@@ -49,5 +62,7 @@ def test_version_cleaner(supported_service: SupportedSvc) -> None:
     assert supported_service._clean_version_parts(["0", "1", "2"]) == [0, 1, 2]
     assert supported_service._clean_version_parts(["0", "1", "2/spam"]) == [0, 1, 2]
     assert supported_service._clean_version_parts(["0", "1spam", "2"]) == [0, 1]
-    assert supported_service._clean_version_parts(["0?bacon", "1/eggs", "2/spam"]) == [0]
+    assert supported_service._clean_version_parts(["0?bacon", "1/eggs", "2/spam"]) == [
+        0
+    ]
     assert supported_service._clean_version_parts(["spam", "spam", "spam"]) == []

--- a/tests/test_pyproj.py
+++ b/tests/test_pyproj.py
@@ -7,21 +7,21 @@
 from pyproj import CRS
 
 SUPPORTED_CRS = [
-   'EPSG:3857', # Web Mercator
-   'EPSG:4326', # WGS-84
-   'EPSG:3577', # GDA-94
-   'EPSG:3111', # VicGrid94
-   'EPSG:32648', # WGS 84 / Cambodiacube
-   'ESRI:102022', # Africa
-   # 'EPSG:102022', # Depreciated Africa
-   'EPSG:6933', # Africa
+    "EPSG:3857",  # Web Mercator
+    "EPSG:4326",  # WGS-84
+    "EPSG:3577",  # GDA-94
+    "EPSG:3111",  # VicGrid94
+    "EPSG:32648",  # WGS 84 / Cambodiacube
+    "ESRI:102022",  # Africa
+    # 'EPSG:102022', # Depreciated Africa
+    "EPSG:6933",  # Africa
 ]
 
 
 def test_pyproj_crs() -> None:
-   for crs_string in SUPPORTED_CRS:
-      try:
-         crs = CRS(crs_string)
-         assert crs is not None
-      except Exception:
-         assert True is False
+    for crs_string in SUPPORTED_CRS:
+        try:
+            crs = CRS(crs_string)
+            assert crs is not None
+        except Exception:
+            assert True is False

--- a/tests/test_resource_limits.py
+++ b/tests/test_resource_limits.py
@@ -12,29 +12,39 @@ from datacube_ows.ogc_utils import create_geobox
 
 
 def test_request_scale() -> None:
-    band = {'dtype': 'float64'}
-    stdtile = create_geobox(minx=-20037508.342789, maxx=20037508.342789,
-                            miny=-20037508.342789, maxy=20037508.342789,
-                            crs=CRS("EPSG:3857"),
-                            width=256, height=256)
-    bigtile = create_geobox(minx=-20037508.342789, maxx=20037508.342789,
-                           miny=-20037508.342789, maxy=20037508.342789,
-                           crs=CRS("EPSG:3857"),
-                           width=512, height=512)
-    rs1 = datacube_ows.resource_limits.RequestScale(CRS("EPSG:3857"), (10.0, 10.0),
-                                                    bigtile, 2,
-                                                    request_bands=[band])
+    band = {"dtype": "float64"}
+    stdtile = create_geobox(
+        minx=-20037508.342789,
+        maxx=20037508.342789,
+        miny=-20037508.342789,
+        maxy=20037508.342789,
+        crs=CRS("EPSG:3857"),
+        width=256,
+        height=256,
+    )
+    bigtile = create_geobox(
+        minx=-20037508.342789,
+        maxx=20037508.342789,
+        miny=-20037508.342789,
+        maxy=20037508.342789,
+        crs=CRS("EPSG:3857"),
+        width=512,
+        height=512,
+    )
+    rs1 = datacube_ows.resource_limits.RequestScale(
+        CRS("EPSG:3857"), (10.0, 10.0), bigtile, 2, request_bands=[band]
+    )
     assert pytest.approx(rs1.standard_scale / rs1.standard_scale, 1e-8) == 1.0
     assert pytest.approx(rs1 / rs1.standard_scale, 1e-8) == 200 / 3
     assert pytest.approx(rs1.load_factor, 1e-8) == 200 / 3
     assert pytest.approx(rs1.standard_scale.zoom_lvl_offset, 1e-64) == 0.0
-    rs2 = datacube_ows.resource_limits.RequestScale(CRS("EPSG:3857"), (25.0, 25.0),
-                                                    stdtile, 4,
-                                                    total_band_size=6)
+    rs2 = datacube_ows.resource_limits.RequestScale(
+        CRS("EPSG:3857"), (25.0, 25.0), stdtile, 4, total_band_size=6
+    )
     assert pytest.approx(rs2.zoom_lvl_offset, 1e-8) == 1.0
-    rs3 = datacube_ows.resource_limits.RequestScale(CRS("EPSG:3857"), (25.0, 25.0),
-                                                   stdtile, 64,
-                                                   total_band_size=6)
+    rs3 = datacube_ows.resource_limits.RequestScale(
+        CRS("EPSG:3857"), (25.0, 25.0), stdtile, 64, total_band_size=6
+    )
     assert pytest.approx(rs3.zoom_lvl_offset, 1e-8) == 3.0
     assert pytest.approx(rs3.base_zoom_level, 0.1) == 0.0
     assert pytest.approx(rs3.load_adjusted_zoom_level, 0.1) == -3.0
@@ -42,9 +52,7 @@ def test_request_scale() -> None:
 
 def test_degree_to_metres() -> None:
     xres, yres = datacube_ows.resource_limits.RequestScale._metre_resolution(
-        None,
-        CRS("EPSG:4326"),
-        (0.005, 0.005)
+        None, CRS("EPSG:4326"), (0.005, 0.005)
     )
     assert xres > 1.0
     assert yres > 1.0

--- a/tests/test_startup.py
+++ b/tests/test_startup.py
@@ -15,6 +15,7 @@ import pytest
 
 def test_fake_creds(monkeypatch) -> None:
     from datacube_ows.startup_utils import CredentialManager, initialise_aws_credentials
+
     CredentialManager._instance = None
     log = MagicMock()
     monkeypatch.setenv("AWS_DEFAULT_REGION", "")
@@ -39,6 +40,7 @@ def test_renewable_creds(monkeypatch) -> None:
         RefreshableCredentials,
         initialise_aws_credentials,
     )
+
     CredentialManager._instance = None
     log = MagicMock()
     monkeypatch.setenv("AWS_DEFAULT_REGION", "")
@@ -58,6 +60,7 @@ def test_renewable_creds(monkeypatch) -> None:
 
 def test_s3_endpoint_default(monkeypatch) -> None:
     from datacube_ows.startup_utils import CredentialManager, initialise_aws_credentials
+
     CredentialManager._instance = None
     log = MagicMock()
     monkeypatch.setenv("AWS_DEFAULT_REGION", "us-west-1")
@@ -65,8 +68,10 @@ def test_s3_endpoint_default(monkeypatch) -> None:
     initialise_aws_credentials(log=log)
     assert "AWS_S3_ENDPOINT" not in os.environ
 
+
 def test_initialise_logger() -> None:
     from datacube_ows.startup_utils import initialise_logger
+
     log = initialise_logger("tim.the.testlogger")
     assert log is not None
     log.info("Test")
@@ -74,24 +79,28 @@ def test_initialise_logger() -> None:
 
 def test_initialise_ign_warn() -> None:
     from datacube_ows.startup_utils import initialise_ignorable_warnings
+
     initialise_ignorable_warnings()
 
 
 def test_initialise_nodebugging(monkeypatch) -> None:
     monkeypatch.setenv("PYDEV_DEBUG", "")
     from datacube_ows.startup_utils import initialise_debugging
+
     initialise_debugging()
 
 
 def test_initialise_explicit_nodebugging(monkeypatch) -> None:
     monkeypatch.setenv("PYDEV_DEBUG", "no")
     from datacube_ows.startup_utils import initialise_debugging
+
     initialise_debugging()
 
 
 def test_initialise_debugging(monkeypatch) -> None:
     monkeypatch.setenv("PYDEV_DEBUG", "YES")
     from datacube_ows.startup_utils import initialise_debugging
+
     fake_mod = MagicMock()
     with patch.dict("sys.modules", pydevd_pycharm=fake_mod):
         initialise_debugging()
@@ -101,6 +110,7 @@ def test_initialise_debugging(monkeypatch) -> None:
 def test_initialise_sentry(monkeypatch) -> None:
     monkeypatch.setenv("SENTRY_DSN", "")
     from datacube_ows.startup_utils import initialise_sentry
+
     initialise_sentry()
     monkeypatch.setenv("SENTRY_DSN", "https://key@sentry.local/projid")
     log = MagicMock()
@@ -111,11 +121,13 @@ def test_initialise_sentry(monkeypatch) -> None:
 def test_prometheus_inactive(monkeypatch) -> None:
     monkeypatch.setenv("PROMETHEUS_MULTIPROC_DIR", "")
     from datacube_ows.startup_utils import initialise_prometheus
+
     initialise_prometheus(None)
 
 
 def test_supported_version() -> None:
     from datacube_ows.protocol_versions import SupportedSvcVersion
+
     ver = SupportedSvcVersion("wts", "1.2.3", "a", "b")
     assert ver.service == "wts"
     assert ver.service_upper == "WTS"
@@ -124,6 +136,7 @@ def test_supported_version() -> None:
     assert ver.router == "a"
     assert ver.exception_class == "b"
     from datacube_ows.protocol_versions import supported_versions
+
     supported = supported_versions()
     assert supported["wms"].versions[0].service == "wms"
 
@@ -137,12 +150,15 @@ def babel_cfg():
     cfg.message_domain = "ows_cfg"
     return cfg
 
+
 @pytest.fixture
 def flask_app() -> flask.Flask:
     return flask.Flask("test_flask_app")
 
+
 def test_init_babel_on(babel_cfg, flask_app) -> None:
     from datacube_ows.startup_utils import initialise_babel
+
     with flask_app.app_context():
         bab = initialise_babel(babel_cfg, flask_app)
         assert bab is not None
@@ -151,6 +167,7 @@ def test_init_babel_on(babel_cfg, flask_app) -> None:
 
 def test_init_babel_off(babel_cfg, flask_app) -> None:
     from datacube_ows.startup_utils import initialise_babel
+
     babel_cfg.internationalised = False
     bab = initialise_babel(babel_cfg, flask_app)
     assert bab is None
@@ -166,6 +183,6 @@ def test_sentry_before_send() -> None:
     try:
         _ = LGEOS380().GEOSGeom_destroy()
     except Exception:
-        hint = {'exc_info': sys.exc_info()}
-        assert 'exc_info' in hint
+        hint = {"exc_info": sys.exc_info()}
+        assert "exc_info" in hint
         assert before_send("event", hint) is None

--- a/tests/test_style_api.py
+++ b/tests/test_style_api.py
@@ -40,8 +40,8 @@ def simple_rgb_style_cfg() -> CFG_DICT:
         "components": {
             "red": {"red": 1.0},
             "green": {"green": 1.0},
-            "blue": {"blue": 1.0}
-        }
+            "blue": {"blue": 1.0},
+        },
     }
 
 
@@ -55,9 +55,9 @@ def simple_rgb_perband_scaling_style_cfg() -> CFG_DICT:
         "components": {
             "red": {"red": 1.0, "scale_range": [0, 200]},
             "green": {"green": 1.0, "scale_range": [0, 500]},
-            "blue": {"blue": 1.0}
+            "blue": {"blue": 1.0},
         },
-        "scale_range": [0, 350]
+        "scale_range": [0, 350],
     }
 
 
@@ -72,7 +72,9 @@ def test_component_style(dummy_raw_data, null_mask, simple_rgb_style_cfg) -> Non
     assert result["blue"].values[0][0] == 2
 
 
-def test_perband_component_style(dummy_raw_data, null_mask, simple_rgb_perband_scaling_style_cfg) -> None:
+def test_perband_component_style(
+    dummy_raw_data, null_mask, simple_rgb_perband_scaling_style_cfg
+) -> None:
     style = StandaloneStyle(simple_rgb_perband_scaling_style_cfg)
     mask = style.to_mask(dummy_raw_data, null_mask)
     result = style.transform_data(dummy_raw_data, mask)
@@ -81,16 +83,15 @@ def test_perband_component_style(dummy_raw_data, null_mask, simple_rgb_perband_s
 
 
 def test_external_legends(simple_rgb_style_cfg) -> None:
-    simple_rgb_style_cfg["legend"] = {
-        "url": "http://fake.com/not/a/real/image_url.png"
-    }
+    simple_rgb_style_cfg["legend"] = {"url": "http://fake.com/not/a/real/image_url.png"}
     style = StandaloneStyle(simple_rgb_style_cfg)
     for l in style.legend_cfg.legend_urls:  # noqa: E741
-        assert style.legend_cfg.legend_urls[l] == "http://fake.com/not/a/real/image_url.png"
+        assert (
+            style.legend_cfg.legend_urls[l]
+            == "http://fake.com/not/a/real/image_url.png"
+        )
     simple_rgb_style_cfg["legend"] = {
-        "url": {
-           "de": "http://fake.com/not/a/real/image_url.png"
-        }
+        "url": {"de": "http://fake.com/not/a/real/image_url.png"}
     }
     with pytest.raises(ConfigException) as e:
         style = StandaloneStyle(simple_rgb_style_cfg)
@@ -106,36 +107,29 @@ def simple_ramp_style_cfg() -> CFG_DICT:
         "index_function": {
             "function": "datacube_ows.band_utils.norm_diff",
             "mapped_bands": True,
-            "kwargs": {
-                "band1": "ir",
-                "band2": "red"
-            }
+            "kwargs": {"band1": "ir", "band2": "red"},
         },
         "needed_bands": ["red", "ir"],
         "color_ramp": [
-            {
-                "value": -0.00000001,
-                "color": "#000000",
-                "alpha": 0.0
-            },
-            {
-                "value": 0.0,
-                "color": "#000000",
-                "alpha": 1.0
-            },
+            {"value": -0.00000001, "color": "#000000", "alpha": 0.0},
+            {"value": 0.0, "color": "#000000", "alpha": 1.0},
             {"value": 0.2, "color": "#FF00FF"},
             {"value": 0.4, "color": "#00FF00"},
             {"value": 0.5, "color": "#FFFF00"},
             {"value": 0.6, "color": "#0000FF"},
             {"value": 0.8, "color": "#00FFFF"},
-            {"value": 1.0, "color": "#FFFFFF"}
+            {"value": 1.0, "color": "#FFFFFF"},
         ],
     }
 
 
-def test_ramp_style(dummy_raw_calc_data, raw_calc_null_mask, simple_ramp_style_cfg) -> None:
+def test_ramp_style(
+    dummy_raw_calc_data, raw_calc_null_mask, simple_ramp_style_cfg
+) -> None:
     style = StandaloneStyle(simple_ramp_style_cfg)
-    result = apply_ows_style(style, dummy_raw_calc_data, valid_data_mask=raw_calc_null_mask)
+    result = apply_ows_style(
+        style, dummy_raw_calc_data, valid_data_mask=raw_calc_null_mask
+    )
     for channel in ("red", "green", "blue", "alpha"):
         assert channel in result.data_vars
     # point 0 800, 200 (idx=0.6)maps to blue
@@ -153,7 +147,7 @@ def test_ramp_style(dummy_raw_calc_data, raw_calc_null_mask, simple_ramp_style_c
     # point 3 600,200 (idx=0.5) maps to yellow
     assert result["alpha"].values[3] == 255
     assert result["red"].values[3] == 255
-    assert result["green"].values[3] >= 254 # Why isn't it 255?
+    assert result["green"].values[3] >= 254  # Why isn't it 255?
     assert result["blue"].values[3] == 0
     # point 4 200,200 (idx=0.0) maps to black
     assert result["alpha"].values[4] == 255
@@ -163,16 +157,23 @@ def test_ramp_style(dummy_raw_calc_data, raw_calc_null_mask, simple_ramp_style_c
     # point 5 1000,700 (idx=0.176) maps to between black and magenta
     assert result["alpha"].values[5] == 255
     assert result["green"].values[5] == 0
-    assert abs(result["red"].values[5] - result["blue"].values[5]) <= 1 # Why not exactly equal?
+    assert (
+        abs(result["red"].values[5] - result["blue"].values[5]) <= 1
+    )  # Why not exactly equal?
     assert result["red"].values[5] > 0
     assert result["red"].values[5] < 255
 
-def test_ramp_expr_style(dummy_raw_calc_data, raw_calc_null_mask, simple_ramp_style_cfg) -> None:
+
+def test_ramp_expr_style(
+    dummy_raw_calc_data, raw_calc_null_mask, simple_ramp_style_cfg
+) -> None:
     del simple_ramp_style_cfg["index_function"]
     del simple_ramp_style_cfg["needed_bands"]
     simple_ramp_style_cfg["index_expression"] = "(ir-red)/(ir+red)"
     style = StandaloneStyle(simple_ramp_style_cfg)
-    result = apply_ows_style(style, dummy_raw_calc_data, valid_data_mask=raw_calc_null_mask)
+    result = apply_ows_style(
+        style, dummy_raw_calc_data, valid_data_mask=raw_calc_null_mask
+    )
     for channel in ("red", "green", "blue", "alpha"):
         assert channel in result.data_vars
     # point 0 800, 200 (idx=0.6)maps to blue
@@ -190,7 +191,7 @@ def test_ramp_expr_style(dummy_raw_calc_data, raw_calc_null_mask, simple_ramp_st
     # point 3 600,200 (idx=0.5) maps to yellow
     assert result["alpha"].values[3] == 255
     assert result["red"].values[3] == 255
-    assert result["green"].values[3] >= 254 # Why isn't it 255?
+    assert result["green"].values[3] >= 254  # Why isn't it 255?
     assert result["blue"].values[3] == 0
     # point 4 200,200 (idx=0.0) maps to black
     assert result["alpha"].values[4] == 255
@@ -200,7 +201,9 @@ def test_ramp_expr_style(dummy_raw_calc_data, raw_calc_null_mask, simple_ramp_st
     # point 5 1000,700 (idx=0.176) maps to between black and magenta
     assert result["alpha"].values[5] == 255
     assert result["green"].values[5] == 0
-    assert abs(result["red"].values[5] - result["blue"].values[5]) <= 1 # Why not exactly equal?
+    assert (
+        abs(result["red"].values[5] - result["blue"].values[5]) <= 1
+    )  # Why not exactly equal?
     assert result["red"].values[5] > 0
     assert result["red"].values[5] < 255
 
@@ -214,25 +217,16 @@ def test_ramp_legend_standalone(simple_ramp_style_cfg) -> None:
 
 
 def test_ramp_legend_ranges(simple_ramp_style_cfg) -> None:
-    simple_ramp_style_cfg["legend"] = {
-        "begin": "0.2",
-        "end": "0.8"
-    }
+    simple_ramp_style_cfg["legend"] = {"begin": "0.2", "end": "0.8"}
     style = StandaloneStyle(simple_ramp_style_cfg)
     assert style.legend_cfg.begin == Decimal("0.2")
     assert style.legend_cfg.end == Decimal("0.8")
-    simple_ramp_style_cfg["legend"] = {
-        "begin": "0.3",
-        "end": "0.7"
-    }
+    simple_ramp_style_cfg["legend"] = {"begin": "0.3", "end": "0.7"}
     style = StandaloneStyle(simple_ramp_style_cfg)
     assert style.legend_cfg.begin == Decimal("0.3")
     assert style.legend_cfg.end == Decimal("0.7")
 
-    simple_ramp_style_cfg["legend"] = {
-        "begin": "-0.3",
-        "end": "1.7"
-    }
+    simple_ramp_style_cfg["legend"] = {"begin": "-0.3", "end": "1.7"}
     style = StandaloneStyle(simple_ramp_style_cfg)
     assert style.legend_cfg.begin == Decimal("-0.3")
     assert style.legend_cfg.end == Decimal("1.7")
@@ -242,7 +236,7 @@ def test_ramp_legend_parse_errs(simple_ramp_style_cfg) -> None:
     simple_ramp_style_cfg["legend"] = {
         "begin": "0.15",
         "begin": "0.95",  # noqa: F601
-        "decimal_places": -1
+        "decimal_places": -1,
     }
     with pytest.raises(ConfigException) as e:
         _ = StandaloneStyle(simple_ramp_style_cfg)
@@ -254,7 +248,7 @@ def test_ramp_ticks_multimethod(simple_ramp_style_cfg) -> None:
         "begin": "0.0",
         "end": "1.0",
         "ticks_every": "0.2",
-        "tick_count": 5
+        "tick_count": 5,
     }
     with pytest.raises(ConfigException) as e:
         _ = StandaloneStyle(simple_ramp_style_cfg)
@@ -263,7 +257,7 @@ def test_ramp_ticks_multimethod(simple_ramp_style_cfg) -> None:
         "begin": "0.0",
         "end": "1.0",
         "ticks_every": "0.2",
-        "ticks": ["0.0", "0.2", "0.4", "0.6", "0.8", "1.0"]
+        "ticks": ["0.0", "0.2", "0.4", "0.6", "0.8", "1.0"],
     }
     with pytest.raises(ConfigException) as e:
         _ = StandaloneStyle(simple_ramp_style_cfg)
@@ -272,7 +266,7 @@ def test_ramp_ticks_multimethod(simple_ramp_style_cfg) -> None:
         "begin": "0.0",
         "end": "1.0",
         "ticks": ["0.0", "0.2", "0.4", "0.6", "0.8", "1.0"],
-        "tick_count": 5
+        "tick_count": 5,
     }
     with pytest.raises(ConfigException) as e:
         _ = StandaloneStyle(simple_ramp_style_cfg)
@@ -287,10 +281,7 @@ def test_ramp_ticks_every(simple_ramp_style_cfg) -> None:
         "ticks_every": "1.0",
     }
     style = StandaloneStyle(simple_ramp_style_cfg)
-    assert style.legend_cfg.ticks == [
-        Decimal("0.0"),
-        Decimal("1.0"),
-    ]
+    assert style.legend_cfg.ticks == [Decimal("0.0"), Decimal("1.0")]
     assert style.legend_cfg.default_abstract is None
     simple_ramp_style_cfg["legend"] = {
         "begin": "0.0",
@@ -298,22 +289,14 @@ def test_ramp_ticks_every(simple_ramp_style_cfg) -> None:
         "ticks_every": "0.5",
     }
     style = StandaloneStyle(simple_ramp_style_cfg)
-    assert style.legend_cfg.ticks == [
-        Decimal("0.0"),
-        Decimal("0.5"),
-        Decimal("1.0"),
-    ]
+    assert style.legend_cfg.ticks == [Decimal("0.0"), Decimal("0.5"), Decimal("1.0")]
     simple_ramp_style_cfg["legend"] = {
         "begin": "0.0",
         "end": "1.0",
         "ticks_every": "0.7",
     }
     style = StandaloneStyle(simple_ramp_style_cfg)
-    assert style.legend_cfg.ticks == [
-        Decimal("0.0"),
-        Decimal("0.7"),
-        Decimal("1.0"),
-    ]
+    assert style.legend_cfg.ticks == [Decimal("0.0"), Decimal("0.7"), Decimal("1.0")]
     simple_ramp_style_cfg["legend"] = {
         "begin": "0.0",
         "end": "1.0",
@@ -338,42 +321,18 @@ def test_ramp_ticks_every(simple_ramp_style_cfg) -> None:
     assert "ticks_every must be greater than zero" in str(e.value)
 
 
-
 def test_ramp_tick_count(simple_ramp_style_cfg) -> None:
     # default
-    simple_ramp_style_cfg["legend"] = {
-        "begin": "0.0",
-        "end": "1.0",
-    }
+    simple_ramp_style_cfg["legend"] = {"begin": "0.0", "end": "1.0"}
     style = StandaloneStyle(simple_ramp_style_cfg)
-    assert style.legend_cfg.ticks == [
-        Decimal("0.0"),
-        Decimal("1.0"),
-    ]
-    simple_ramp_style_cfg["legend"] = {
-        "begin": "0.0",
-        "end": "1.0",
-        "tick_count": 1
-    }
+    assert style.legend_cfg.ticks == [Decimal("0.0"), Decimal("1.0")]
+    simple_ramp_style_cfg["legend"] = {"begin": "0.0", "end": "1.0", "tick_count": 1}
     style = StandaloneStyle(simple_ramp_style_cfg)
-    assert style.legend_cfg.ticks == [
-        Decimal("0.0"),
-        Decimal("1.0"),
-    ]
-    simple_ramp_style_cfg["legend"] = {
-        "begin": "0.0",
-        "end": "1.0",
-        "tick_count": 0
-    }
+    assert style.legend_cfg.ticks == [Decimal("0.0"), Decimal("1.0")]
+    simple_ramp_style_cfg["legend"] = {"begin": "0.0", "end": "1.0", "tick_count": 0}
     style = StandaloneStyle(simple_ramp_style_cfg)
-    assert style.legend_cfg.ticks == [
-        Decimal("0.0"),
-    ]
-    simple_ramp_style_cfg["legend"] = {
-        "begin": "0.0",
-        "end": "1.0",
-        "tick_count": 5
-    }
+    assert style.legend_cfg.ticks == [Decimal("0.0")]
+    simple_ramp_style_cfg["legend"] = {"begin": "0.0", "end": "1.0", "tick_count": 5}
     style = StandaloneStyle(simple_ramp_style_cfg)
     assert style.legend_cfg.ticks == [
         Decimal("0.0"),
@@ -383,49 +342,34 @@ def test_ramp_tick_count(simple_ramp_style_cfg) -> None:
         Decimal("0.8"),
         Decimal("1.0"),
     ]
-    simple_ramp_style_cfg["legend"] = {
-        "begin": "0.0",
-        "end": "1.0",
-        "tick_count": -4
-    }
+    simple_ramp_style_cfg["legend"] = {"begin": "0.0", "end": "1.0", "tick_count": -4}
     with pytest.raises(ConfigException) as e:
         style = StandaloneStyle(simple_ramp_style_cfg)
     assert "tick_count cannot be negative" in str(e.value)
 
 
 def test_explicit_ticks(simple_ramp_style_cfg) -> None:
-    simple_ramp_style_cfg["legend"] = {
-        "begin": "0.0",
-        "end": "1.0",
-        "ticks": []
-    }
+    simple_ramp_style_cfg["legend"] = {"begin": "0.0", "end": "1.0", "ticks": []}
     style = StandaloneStyle(simple_ramp_style_cfg)
     assert style.legend_cfg.ticks == []
     simple_ramp_style_cfg["legend"] = {
         "begin": "0.0",
         "end": "1.0",
-        "ticks": ["0.0", "0.7", "1.0"]
+        "ticks": ["0.0", "0.7", "1.0"],
     }
     style = StandaloneStyle(simple_ramp_style_cfg)
-    assert style.legend_cfg.ticks == [
-        Decimal("0.0"),
-        Decimal("0.7"),
-        Decimal("1.0"),
-    ]
+    assert style.legend_cfg.ticks == [Decimal("0.0"), Decimal("0.7"), Decimal("1.0")]
     simple_ramp_style_cfg["legend"] = {
         "begin": "0.0",
         "end": "1.0",
-        "ticks": ["0.2", "0.9"]
+        "ticks": ["0.2", "0.9"],
     }
     style = StandaloneStyle(simple_ramp_style_cfg)
-    assert style.legend_cfg.ticks == [
-        Decimal("0.2"),
-        Decimal("0.9"),
-    ]
+    assert style.legend_cfg.ticks == [Decimal("0.2"), Decimal("0.9")]
     simple_ramp_style_cfg["legend"] = {
         "begin": "0.0",
         "end": "1.0",
-        "ticks": ["0.2", "1.9"]
+        "ticks": ["0.2", "1.9"],
     }
     with pytest.raises(ConfigException) as e:
         style = StandaloneStyle(simple_ramp_style_cfg)
@@ -443,29 +387,27 @@ def rgb_style_with_masking_cfg() -> CFG_DICT:
         "components": {
             "red": {"red": 1.0},
             "green": {"green": 1.0},
-            "blue": {"blue": 1.0}
+            "blue": {"blue": 1.0},
         },
         "pq_masks": [
+            {"band": "pq", "flags": {"splodgy": "Splodgeless"}},
             {
                 "band": "pq",
-                "flags": {
-                    'splodgy': "Splodgeless",
-                },
+                "flags": {"ugly": True, "impossible": "Woah!"},
+                "invert": True,
             },
-            {
-                "band": "pq",
-                "flags": {
-                    "ugly": True,
-                    "impossible": "Woah!"
-                },
-                "invert": True
-            },
-        ]
+        ],
     }
 
 
-def test_component_style_with_masking(dummy_raw_calc_data, raw_calc_null_mask, rgb_style_with_masking_cfg) -> None:
-    result = apply_ows_style_cfg(rgb_style_with_masking_cfg, dummy_raw_calc_data, valid_data_mask=raw_calc_null_mask)
+def test_component_style_with_masking(
+    dummy_raw_calc_data, raw_calc_null_mask, rgb_style_with_masking_cfg
+) -> None:
+    result = apply_ows_style_cfg(
+        rgb_style_with_masking_cfg,
+        dummy_raw_calc_data,
+        valid_data_mask=raw_calc_null_mask,
+    )
     for channel in ("red", "green", "blue", "alpha"):
         assert channel in result.data_vars
     alphas = result["alpha"].values
@@ -488,33 +430,20 @@ def simple_colormap_style_cfg() -> CFG_DICT:
                 {
                     "title": "Impossibly Tasty",
                     "abstract": "Tasty AND Impossible",
-                    "flags": {
-                        "and": {
-                            "flavour": "Tasty",
-                            "impossible": "Woah!"
-                        },
-                    },
-                    "color": "#FF0000"
+                    "flags": {"and": {"flavour": "Tasty", "impossible": "Woah!"}},
+                    "color": "#FF0000",
                 },
                 {
                     "title": "Possibly Tasty",
                     "abstract": "Tasty and Possible",
-                    "flags": {
-                        "flavour": "Tasty",
-                        "impossible": False
-                    },
-                    "color": "#00FF00"
+                    "flags": {"flavour": "Tasty", "impossible": False},
+                    "color": "#00FF00",
                 },
                 {
                     "title": "Ugly/Splodgy",
                     "abstract": "Ugly or splodgy",
-                    "flags": {
-                        "or": {
-                            "ugly": True,
-                            "splodgy": "Splodgy"
-                        }
-                    },
-                    "color": "#0000FF"
+                    "flags": {"or": {"ugly": True, "splodgy": "Splodgy"}},
+                    "color": "#0000FF",
                 },
             ]
         },
@@ -528,39 +457,23 @@ def simple_colormap_style_cfg() -> CFG_DICT:
                         {
                             "title": "Bland to Tasty",
                             "abstract": "All yummification.",
-                            "flags": [
-                                {
-                                    "flavour": "Bland"
-                                },
-                                {
-                                    "flavour": "Tasty"
-                                },
-                            ],
-                            "color": "#8080FF"
+                            "flags": [{"flavour": "Bland"}, {"flavour": "Tasty"}],
+                            "color": "#8080FF",
                         },
                         {
                             "title": "Was ugly, is splodgy",
                             "abstract": "unless they have also been yummified",
-                            "flags": [
-                                {
-                                    "ugly": True,
-                                },
-                                {
-                                    "splodgy": "Splodgy"
-                                }
-                            ],
-                            "color": "#FF00FF"
+                            "flags": [{"ugly": True}, {"splodgy": "Splodgy"}],
+                            "color": "#FF00FF",
                         },
                         {
                             "title": "Woah!",
                             "abstract": "Ended up impossible (may have just always been impossible) - doesn't include impossible yummifications",
                             "flags": [
-                                {}, # Empty date rule = matches all remaining pixels for that date
-                                {
-                                    "impossible": "Woah!"
-                                }
+                                {},  # Empty date rule = matches all remaining pixels for that date
+                                {"impossible": "Woah!"},
                             ],
-                            "color": "#FF0080"
+                            "color": "#FF0080",
                         },
                         {
                             "title": "Flawless to Perfect",
@@ -573,7 +486,7 @@ def simple_colormap_style_cfg() -> CFG_DICT:
                                         "flavour": "Tasty",
                                         "splodgy": "Splodgeless",
                                         "ugly": False,
-                                    },
+                                    }
                                 },
                                 {
                                     "or": {
@@ -583,25 +496,31 @@ def simple_colormap_style_cfg() -> CFG_DICT:
                                         "splodgy": "Splodgy",
                                         "ugly": True,
                                     }
-                                }
+                                },
                             ],
-                            "color": "#FFFFFF"
+                            "color": "#FFFFFF",
                         },
                         {
                             "title": "Everything else",
                             "abstract": "The rest of what's left",
                             "flags": [{}, {}],
-                            "color": "#808080"
-                        }
+                            "color": "#808080",
+                        },
                     ]
-                }
+                },
             }
-        ]
+        ],
     }
 
 
-def test_colormap_style(dummy_col_map_data, raw_calc_null_mask, simple_colormap_style_cfg) -> None:
-    result = apply_ows_style_cfg(simple_colormap_style_cfg, dummy_col_map_data, valid_data_mask=raw_calc_null_mask)
+def test_colormap_style(
+    dummy_col_map_data, raw_calc_null_mask, simple_colormap_style_cfg
+) -> None:
+    result = apply_ows_style_cfg(
+        simple_colormap_style_cfg,
+        dummy_col_map_data,
+        valid_data_mask=raw_calc_null_mask,
+    )
     for channel in ("red", "green", "blue", "alpha"):
         assert channel in result.data_vars
     # point 0 tasy and possible: green
@@ -632,11 +551,15 @@ def test_colormap_style(dummy_col_map_data, raw_calc_null_mask, simple_colormap_
     # point 5 fall through -transparent
     assert result["alpha"].values[5] == 0
 
-def test_colormap_multidate(dummy_col_map_time_data, timed_raw_calc_null_mask, simple_colormap_style_cfg) -> None:
+
+def test_colormap_multidate(
+    dummy_col_map_time_data, timed_raw_calc_null_mask, simple_colormap_style_cfg
+) -> None:
     result = apply_ows_style_cfg(
-                        simple_colormap_style_cfg,
-                        dummy_col_map_time_data,
-                        valid_data_mask=timed_raw_calc_null_mask)
+        simple_colormap_style_cfg,
+        dummy_col_map_time_data,
+        valid_data_mask=timed_raw_calc_null_mask,
+    )
     # Point 0: fallback
     assert result["alpha"].values[0] == 255
     assert result["red"].values[0] == 128
@@ -668,6 +591,7 @@ def test_colormap_multidate(dummy_col_map_time_data, timed_raw_calc_null_mask, s
     assert result["green"].values[5] == 128
     assert result["blue"].values[5] == 255
 
+
 @pytest.fixture
 def enum_colormap_style_cfg() -> CFG_DICT:
     return {
@@ -676,21 +600,9 @@ def enum_colormap_style_cfg() -> CFG_DICT:
         "abstract": "This is a Test Style for Datacube WMS",
         "value_map": {
             "pq": [
-                {
-                    "title": "Blah",
-                    "values": [8, 25],
-                    "color": "#FF0000"
-                },
-                {
-                    "title": "Rock and Roll",
-                    "values": [4, 19, 25],
-                    "color": "#00FF00"
-                },
-                {
-                    "title": "",
-                    "values": [17],
-                    "color": "#0000FF"
-                },
+                {"title": "Blah", "values": [8, 25], "color": "#FF0000"},
+                {"title": "Rock and Roll", "values": [4, 19, 25], "color": "#00FF00"},
+                {"title": "", "values": [17], "color": "#0000FF"},
             ]
         },
         "multi_date": [
@@ -703,29 +615,33 @@ def enum_colormap_style_cfg() -> CFG_DICT:
                         {
                             "title": "Rock and Roll",
                             "values": [[], [14, 19, 27]],
-                            "color": "#00FF00"
+                            "color": "#00FF00",
                         },
                         {
                             "title": "Blah Blah",
                             "values": [[8, 25], [17, 30, 31]],
-                            "color": "#FF0000"
+                            "color": "#FF0000",
                         },
                         {
                             "title": "Foo Blah",
                             "invert": [True, False],
                             "values": [[10], []],
                             "color": "#0000FF",
-                            "alpha": 0.0
+                            "alpha": 0.0,
                         },
                     ]
-                }
+                },
             }
-        ]
+        ],
     }
 
 
-def test_enum_colormap_style(dummy_col_map_data, raw_calc_null_mask, enum_colormap_style_cfg) -> None:
-    result = apply_ows_style_cfg(enum_colormap_style_cfg, dummy_col_map_data, valid_data_mask=raw_calc_null_mask)
+def test_enum_colormap_style(
+    dummy_col_map_data, raw_calc_null_mask, enum_colormap_style_cfg
+) -> None:
+    result = apply_ows_style_cfg(
+        enum_colormap_style_cfg, dummy_col_map_data, valid_data_mask=raw_calc_null_mask
+    )
     for channel in ("red", "green", "blue", "alpha"):
         assert channel in result.data_vars
     # point 0 (8) Blah - red
@@ -756,10 +672,15 @@ def test_enum_colormap_style(dummy_col_map_data, raw_calc_null_mask, enum_colorm
     assert result["green"].values[5] == 0
     assert result["blue"].values[5] == 255
 
-def test_enum_colormap_multidate(dummy_col_map_time_data, timed_raw_calc_null_mask, enum_colormap_style_cfg) -> None:
-    result = apply_ows_style_cfg(enum_colormap_style_cfg,
-                                 dummy_col_map_time_data,
-                                 valid_data_mask=timed_raw_calc_null_mask)
+
+def test_enum_colormap_multidate(
+    dummy_col_map_time_data, timed_raw_calc_null_mask, enum_colormap_style_cfg
+) -> None:
+    result = apply_ows_style_cfg(
+        enum_colormap_style_cfg,
+        dummy_col_map_time_data,
+        valid_data_mask=timed_raw_calc_null_mask,
+    )
     for channel in ("red", "green", "blue", "alpha"):
         assert channel in result.data_vars
     # point 0 (8->30) Blah Blah - red
@@ -796,21 +717,13 @@ def enum_animated_value_map() -> CFG_DICT:
         "abstract": "This is a Test Style for Datacube WMS",
         "value_map": {
             "pq": [
-                {
-                    "title": "Blah",
-                    "values": [8, 25],
-                    "color": "#FF0000"
-                },
+                {"title": "Blah", "values": [8, 25], "color": "#FF0000"},
                 {
                     "title": "Rock and Roll",
                     "values": [4, 19, 25, 30],
-                    "color": "#00FF00"
+                    "color": "#00FF00",
                 },
-                {
-                    "title": "",
-                    "values": [17],
-                    "color": "#0000FF"
-                },
+                {"title": "", "values": [17], "color": "#0000FF"},
             ]
         },
         "multi_date": [
@@ -819,13 +732,18 @@ def enum_animated_value_map() -> CFG_DICT:
                 "preserve_user_date_order": True,
                 "allowed_count_range": [2, 2],
             }
-        ]
+        ],
     }
 
-def test_animated_colour_map(enum_animated_value_map, dummy_col_map_time_data, timed_raw_calc_null_mask) -> None:
-    result = apply_ows_style_cfg(enum_animated_value_map,
-                                 dummy_col_map_time_data,
-                                 valid_data_mask=timed_raw_calc_null_mask)
+
+def test_animated_colour_map(
+    enum_animated_value_map, dummy_col_map_time_data, timed_raw_calc_null_mask
+) -> None:
+    result = apply_ows_style_cfg(
+        enum_animated_value_map,
+        dummy_col_map_time_data,
+        valid_data_mask=timed_raw_calc_null_mask,
+    )
     for channel in ("red", "green", "blue", "alpha"):
         assert channel in result.data_vars
     # point 0 (8) Blah - red, green
@@ -858,21 +776,9 @@ def enum_colormap_aggregate_multidate() -> CFG_DICT:
         "abstract": "This is a Test Style for Datacube WMS",
         "value_map": {
             "pq": [
-                {
-                    "title": "Blah",
-                    "values": [8, 25],
-                    "color": "#FF0000"
-                },
-                {
-                    "title": "Rock and Roll",
-                    "values": [4, 19, 25],
-                    "color": "#00FF00"
-                },
-                {
-                    "title": "",
-                    "values": [17],
-                    "color": "#0000FF"
-                },
+                {"title": "Blah", "values": [8, 25], "color": "#FF0000"},
+                {"title": "Rock and Roll", "values": [4, 19, 25], "color": "#00FF00"},
+                {"title": "", "values": [17], "color": "#0000FF"},
             ]
         },
         "multi_date": [
@@ -883,27 +789,28 @@ def enum_colormap_aggregate_multidate() -> CFG_DICT:
                 "aggregator_function": test_agg,
                 "value_map": {
                     "pq": [
-                        {
-                            "title": "GGG",
-                            "values": [0],
-                            "color": "#0000FF"
-                        },
+                        {"title": "GGG", "values": [0], "color": "#0000FF"},
                         {
                             "title": "SSS",
                             "values": [1],
                             "color": "#0000FF",
-                            "mask": True
+                            "mask": True,
                         },
                     ]
                 },
             }
-        ]
+        ],
     }
 
-def test_aggregator_map(enum_colormap_aggregate_multidate, dummy_col_map_time_data, timed_raw_calc_null_mask) -> None:
-    result = apply_ows_style_cfg(enum_colormap_aggregate_multidate,
-                                 dummy_col_map_time_data,
-                                 valid_data_mask=timed_raw_calc_null_mask)
+
+def test_aggregator_map(
+    enum_colormap_aggregate_multidate, dummy_col_map_time_data, timed_raw_calc_null_mask
+) -> None:
+    result = apply_ows_style_cfg(
+        enum_colormap_aggregate_multidate,
+        dummy_col_map_time_data,
+        valid_data_mask=timed_raw_calc_null_mask,
+    )
     for channel in ("red", "green", "blue", "alpha"):
         assert channel in result.data_vars
     # point 0 (8->30) no
@@ -923,7 +830,9 @@ def test_aggregator_map(enum_colormap_aggregate_multidate, dummy_col_map_time_da
     assert result["blue"].values[4] == 255
 
 
-def test_invalid_multidate_rules(enum_colormap_style_cfg, simple_colormap_style_cfg) -> None:
+def test_invalid_multidate_rules(
+    enum_colormap_style_cfg, simple_colormap_style_cfg
+) -> None:
     simple_colormap_style_cfg["multi_date"][0]["allowed_count_range"] = [2, 4]
     with pytest.raises(ConfigException) as e:
         _ = StandaloneStyle(simple_colormap_style_cfg)
@@ -934,34 +843,27 @@ def test_invalid_multidate_rules(enum_colormap_style_cfg, simple_colormap_style_
         _ = StandaloneStyle(simple_colormap_style_cfg)
     assert "value maps not supported for animation handlers" in str(e.value)
     simple_colormap_style_cfg["multi_date"][0]["animate"] = False
-    simple_colormap_style_cfg["multi_date"][0]["value_map"]["pq"][3]["invert"] = [True, False, True]
+    simple_colormap_style_cfg["multi_date"][0]["value_map"]["pq"][3]["invert"] = [
+        True,
+        False,
+        True,
+    ]
     with pytest.raises(ConfigException) as e:
         _ = StandaloneStyle(simple_colormap_style_cfg)
     assert "Invert entry has wrong number of rule sets for date count" in str(e.value)
     del simple_colormap_style_cfg["multi_date"][0]["value_map"]["pq"][3]["invert"]
-    orig_flags = simple_colormap_style_cfg["multi_date"][0]["value_map"]["pq"][0]["flags"]
-    simple_colormap_style_cfg["multi_date"][0]["value_map"]["pq"][0]["flags"] = [
-        {
-            "flavour": "Bland"
-        },
-        {
-            "flavour": "Bland"
-        },
-        {
-            "flavour": "Tasty"
-        },
-    ],
+    orig_flags = simple_colormap_style_cfg["multi_date"][0]["value_map"]["pq"][0][
+        "flags"
+    ]
+    simple_colormap_style_cfg["multi_date"][0]["value_map"]["pq"][0]["flags"] = (
+        [{"flavour": "Bland"}, {"flavour": "Bland"}, {"flavour": "Tasty"}],
+    )
     with pytest.raises(ConfigException) as e:
         _ = StandaloneStyle(simple_colormap_style_cfg)
     assert "Flags entry has wrong number of rule sets for date count" in str(e.value)
     enum_colormap_style_cfg["multi_date"][0]["value_map"]["pq"][0]["flags"] = [
-        {
-            "or": {"flavour": "Bland"},
-            "and": {"flavour": "Tasty"},
-        },
-        {
-            "flavour": "Tasty"
-        },
+        {"or": {"flavour": "Bland"}, "and": {"flavour": "Tasty"}},
+        {"flavour": "Tasty"},
     ]
     with pytest.raises(ConfigException) as e:
         _ = StandaloneStyle(enum_colormap_style_cfg)
@@ -983,15 +885,23 @@ def test_map_legend(simple_colormap_style_cfg) -> None:
     assert img.size == (400, 125)
 
 
-def test_api_none_mask(dummy_col_map_data, raw_calc_null_mask, simple_colormap_style_cfg) -> None:
-    null_mask = apply_ows_style_cfg(simple_colormap_style_cfg, dummy_col_map_data, valid_data_mask=raw_calc_null_mask)
+def test_api_none_mask(
+    dummy_col_map_data, raw_calc_null_mask, simple_colormap_style_cfg
+) -> None:
+    null_mask = apply_ows_style_cfg(
+        simple_colormap_style_cfg,
+        dummy_col_map_data,
+        valid_data_mask=raw_calc_null_mask,
+    )
     none_mask = apply_ows_style_cfg(simple_colormap_style_cfg, dummy_col_map_data)
     for i in range(6):
         for c in ("red", "green", "blue", "alpha"):
             assert null_mask[c].values[i] == none_mask[c].values[i]
 
 
-def test_landsat_like_configs(dummy_raw_ls_data, configs_for_landsat, null_mask) -> None:
+def test_landsat_like_configs(
+    dummy_raw_ls_data, configs_for_landsat, null_mask
+) -> None:
     for cfg in configs_for_landsat:
         style = StandaloneStyle(cfg)
         mask = style.to_mask(dummy_raw_ls_data, null_mask)
@@ -1007,7 +917,9 @@ def test_wofs_like_configs(dummy_raw_wo_data, configs_for_wofs, null_mask) -> No
         assert result
 
 
-def test_fc_wofs_like_configs(dummy_raw_fc_plus_wo, configs_for_combined_fc_wofs, null_mask) -> None:
+def test_fc_wofs_like_configs(
+    dummy_raw_fc_plus_wo, configs_for_combined_fc_wofs, null_mask
+) -> None:
     for cfg in configs_for_combined_fc_wofs:
         style = StandaloneStyle(cfg)
         mask = style.to_mask(dummy_raw_fc_plus_wo, null_mask)

--- a/tests/test_styles.py
+++ b/tests/test_styles.py
@@ -60,18 +60,18 @@ def product_layer():
     product_layer.object_label = "layer.test_product"
     product_layer.pq_band = "test_band"
     product_layer.product_names = ["test_odc_product"]
-    product_layer.products = [FakeODCProduct('test_odc_product')]
+    product_layer.products = [FakeODCProduct("test_odc_product")]
     product_layer.low_res_product_names = ["test_odc_summary_product"]
-    product_layer.low_res_products = [FakeODCProduct('test_odc_summary_product')]
+    product_layer.low_res_products = [FakeODCProduct("test_odc_summary_product")]
     product_layer.always_fetch_bands = ["red", "green", "blue"]
     product_layer.band_idx = BandIndex.__new__(BandIndex)
     product_layer.band_idx._unready_attributes = []
     product_layer.band_idx.layer = product_layer
     product_layer.band_idx.band_cfg = {
-        "red": ["crimson", "foo", ],
+        "red": ["crimson", "foo"],
         "green": [],
         "blue": ["azure", "bar"],
-        "fake": []
+        "fake": [],
     }
     product_layer.band_idx._idx = {
         "red": "red",
@@ -83,9 +83,7 @@ def product_layer():
         "azure": "red",
         "fake": "fake",
     }
-    product_layer.global_cfg.layer_index = {
-        "test_product": product_layer
-    }
+    product_layer.global_cfg.layer_index = {"test_product": product_layer}
     product_layer.data_manual_merge = False
     product_layer.fuse_func = None
     product_layer.flag_bands = {
@@ -114,17 +112,15 @@ def style_cfg_lin() -> CFG_DICT:
         "components": {
             "red": {"red": 1.0},
             "green": {"green": 1.0},
-            "blue": {"blue": 1.0}
-        }
+            "blue": {"blue": 1.0},
+        },
     }
 
 
 @pytest.fixture
 def style_cfg_lin_clone() -> CFG_DICT:
     return {
-        "inherits": {
-            "style": "test_style",
-        },
+        "inherits": {"style": "test_style"},
         "name": "test_style_2",
         "title": "Test Style 2",
         "scale_factor": None,
@@ -144,12 +140,9 @@ def style_cfg_nonlin() -> CFG_DICT:
             "red": {"red": 1.0},
             "green": {
                 "function": "datacube_ows.band_utils.norm_diff",
-                "kwargs": {
-                    "band1": "red",
-                    "band2": "green",
-                }
+                "kwargs": {"band1": "red", "band2": "green"},
             },
-            "blue": {"blue": 1.0}
+            "blue": {"blue": 1.0},
         },
         "additional_bands": [],
     }
@@ -167,25 +160,17 @@ def style_cfg_map() -> CFG_DICT:
                 {
                     "title": "Invalid",
                     "abstract": "An Invalid Value",
-                    "flags": {
-                        "bar": True,
-                        "baz": False
-                    },
-                    "color": "#000000"
+                    "flags": {"bar": True, "baz": False},
+                    "color": "#000000",
                 },
                 {
                     "title": "Valid",
                     "abstract": "A Valid Value",
-                    "flags": {
-                        "or": {
-                            "x": True,
-                            "y": True
-                        }
-                    },
-                    "color": "#FFFFFF"
-                }
+                    "flags": {"or": {"x": True, "y": True}},
+                    "color": "#FFFFFF",
+                },
             ]
-        }
+        },
     }
 
 
@@ -198,12 +183,8 @@ def product_layer_alpha_map():
     product_layer.product_names = ["test_odc_product"]
     product_layer.always_fetch_bands = ["foo"]
     product_layer.band_idx = BandIndex.__new__(BandIndex)
-    product_layer.band_idx.band_cfg = {
-        "foo": ["foo"]
-    }
-    product_layer.band_idx._idx = {
-        "foo": "foo"
-    }
+    product_layer.band_idx.band_cfg = {"foo": ["foo"]}
+    product_layer.band_idx._idx = {"foo": "foo"}
     return product_layer
 
 
@@ -219,14 +200,12 @@ def style_cfg_map_alpha_1() -> CFG_DICT:
                 {
                     "title": "Transparent",
                     "abstract": "A Transparent Value",
-                    "flags": {
-                        "bar": True,
-                    },
+                    "flags": {"bar": True},
                     "color": "#000000",
-                    "alpha": 0.0
+                    "alpha": 0.0,
                 }
             ]
-        }
+        },
     }
 
 
@@ -242,14 +221,12 @@ def style_cfg_map_alpha_2() -> CFG_DICT:
                 {
                     "title": "Semi-Transparent",
                     "abstract": "A Semi-Transparent Value",
-                    "flags": {
-                        "bar": False,
-                    },
+                    "flags": {"bar": False},
                     "color": "#000000",
-                    "alpha": 0.5
+                    "alpha": 0.5,
                 }
             ]
-        }
+        },
     }
 
 
@@ -265,13 +242,11 @@ def style_cfg_map_alpha_3() -> CFG_DICT:
                 {
                     "title": "Non-Transparent",
                     "abstract": "A Non-Transparent Value",
-                    "flags": {
-                        "bar": False,
-                    },
+                    "flags": {"bar": False},
                     "color": "#000000",
                 }
             ]
-        }
+        },
     }
 
 
@@ -280,51 +255,52 @@ def test_valuemap_ctor() -> None:
     style.name = "style_name"
     style.product.name = "layer_name"
 
-    vm = datacube_ows.styles.colormap.ValueMapRule(style, "band3", {
-        "title": "",
-        "abstract": "Abstract abstractions",
-        "values": [1, 2],
-        "color": "#FFFFFF"
-    })
-    assert vm.label == "Abstract abstractions"
-    with pytest.raises(ConfigException) as e:
-        vm = datacube_ows.styles.colormap.ValueMapRule(style, "band3", {
+    vm = datacube_ows.styles.colormap.ValueMapRule(
+        style,
+        "band3",
+        {
             "title": "",
             "abstract": "Abstract abstractions",
-            "flags": {
-                "and": {
-                    "flag": "val",
-                },
-                "or": {
-                    "other_flag": "other_val"
-                }
+            "values": [1, 2],
+            "color": "#FFFFFF",
+        },
+    )
+    assert vm.label == "Abstract abstractions"
+    with pytest.raises(ConfigException) as e:
+        vm = datacube_ows.styles.colormap.ValueMapRule(
+            style,
+            "band3",
+            {
+                "title": "",
+                "abstract": "Abstract abstractions",
+                "flags": {"and": {"flag": "val"}, "or": {"other_flag": "other_val"}},
+                "color": "#FFFFFF",
             },
-            "color": "#FFFFFF"
-        })
+        )
     assert "combines 'and' and 'or' rules" in str(e.value)
     assert "style_name" in str(e.value)
     assert "layer_name" in str(e.value)
     with pytest.raises(ConfigException) as e:
-        vm = datacube_ows.styles.colormap.ValueMapRule(style, "band3", {
-            "title": "",
-            "abstract": "Abstract abstractions",
-            "flags": {
-                "and": {
-                    "flag": "val",
-                },
+        vm = datacube_ows.styles.colormap.ValueMapRule(
+            style,
+            "band3",
+            {
+                "title": "",
+                "abstract": "Abstract abstractions",
+                "flags": {"and": {"flag": "val"}},
+                "values": [1, 2, 3],
+                "color": "#FFFFFF",
             },
-            "values": [1, 2, 3],
-            "color": "#FFFFFF"
-        })
+        )
     assert "has both a 'flags' and a 'values' section - choose one" in str(e.value)
     assert "style_name" in str(e.value)
     assert "layer_name" in str(e.value)
     with pytest.raises(ConfigException) as e:
-        vm = datacube_ows.styles.colormap.ValueMapRule(style, "band3", {
-            "title": "",
-            "abstract": "Abstract abstractions",
-            "color": "#FFFFFF"
-        })
+        vm = datacube_ows.styles.colormap.ValueMapRule(
+            style,
+            "band3",
+            {"title": "", "abstract": "Abstract abstractions", "color": "#FFFFFF"},
+        )
     assert "must have a non-empty 'flags' or 'values' section" in str(e.value)
     assert "style_name" in str(e.value)
     assert "layer_name" in str(e.value)
@@ -340,14 +316,12 @@ def style_cfg_ramp() -> CFG_DICT:
         "index_function": {
             "function": "datacube_ows.band_utils.single_band",
             "mapped_bands": False,
-            "kwargs": {
-                "band": "foo"
-            }
+            "kwargs": {"band": "foo"},
         },
         "color_ramp": [
             {"value": 0.0, "color": "#FFFFFF", "alpha": 0.0},
-            {"value": 1.0, "color": "#000000", "alpha": 1.0}
-        ]
+            {"value": 1.0, "color": "#000000", "alpha": 1.0},
+        ],
     }
 
 
@@ -371,15 +345,13 @@ def style_cfg_ramp_mapped() -> CFG_DICT:
         "index_function": {
             "function": "datacube_ows.band_utils.single_band",
             "mapped_bands": True,
-            "kwargs": {
-                "band": "bar"
-            }
+            "kwargs": {"band": "bar"},
         },
         "band_map": {"bar": "foo"},
         "color_ramp": [
             {"value": 0.0, "color": "#FFFFFF", "alpha": 0.0},
-            {"value": 1.0, "color": "#000000", "alpha": 1.0}
-        ]
+            {"value": 1.0, "color": "#000000", "alpha": 1.0},
+        ],
     }
 
 
@@ -389,9 +361,7 @@ def test_correct_style_hybrid(product_layer, style_cfg_lin) -> None:
     style_cfg_lin["index_function"] = {
         "function": "datacube_ows.band_utils.constant",
         "mapped_bands": True,
-        "kwargs": {
-            "const": "0.1"
-        }
+        "kwargs": {"const": "0.1"},
     }
     style_def = datacube_ows.styles.StyleDef(product_layer, style_cfg_lin)
 
@@ -404,9 +374,7 @@ def test_correct_style_nonlin_hybrid(product_layer, style_cfg_nonlin) -> None:
     style_cfg_nonlin["index_function"] = {
         "function": "datacube_ows.band_utils.constant",
         "mapped_bands": True,
-        "kwargs": {
-            "const": "0.1"
-        }
+        "kwargs": {"const": "0.1"},
     }
     style_def = datacube_ows.styles.StyleDef(product_layer, style_cfg_nonlin)
     assert isinstance(style_def, datacube_ows.styles.hybrid.HybridStyleDef)
@@ -418,16 +386,18 @@ def test_invalid_component_ratio(product_layer, style_cfg_nonlin) -> None:
     style_cfg_nonlin["index_function"] = {
         "function": "datacube_ows.band_utils.constant",
         "mapped_bands": True,
-        "kwargs": {
-            "const": "0.1"
-        }
+        "kwargs": {"const": "0.1"},
     }
     with pytest.raises(ConfigException) as e:
         _ = datacube_ows.styles.StyleDef(product_layer, style_cfg_nonlin)
-    assert "Component ratio must be a floating point number between 0 and 1" in str(e.value)
+    assert "Component ratio must be a floating point number between 0 and 1" in str(
+        e.value
+    )
 
 
-def test_correct_style_linear(product_layer, style_cfg_lin, style_cfg_lin_clone) -> None:
+def test_correct_style_linear(
+    product_layer, style_cfg_lin, style_cfg_lin_clone
+) -> None:
     style_def = datacube_ows.styles.StyleDef(product_layer, style_cfg_lin)
     product_layer.style_index[style_def.name] = style_def
     assert isinstance(style_def, datacube_ows.styles.component.ComponentStyleDef)
@@ -435,12 +405,15 @@ def test_correct_style_linear(product_layer, style_cfg_lin, style_cfg_lin_clone)
 
 def test_unresolvable_style(product_layer) -> None:
     with pytest.raises(ConfigException) as e:
-        _ = datacube_ows.styles.StyleDef(product_layer, {
-            "foo": "This is not real",
-            "name": "gotaname",
-            "abstract": "gotabstract",
-            "splunge": "doodly-doo"
-        })
+        _ = datacube_ows.styles.StyleDef(
+            product_layer,
+            {
+                "foo": "This is not real",
+                "name": "gotaname",
+                "abstract": "gotabstract",
+                "splunge": "doodly-doo",
+            },
+        )
     assert "could not determine style type" in str(e.value)
 
 
@@ -462,21 +435,19 @@ def test_inherit_exceptions(product_layer, style_cfg_lin, style_cfg_lin_clone) -
     except OWSEntryNotFound:
         pass
     try:
-        style = datacube_ows.styles.StyleDef.lookup_impl(product_layer.global_cfg,
-                                                         keyvals={
-                                                             "style": "test_style",
-                                                             "layer": "fake-layer"
-                                                         })
+        style = datacube_ows.styles.StyleDef.lookup_impl(
+            product_layer.global_cfg,
+            keyvals={"style": "test_style", "layer": "fake-layer"},
+        )
         assert style == "Expected exception not thrown"
     except OWSEntryNotFound:
         pass
     try:
-        style = datacube_ows.styles.StyleDef.lookup_impl(product_layer.global_cfg,
-                                                 keyvals={
-                                                     "style": "fake_style",
-                                                     "layer": "test_product"
-                                                 },
-                                                subs={"layer": {"test_product": product_layer}})
+        style = datacube_ows.styles.StyleDef.lookup_impl(
+            product_layer.global_cfg,
+            keyvals={"style": "fake_style", "layer": "test_product"},
+            subs={"layer": {"test_product": product_layer}},
+        )
         assert style == "Expected exception not thrown"
     except OWSEntryNotFound:
         pass
@@ -484,7 +455,7 @@ def test_inherit_exceptions(product_layer, style_cfg_lin, style_cfg_lin_clone) -
 
 def test_style_exceptions(product_layer, style_cfg_map: dict) -> None:
     style_no_name = dict(style_cfg_map)
-    style_no_name.pop('name', None)
+    style_no_name.pop("name", None)
     with pytest.raises(KeyError):
         _ = datacube_ows.styles.StyleDef(product_layer, style_no_name)
 
@@ -499,41 +470,46 @@ def test_alpha_style_map(
     product_layer_alpha_map,
     style_cfg_map_alpha_1,
     style_cfg_map_alpha_2,
-    style_cfg_map_alpha_3) -> None:
-
+    style_cfg_map_alpha_3,
+) -> None:
     def fake_make_mask(data: DataArray, **kwargs) -> DataArray:
         return data
-
 
     band = np.array([True, True, True])
     timarray = [np.datetime64(datetime.date.today(), "ns")]
     times = DataArray(timarray, coords=[timarray], dims=["time"], name="time")
-    da = DataArray(band, name='foo',
-                         attrs = {
-                            "flags_definition": {
-                                "foo": {"bits": 0},
-                                "floop": {"bits": 1},
-                         }
-    })
-    dst = Dataset(data_vars={'foo': da})
+    da = DataArray(
+        band,
+        name="foo",
+        attrs={"flags_definition": {"foo": {"bits": 0}, "floop": {"bits": 1}}},
+    )
+    dst = Dataset(data_vars={"foo": da})
     ds = concat([dst], times)
     npmap = np.array([True, True, True])
     damap = DataArray(npmap)
 
-    with patch('datacube_ows.config_utils.make_mask', new_callable=lambda: fake_make_mask):
-        style_def = datacube_ows.styles.StyleDef(product_layer_alpha_map, style_cfg_map_alpha_1)
+    with patch(
+        "datacube_ows.config_utils.make_mask", new_callable=lambda: fake_make_mask
+    ):
+        style_def = datacube_ows.styles.StyleDef(
+            product_layer_alpha_map, style_cfg_map_alpha_1
+        )
 
         result = style_def.transform_data(ds, damap)
         alpha_channel = result["alpha"].values
         assert (alpha_channel == 0).all()
 
-        style_def = datacube_ows.styles.StyleDef(product_layer_alpha_map, style_cfg_map_alpha_2)
+        style_def = datacube_ows.styles.StyleDef(
+            product_layer_alpha_map, style_cfg_map_alpha_2
+        )
 
         result = style_def.transform_data(ds, None)
         alpha_channel = result["alpha"].values
         assert (alpha_channel == 128).all()
 
-        style_def = datacube_ows.styles.StyleDef(product_layer_alpha_map, style_cfg_map_alpha_3)
+        style_def = datacube_ows.styles.StyleDef(
+            product_layer_alpha_map, style_cfg_map_alpha_3
+        )
 
         result = style_def.transform_data(ds, damap)
         alpha_channel = result["alpha"].values
@@ -579,7 +555,9 @@ def test_dynamic_range_compression_scale_range(product_layer, style_cfg_lin) -> 
     assert compressed[2] == 255
 
 
-def test_dynamic_range_compression_scale_range_clip(product_layer, style_cfg_lin) -> None:
+def test_dynamic_range_compression_scale_range_clip(
+    product_layer, style_cfg_lin
+) -> None:
     style_cfg_lin["scale_range"] = [-3000, 3000]
 
     style_def = datacube_ows.styles.StyleDef(product_layer, style_cfg_lin)
@@ -622,12 +600,8 @@ def product_layer_mask_map():
     product_layer.product_names = ["test_odc_product"]
     product_layer.always_fetch_bands = ["foo"]
     product_layer.band_idx = BandIndex.__new__(BandIndex)
-    product_layer.band_idx.band_cfg = {
-        "foo": ["foo"]
-    }
-    product_layer.band_idx._idx = {
-        "foo": "foo"
-    }
+    product_layer.band_idx.band_cfg = {"foo": ["foo"]}
+    product_layer.band_idx._idx = {"foo": "foo"}
     return product_layer
 
 
@@ -643,30 +617,24 @@ def style_cfg_map_mask() -> CFG_DICT:
                 {
                     "title": "Transparent",
                     "abstract": "A Transparent Value",
-                    "flags": {
-                        "bar": 1,
-                    },
+                    "flags": {"bar": 1},
                     "color": "#111111",
-                    "mask": True
+                    "mask": True,
                 },
                 {
                     "title": "Non-Transparent",
                     "abstract": "A Non-Transparent Value",
-                    "flags": {
-                        "bar": 2,
-                    },
+                    "flags": {"bar": 2},
                     "color": "#FFFFFF",
                 },
                 {
                     "title": "Impossible",
                     "abstract": "Will already have matched a previous rule",
-                    "flags": {
-                        "bar": 1,
-                    },
+                    "flags": {"bar": 1},
                     "color": "#54d56f",
-                }
+                },
             ]
-        }
+        },
     }
 
 
@@ -675,52 +643,55 @@ def test_RGBAMapped_Masking(product_layer_mask_map, style_cfg_map_mask) -> None:
         val = kwargs["bar"]
         return data == val
 
-
     dim = np.array([0, 1, 2, 3, 4, 5])
     band = np.array([0, 0, 1, 1, 2, 2])
     timarray = [np.datetime64(datetime.date.today(), "ns")]
     times = DataArray(timarray, coords=[timarray], dims=["time"], name="time")
-    da = DataArray(band, name='foo', coords={"dim": dim}, dims=["dim"])
-    dst = Dataset(data_vars={'foo': da})
+    da = DataArray(band, name="foo", coords={"dim": dim}, dims=["dim"])
+    dst = Dataset(data_vars={"foo": da})
     ds = concat([dst], times)
 
     npmap = np.array([True, True, True, True, True, True])
     damap = DataArray(npmap, coords={"dim": dim}, dims=["dim"])
 
-    with patch('datacube_ows.config_utils.make_mask', new_callable=lambda: fake_make_mask):
-        style_def = datacube_ows.styles.StyleDef(product_layer_mask_map, style_cfg_map_mask)
+    with patch(
+        "datacube_ows.config_utils.make_mask", new_callable=lambda: fake_make_mask
+    ):
+        style_def = datacube_ows.styles.StyleDef(
+            product_layer_mask_map, style_cfg_map_mask
+        )
         data = style_def.transform_data(ds, damap)
         r = data["red"]
         g = data["green"]
         b = data["blue"]
         a = data["alpha"]
 
-        assert (r.values[2] == 17)
-        assert (g.values[2] == 17)
-        assert (b.values[2] == 17)
-        assert (a.values[2] == 0)
-        assert (r.values[4] == 255)
-        assert (g.values[4] == 255)
-        assert (b.values[4] == 255)
-        assert (a.values[4] == 255)
+        assert r.values[2] == 17
+        assert g.values[2] == 17
+        assert b.values[2] == 17
+        assert a.values[2] == 0
+        assert r.values[4] == 255
+        assert g.values[4] == 255
+        assert b.values[4] == 255
+        assert a.values[4] == 255
 
 
 def test_reint() -> None:
     from datacube_ows.styles.colormap import ColorMapStyleDef
 
-    band = np.array([0., 0., 1., 1., 2., 2.])
-    da = DataArray(band, name='foo')
+    band = np.array([0.0, 0.0, 1.0, 1.0, 2.0, 2.0])
+    da = DataArray(band, name="foo")
 
-    assert (band.dtype.kind == "f")
+    assert band.dtype.kind == "f"
     data = ColorMapStyleDef.reint(band)
-    assert (data.dtype.kind == "i")
+    assert data.dtype.kind == "i"
 
-    assert (da.dtype.kind == "f")
+    assert da.dtype.kind == "f"
     data = ColorMapStyleDef.reint(da)
-    assert (data.dtype.kind == "i")
+    assert data.dtype.kind == "i"
 
     data = ColorMapStyleDef.reint(data)
-    assert (data.dtype.kind == "i")
+    assert data.dtype.kind == "i"
 
 
 def test_createcolordata() -> None:
@@ -729,7 +700,7 @@ def test_createcolordata() -> None:
     from datacube_ows.styles.colormap import ColorMapStyleDef
 
     band = np.array([0, 0, 1, 1, 2, 2])
-    da = DataArray(band, name='foo')
+    da = DataArray(band, name="foo")
     rgba = to_rgba("#FFFFFF")
 
     data = ColorMapStyleDef.create_colordata(da, rgba, (band >= 0))
@@ -742,7 +713,7 @@ def test_createcolordata_alpha() -> None:
     from datacube_ows.styles.colormap import ColorMapStyleDef
 
     band = np.array([0, 0, 1, 1, 2, 2])
-    da = DataArray(band, name='foo')
+    da = DataArray(band, name="foo")
     rgba = to_rgba("#FFFFFF", alpha=0.0)
 
     data = ColorMapStyleDef.create_colordata(da, rgba, (band >= 0))
@@ -755,7 +726,7 @@ def test_createcolordata_mask() -> None:
     from datacube_ows.styles.colormap import ColorMapStyleDef
 
     band = np.array([0, 0, 1, 1, 2, 2])
-    da = DataArray(band, name='foo')
+    da = DataArray(band, name="foo")
     rgba = to_rgba("#FFFFFF", alpha=0.0)
 
     data = ColorMapStyleDef.create_colordata(da, rgba, (band > 0))
@@ -769,10 +740,12 @@ def test_createcolordata_remask() -> None:
     from datacube_ows.styles.colormap import ColorMapStyleDef
 
     band = np.array([0, 0, 1, 1, np.nan, np.nan])
-    da = DataArray(band, name='foo')
+    da = DataArray(band, name="foo")
     rgba = to_rgba("#FFFFFF", alpha=0.0)
 
-    data = ColorMapStyleDef.create_colordata(da, rgba, np.array([True, True, True, True, True, True]))
+    data = ColorMapStyleDef.create_colordata(
+        da, rgba, np.array([True, True, True, True, True, True])
+    )
     assert (np.isfinite(data["red"][0:3:1])).all()
     assert (np.isnan(data["red"][4:5:1])).all()
 
@@ -804,6 +777,7 @@ def test_bad_mpl_ramp() -> None:
         _ = read_mpl_ramp("definitely_not_a_real_matplotlib_ramp_name")
     assert "Invalid Matplotlib name: " in str(e.value)
 
+
 @pytest.fixture
 def style_with_pq_masking() -> CFG_DICT:
     return {
@@ -815,15 +789,11 @@ def style_with_pq_masking() -> CFG_DICT:
         "components": {
             "red": {"red": 1.0},
             "green": {"green": 1.0},
-            "blue": {"blue": 1.0}
+            "blue": {"blue": 1.0},
         },
-        "pq_masks": [
-            {
-                "band": "pq",
-                "values": [0, 1, 2],
-            }
-        ]
+        "pq_masks": [{"band": "pq", "values": [0, 1, 2]}],
     }
+
 
 def test_style_with_pq_masks(product_layer, style_with_pq_masking, minimal_dc) -> None:
     def fake_make_mask(data, **kwargs):
@@ -835,10 +805,10 @@ def test_style_with_pq_masks(product_layer, style_with_pq_masking, minimal_dc) -
     timarray = [np.datetime64(datetime.date.today(), "ns")]
     times = DataArray(timarray, coords=[timarray], dims=["time"], name="time")
     data_vars = {
-        "pq": DataArray(band, name='pq', coords={"dim": dim}, dims=["dim"]),
-        "red": DataArray(band, name='red', coords={"dim": dim}, dims=["dim"]),
-        "green": DataArray(band, name='green', coords={"dim": dim}, dims=["dim"]),
-        "blue": DataArray(band, name='blue', coords={"dim": dim}, dims=["dim"]),
+        "pq": DataArray(band, name="pq", coords={"dim": dim}, dims=["dim"]),
+        "red": DataArray(band, name="red", coords={"dim": dim}, dims=["dim"]),
+        "green": DataArray(band, name="green", coords={"dim": dim}, dims=["dim"]),
+        "blue": DataArray(band, name="blue", coords={"dim": dim}, dims=["dim"]),
     }
     dst = Dataset(data_vars=data_vars)
     ds = concat([dst], times)
@@ -846,21 +816,27 @@ def test_style_with_pq_masks(product_layer, style_with_pq_masking, minimal_dc) -
     npmap = np.array([True, True, True, True, True, True])
     damap = DataArray(npmap, coords={"dim": dim}, dims=["dim"])
 
-    with patch('datacube_ows.config_utils.make_mask', new_callable=lambda: fake_make_mask):
+    with patch(
+        "datacube_ows.config_utils.make_mask", new_callable=lambda: fake_make_mask
+    ):
         style_def = datacube_ows.styles.StyleDef(product_layer, style_with_pq_masking)
         style_def.make_ready(minimal_dc)
         mask = style_def.to_mask(ds, damap)
         data = style_def.transform_data(ds, mask)
         a = data["alpha"]
 
-        assert (a.values[2] == 255)
-        assert (a.values[4] == 0)
+        assert a.values[2] == 255
+        assert a.values[4] == 0
+
 
 def test_styles_with_invalid_pq_masks(product_layer, style_with_pq_masking) -> None:
     style_with_pq_masking["pq_masks"][0]["band"] = "invalid_band"
     with pytest.raises(ConfigException) as e:
         _ = datacube_ows.styles.StyleDef(product_layer, style_with_pq_masking)
-    assert "has a mask that references flag band invalid_band which is not defined" in str(e.value)
+    assert (
+        "has a mask that references flag band invalid_band which is not defined"
+        in str(e.value)
+    )
     product_layer.flag_bands = {}
     product_layer.allflag_productbands = []
     with pytest.raises(ConfigException) as e:

--- a/tests/test_time_res_method.py
+++ b/tests/test_time_res_method.py
@@ -16,10 +16,8 @@ from datacube_ows.ows_configuration import TimeRes
 def simple_geobox() -> GeoBox:
     from affine import Affine
 
-    aff = Affine.translation(145.0, -35.0) * Affine.scale(
-        1.0 / 256, 2.0 / 256
-    )
-    return GeoBox((256, 256), aff, 'EPSG:4326')
+    aff = Affine.translation(145.0, -35.0) * Affine.scale(1.0 / 256, 2.0 / 256)
+    return GeoBox((256, 256), aff, "EPSG:4326")
 
 
 def test_timeres_enum(simple_geobox) -> None:
@@ -50,8 +48,7 @@ def test_solar(simple_geobox) -> None:
     assert "Solar time resolution search_times requires a geobox" in str(e.value)
 
     assert res.search_times(
-        datetime(2020, 6, 7, 20, 20, 0, tzinfo=timezone.utc),
-        simple_geobox,
+        datetime(2020, 6, 7, 20, 20, 0, tzinfo=timezone.utc), simple_geobox
     ) == (
         datetime(2020, 6, 6, 14, 0, tzinfo=timezone.utc),
         datetime(2020, 6, 7, 13, 59, 59, tzinfo=timezone.utc),

--- a/tests/test_update_ranges.py
+++ b/tests/test_update_ranges.py
@@ -7,6 +7,7 @@
 """Test update ranges on DB using Click testing
 https://click.palletsprojects.com/en/7.x/testing/
 """
+
 import pytest
 from click.testing import CliRunner
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -27,20 +27,90 @@ def datasets_for_sorting() -> list:
     utc = timezone.utc
     DT = datetime.datetime
     return [
-        mock_ds_for_sort("A", DT(2022, 7, 15, 0, 0, tzinfo=utc), DT(2022, 7, 15, 9, 45, tzinfo=utc), 148.0, "prod_a"),
-        mock_ds_for_sort("B", DT(2022, 7, 15, 0, 0, tzinfo=utc), DT(2022, 7, 15, 10, 45, tzinfo=utc), 148.0, "prod_a"),
-        mock_ds_for_sort("C", DT(2022, 7, 15, 5, 0, tzinfo=utc), DT(2022, 7, 15, 0, 5, tzinfo=utc), 128.0, "prod_a"),
-        mock_ds_for_sort("D", DT(2022, 7, 15, 5, 0, tzinfo=utc), DT(2022, 7, 15, 14, 45, tzinfo=utc), 128.0, "prod_a"),
-
-        mock_ds_for_sort("E", DT(2022, 7, 15, 0, 0, tzinfo=utc), DT(2022, 7, 15, 9, 45, tzinfo=utc), 128.0, "prod_b"),
-        mock_ds_for_sort("F", DT(2022, 7, 15, 0, 0, tzinfo=utc), DT(2022, 7, 15, 10, 45, tzinfo=utc), 128.0, "prod_b"),
-        mock_ds_for_sort("G", DT(2022, 7, 15, 5, 0, tzinfo=utc), DT(2022, 7, 15, 0, 5, tzinfo=utc), 148.0, "prod_b"),
-        mock_ds_for_sort("H", DT(2022, 7, 15, 5, 0, tzinfo=utc), DT(2022, 7, 15, 14, 45, tzinfo=utc), 148.0, "prod_b"),
-
-        mock_ds_for_sort("I", DT(2022, 7, 15, 0, 0, tzinfo=utc), DT(2022, 7, 15, 9, 45, tzinfo=utc), 128.0, "prod_c"),
-        mock_ds_for_sort("J", DT(2022, 7, 15, 0, 0, tzinfo=utc), DT(2022, 7, 15, 10, 45, tzinfo=utc), 128.0, "prod_c"),
-        mock_ds_for_sort("K", DT(2022, 7, 15, 5, 0, tzinfo=utc), DT(2022, 7, 15, 0, 45, tzinfo=utc), 148.0, "prod_c"),
-        mock_ds_for_sort("L", DT(2022, 7, 15, 5, 0, tzinfo=utc), DT(2022, 7, 15, 14, 45, tzinfo=utc), 148.0, "prod_c"),
+        mock_ds_for_sort(
+            "A",
+            DT(2022, 7, 15, 0, 0, tzinfo=utc),
+            DT(2022, 7, 15, 9, 45, tzinfo=utc),
+            148.0,
+            "prod_a",
+        ),
+        mock_ds_for_sort(
+            "B",
+            DT(2022, 7, 15, 0, 0, tzinfo=utc),
+            DT(2022, 7, 15, 10, 45, tzinfo=utc),
+            148.0,
+            "prod_a",
+        ),
+        mock_ds_for_sort(
+            "C",
+            DT(2022, 7, 15, 5, 0, tzinfo=utc),
+            DT(2022, 7, 15, 0, 5, tzinfo=utc),
+            128.0,
+            "prod_a",
+        ),
+        mock_ds_for_sort(
+            "D",
+            DT(2022, 7, 15, 5, 0, tzinfo=utc),
+            DT(2022, 7, 15, 14, 45, tzinfo=utc),
+            128.0,
+            "prod_a",
+        ),
+        mock_ds_for_sort(
+            "E",
+            DT(2022, 7, 15, 0, 0, tzinfo=utc),
+            DT(2022, 7, 15, 9, 45, tzinfo=utc),
+            128.0,
+            "prod_b",
+        ),
+        mock_ds_for_sort(
+            "F",
+            DT(2022, 7, 15, 0, 0, tzinfo=utc),
+            DT(2022, 7, 15, 10, 45, tzinfo=utc),
+            128.0,
+            "prod_b",
+        ),
+        mock_ds_for_sort(
+            "G",
+            DT(2022, 7, 15, 5, 0, tzinfo=utc),
+            DT(2022, 7, 15, 0, 5, tzinfo=utc),
+            148.0,
+            "prod_b",
+        ),
+        mock_ds_for_sort(
+            "H",
+            DT(2022, 7, 15, 5, 0, tzinfo=utc),
+            DT(2022, 7, 15, 14, 45, tzinfo=utc),
+            148.0,
+            "prod_b",
+        ),
+        mock_ds_for_sort(
+            "I",
+            DT(2022, 7, 15, 0, 0, tzinfo=utc),
+            DT(2022, 7, 15, 9, 45, tzinfo=utc),
+            128.0,
+            "prod_c",
+        ),
+        mock_ds_for_sort(
+            "J",
+            DT(2022, 7, 15, 0, 0, tzinfo=utc),
+            DT(2022, 7, 15, 10, 45, tzinfo=utc),
+            128.0,
+            "prod_c",
+        ),
+        mock_ds_for_sort(
+            "K",
+            DT(2022, 7, 15, 5, 0, tzinfo=utc),
+            DT(2022, 7, 15, 0, 45, tzinfo=utc),
+            148.0,
+            "prod_c",
+        ),
+        mock_ds_for_sort(
+            "L",
+            DT(2022, 7, 15, 5, 0, tzinfo=utc),
+            DT(2022, 7, 15, 14, 45, tzinfo=utc),
+            148.0,
+            "prod_c",
+        ),
     ]
 
 
@@ -53,15 +123,27 @@ def test_group_by_stat(datasets_for_sorting) -> None:
     date_only = Datacube.group_datasets(datasets_for_sorting, gby)
     assert len(date_only) == 1
     arrays = date_only.values
-    assert [ds.id for ds in arrays[0]] == ['A', 'B', 'E', 'F', 'I', 'J', 'C', 'D', 'G', 'H', 'K', 'L']
-
+    assert [ds.id for ds in arrays[0]] == [
+        "A",
+        "B",
+        "E",
+        "F",
+        "I",
+        "J",
+        "C",
+        "D",
+        "G",
+        "H",
+        "K",
+        "L",
+    ]
 
     gby = group_by_begin_datetime(["prod_c", "prod_b", "prod_a"], truncate_dates=False)
     date_only = Datacube.group_datasets(datasets_for_sorting, gby)
     assert len(date_only) == 2
     arrays = date_only.values
-    assert [ds.id for ds in arrays[0]] == ['I', 'J', 'E', 'F', 'A', 'B']
-    assert [ds.id for ds in arrays[1]] == ['K', 'L', 'G', 'H', 'C', 'D']
+    assert [ds.id for ds in arrays[0]] == ["I", "J", "E", "F", "A", "B"]
+    assert [ds.id for ds in arrays[1]] == ["K", "L", "G", "H", "C", "D"]
 
 
 def test_group_by_solar(datasets_for_sorting) -> None:
@@ -73,16 +155,37 @@ def test_group_by_solar(datasets_for_sorting) -> None:
     date_only = Datacube.group_datasets(datasets_for_sorting, gby)
     assert len(date_only) == 2
     arrays = date_only.values
-    assert [ds.id for ds in arrays[0]] == ['A', 'B', 'E', 'F', 'I', 'J', 'C', 'D', 'G', 'K']
-    assert [ds.id for ds in arrays[1]] == ['H', 'L']
-
+    assert [ds.id for ds in arrays[0]] == [
+        "A",
+        "B",
+        "E",
+        "F",
+        "I",
+        "J",
+        "C",
+        "D",
+        "G",
+        "K",
+    ]
+    assert [ds.id for ds in arrays[1]] == ["H", "L"]
 
     gby = group_by_solar(["prod_c", "prod_b", "prod_a"])
     date_only = Datacube.group_datasets(datasets_for_sorting, gby)
     assert len(date_only) == 2
     arrays = date_only.values
-    assert [ds.id for ds in arrays[0]] == ['I', 'J', 'K', 'E', 'F', 'G', 'A', 'B', 'C', 'D']
-    assert [ds.id for ds in arrays[1]] == ['L', 'H']
+    assert [ds.id for ds in arrays[0]] == [
+        "I",
+        "J",
+        "K",
+        "E",
+        "F",
+        "G",
+        "A",
+        "B",
+        "C",
+        "D",
+    ]
+    assert [ds.id for ds in arrays[1]] == ["L", "H"]
 
 
 def test_group_by_mosaic(datasets_for_sorting) -> None:
@@ -94,18 +197,44 @@ def test_group_by_mosaic(datasets_for_sorting) -> None:
     date_only = Datacube.group_datasets(datasets_for_sorting, gby)
     assert len(date_only) == 1
     arrays = date_only.values
-    assert [ds.id for ds in arrays[0]] == ['A', 'B', 'E', 'F', 'I', 'J', 'C', 'D', 'G', 'K', 'H', 'L']
-
+    assert [ds.id for ds in arrays[0]] == [
+        "A",
+        "B",
+        "E",
+        "F",
+        "I",
+        "J",
+        "C",
+        "D",
+        "G",
+        "K",
+        "H",
+        "L",
+    ]
 
     gby = group_by_mosaic(["prod_c", "prod_b", "prod_a"])
     date_only = Datacube.group_datasets(datasets_for_sorting, gby)
     assert len(date_only) == 1
     arrays = date_only.values
-    assert [ds.id for ds in arrays[0]] == ['I', 'J', 'K', 'E', 'F', 'G', 'A', 'B', 'C', 'D', 'L', 'H']
+    assert [ds.id for ds in arrays[0]] == [
+        "I",
+        "J",
+        "K",
+        "E",
+        "F",
+        "G",
+        "A",
+        "B",
+        "C",
+        "D",
+        "L",
+        "H",
+    ]
 
 
 def test_find_in_dates() -> None:
     from datacube_ows.utils import find_matching_date
+
     dates = [
         datetime.datetime(1991, 8, 3, 22, 15, 24, 122234, tzinfo=timezone.utc),
         datetime.datetime(1991, 8, 5, 14, 6, 12, 156238, tzinfo=timezone.utc),
@@ -117,12 +246,30 @@ def test_find_in_dates() -> None:
         datetime.datetime(1999, 12, 31, 22, 22, 22, 222222, tzinfo=timezone.utc),
         datetime.datetime(2011, 7, 23, 12, 4, 12, 723494, tzinfo=timezone.utc),
     ]
-    assert find_matching_date(datetime.datetime(1991, 8, 3, 22, 15, 24, 122234, tzinfo=timezone.utc), dates)
-    assert find_matching_date(datetime.datetime(2011, 7, 23, 12, 4, 12, 723494, tzinfo=timezone.utc), dates)
-    assert find_matching_date(datetime.datetime(1992, 2, 5, 15, 45, 11, 234110, tzinfo=timezone.utc), dates)
-    assert find_matching_date(datetime.datetime(1996, 1, 23, 12, 15, 25, 723411, tzinfo=timezone.utc), dates)
-    assert not find_matching_date(datetime.datetime(1996, 1, 23, 12, 15, 26, 723411, tzinfo=timezone.utc), dates)
-    assert find_matching_date(datetime.datetime(1996, 1, 23, 12, 15, 27, 723411, tzinfo=timezone.utc), dates)
-    assert not find_matching_date(datetime.datetime(1896, 1, 23, 12, 15, 26, 723411, tzinfo=timezone.utc), dates)
-    assert not find_matching_date(datetime.datetime(2016, 1, 23, 12, 15, 26, 723411, tzinfo=timezone.utc), dates)
-    assert not find_matching_date(datetime.datetime(2011, 7, 23, 12, 4, 12, 723494, tzinfo=timezone.utc), [])
+    assert find_matching_date(
+        datetime.datetime(1991, 8, 3, 22, 15, 24, 122234, tzinfo=timezone.utc), dates
+    )
+    assert find_matching_date(
+        datetime.datetime(2011, 7, 23, 12, 4, 12, 723494, tzinfo=timezone.utc), dates
+    )
+    assert find_matching_date(
+        datetime.datetime(1992, 2, 5, 15, 45, 11, 234110, tzinfo=timezone.utc), dates
+    )
+    assert find_matching_date(
+        datetime.datetime(1996, 1, 23, 12, 15, 25, 723411, tzinfo=timezone.utc), dates
+    )
+    assert not find_matching_date(
+        datetime.datetime(1996, 1, 23, 12, 15, 26, 723411, tzinfo=timezone.utc), dates
+    )
+    assert find_matching_date(
+        datetime.datetime(1996, 1, 23, 12, 15, 27, 723411, tzinfo=timezone.utc), dates
+    )
+    assert not find_matching_date(
+        datetime.datetime(1896, 1, 23, 12, 15, 26, 723411, tzinfo=timezone.utc), dates
+    )
+    assert not find_matching_date(
+        datetime.datetime(2016, 1, 23, 12, 15, 26, 723411, tzinfo=timezone.utc), dates
+    )
+    assert not find_matching_date(
+        datetime.datetime(2011, 7, 23, 12, 4, 12, 723494, tzinfo=timezone.utc), []
+    )

--- a/tests/test_wcs2_utils.py
+++ b/tests/test_wcs2_utils.py
@@ -15,9 +15,7 @@ from datacube_ows.wcs2_utils import uniform_crs
 @pytest.fixture
 def minimal_cfg():
     cfg = MagicMock()
-    cfg.published_CRSs = {
-        "dummy": {},
-    }
+    cfg.published_CRSs = {"dummy": {}}
     return cfg
 
 

--- a/tests/test_wcs_scaler.py
+++ b/tests/test_wcs_scaler.py
@@ -67,10 +67,9 @@ def layer_crs_nongeom():
     }
     product_layer.global_cfg.internal_CRSs = product_layer.global_cfg.published_CRSs
     product_layer.native_CRS = "TEST:NATIVE_CRS"
-    product_layer.native_CRS_def = \
-        product_layer.global_cfg.published_CRSs[
-            product_layer.native_CRS
-        ]
+    product_layer.native_CRS_def = product_layer.global_cfg.published_CRSs[
+        product_layer.native_CRS
+    ]
     return product_layer
 
 
@@ -86,7 +85,7 @@ def layer_crs_geom():
             "vertical_coord": "y",
             "vertical_coord_first": False,
             "gml_name": "http://www.opengis.net/def/crs/EPSG/0/3857",
-            "alias_of": False
+            "alias_of": False,
         },
         "EPSG:4326": {  # WGS-84
             "geographic": True,
@@ -94,7 +93,7 @@ def layer_crs_geom():
             "horizontal_coord": "longitude",
             "vertical_coord": "latitude",
             "gml_name": "http://www.opengis.net/def/crs/EPSG/0/4326",
-            "alias_of": False
+            "alias_of": False,
         },
         "EPSG:3577": {
             "geographic": False,
@@ -102,54 +101,67 @@ def layer_crs_geom():
             "vertical_coord": "y",
             "vertical_coord_first": False,
             "gml_name": "http://www.opengis.net/def/crs/EPSG/0/3577",
-            "alias_of": False
+            "alias_of": False,
         },
     }
     product_layer.global_cfg.internal_CRSs = product_layer.global_cfg.published_CRSs
     product_layer.native_CRS = "EPSG:3577"
-    product_layer.native_CRS_def = \
-        product_layer.global_cfg.published_CRSs[
-            product_layer.native_CRS
-        ]
+    product_layer.native_CRS_def = product_layer.global_cfg.published_CRSs[
+        product_layer.native_CRS
+    ]
     product_layer.grids = {
-        'EPSG:3857': {
-            'origin': (12324052.573696733, -5742240.963567746),
-            'resolution': (24.631092099500425, -27.828535092231032)
+        "EPSG:3857": {
+            "origin": (12324052.573696733, -5742240.963567746),
+            "resolution": (24.631092099500425, -27.828535092231032),
         },
-        'EPSG:4326': {
-            'origin': (-8.95553593506657, 157.105656164263),
-            'resolution': (-0.00017552732376162043, 0.0002723248887547909)
+        "EPSG:4326": {
+            "origin": (-8.95553593506657, 157.105656164263),
+            "resolution": (-0.00017552732376162043, 0.0002723248887547909),
         },
-        'EPSG:3577': {
-            'origin': (-2407984.8524648934, -5195512.771063174),
-            'resolution': (25, -25)
+        "EPSG:3577": {
+            "origin": (-2407984.8524648934, -5195512.771063174),
+            "resolution": (25, -25),
         },
     }
-    times = [datetime.date(2013, 1, 1), datetime.date(2014, 1, 1), datetime.date(2015, 1, 1),
-              datetime.date(2016, 1, 1), datetime.date(2017, 1, 1), datetime.date(2018, 1, 1)]
+    times = [
+        datetime.date(2013, 1, 1),
+        datetime.date(2014, 1, 1),
+        datetime.date(2015, 1, 1),
+        datetime.date(2016, 1, 1),
+        datetime.date(2017, 1, 1),
+        datetime.date(2018, 1, 1),
+    ]
     product_layer.dynamic = False
     product_layer._ranges = LayerExtent(
         lat=CoordRange(min=-34.5250413940276, max=-33.772472435988),
         lon=CoordRange(min=150.330509919584, max=151.258021405841),
         times=times,
         bboxes={
-            'EPSG:3111': {
-                'top': 5725844.213533809, 'left': -1623290.9363678931,
-                'right': 3983581.449863785, 'bottom': 1042109.9920098772
+            "EPSG:3111": {
+                "top": 5725844.213533809,
+                "left": -1623290.9363678931,
+                "right": 3983581.449863785,
+                "bottom": 1042109.9920098772,
             },
-            'EPSG:3577': {
-                'top': -936185.3115191332, 'left': -2407984.8524648934,
-                'right': 2834259.110253384, 'bottom': -5195512.771063174
+            "EPSG:3577": {
+                "top": -936185.3115191332,
+                "left": -2407984.8524648934,
+                "right": 2834259.110253384,
+                "bottom": -5195512.771063174,
             },
-            'EPSG:3857': {
-                'top': -1001009.9542990683, 'left': 12324052.573696733,
-                'right': 17488921.644948877, 'bottom': -5742240.963567746
+            "EPSG:3857": {
+                "top": -1001009.9542990683,
+                "left": 12324052.573696733,
+                "right": 17488921.644948877,
+                "bottom": -5742240.963567746,
             },
-            'EPSG:4326': {
-                'top': -8.95553593506657, 'left': 110.708847892443,
-                'right': 157.105656164263, 'bottom': -45.761684927317
-            }
-        }
+            "EPSG:4326": {
+                "top": -8.95553593506657,
+                "left": 110.708847892443,
+                "right": 157.105656164263,
+                "bottom": -45.761684927317,
+            },
+        },
     )
     return product_layer
 
@@ -196,7 +208,7 @@ def test_spatial_parameter_isdim_test_crs(layer_crs_nongeom) -> None:
     assert param.hortizonal_cults == 7
     assert param.verbal_tics == -13
     with pytest.raises(WCSScalerUnknownDimension) as e:
-       _ = param.horivertal_calzones
+        _ = param.horivertal_calzones
     assert e.value.dim == "horivertal_calzones"
 
 
@@ -253,6 +265,7 @@ def assert_approx_tuple(a, b) -> None:
         else:
             assert aa == pytest.approx(bb, rel=1e-4)
 
+
 def test_transform_unsubsetted(layer_crs_geom) -> None:
     scaler = WCSScaler(layer_crs_geom, "EPSG:4326")
     scaler.to_crs("EPSG:3577")
@@ -266,7 +279,9 @@ def test_transform_one_slice(layer_crs_geom) -> None:
     scaler.slice("x", 120.0)
     scaler.to_crs("EPSG:3577")
     assert scaler.crs == "EPSG:3577"
-    assert_approx_tuple(scaler.dim("x"), (None, -1361473.6681777071, -980861.0939271128))
+    assert_approx_tuple(
+        scaler.dim("x"), (None, -1361473.6681777071, -980861.0939271128)
+    )
     assert_approx_tuple(scaler.dim("y"), (None, -5195512.771063174, -936185.3115191332))
 
 
@@ -274,7 +289,9 @@ def test_transform_one_trim(layer_crs_geom) -> None:
     scaler = WCSScaler(layer_crs_geom, "EPSG:4326")
     scaler.trim("x", 120.0, 130.0)
     scaler.to_crs("EPSG:3577")
-    assert_approx_tuple(scaler.dim("x"), (None, -1361473.6681777071, -163710.79405154017))
+    assert_approx_tuple(
+        scaler.dim("x"), (None, -1361473.6681777071, -163710.79405154017)
+    )
     assert_approx_tuple(scaler.dim("y"), (None, -5195512.771063174, -936185.3115191332))
 
 
@@ -283,8 +300,12 @@ def test_transform_two_trims(layer_crs_geom) -> None:
     scaler.trim("x", 120.0, 130.0)
     scaler.trim("y", -30.0, -20.0)
     scaler.to_crs("EPSG:3577")
-    assert_approx_tuple(scaler.dim("x"), (None, -1248178.532656371, -190806.89815343948))
-    assert_approx_tuple(scaler.dim("y"), (None, -3317050.4161210703, -2145729.370620175))
+    assert_approx_tuple(
+        scaler.dim("x"), (None, -1248178.532656371, -190806.89815343948)
+    )
+    assert_approx_tuple(
+        scaler.dim("y"), (None, -3317050.4161210703, -2145729.370620175)
+    )
 
 
 def test_transform_slice_trim(layer_crs_geom) -> None:
@@ -293,7 +314,9 @@ def test_transform_slice_trim(layer_crs_geom) -> None:
     scaler.slice("y", -20.0)
     scaler.to_crs("EPSG:3577")
     assert_approx_tuple(scaler.dim("x"), (None, -1248178.532656371, -208327.4583571618))
-    assert_approx_tuple(scaler.dim("y"), (None, -2202762.0236987285, -2145729.370620175))
+    assert_approx_tuple(
+        scaler.dim("y"), (None, -2202762.0236987285, -2145729.370620175)
+    )
 
 
 def test_transform_two_slices(layer_crs_geom) -> None:
@@ -310,8 +333,12 @@ def test_scale_axis(layer_crs_geom) -> None:
     scaler.to_crs("EPSG:3577")
     scaler.scale_axis("x", 2.0)
     scaler.scale_axis("y", 0.5)
-    assert_approx_tuple(scaler.dim("x"), (419380, -2407984.8524648934, 2834259.110253384))
-    assert_approx_tuple(scaler.dim("y"), (85187, -5195512.771063174, -936185.3115191332))
+    assert_approx_tuple(
+        scaler.dim("x"), (419380, -2407984.8524648934, 2834259.110253384)
+    )
+    assert_approx_tuple(
+        scaler.dim("y"), (85187, -5195512.771063174, -936185.3115191332)
+    )
 
 
 def test_scale_size(layer_crs_geom) -> None:
@@ -338,7 +365,12 @@ def test_scaler_default(layer_crs_geom) -> None:
     scaler.to_crs("EPSG:3577")
     affine = scaler.affine()
     assert affine == Affine(
-#        -25.000014436231336, 0.0, -5195512.771063174,
-#        0.0, 24.999971208537733, 2834259.110253384)
-         24.999971208537733, 0.0, -2407984.8524648934,
-         0.0, -25.000014436231336, -936185.3115191332)
+        #        -25.000014436231336, 0.0, -5195512.771063174,
+        #        0.0, 24.999971208537733, 2834259.110253384)
+        24.999971208537733,
+        0.0,
+        -2407984.8524648934,
+        0.0,
+        -25.000014436231336,
+        -936185.3115191332,
+    )

--- a/tests/test_wms_utils.py
+++ b/tests/test_wms_utils.py
@@ -20,9 +20,14 @@ def test_parse_time_delta() -> None:
     from dateutil.relativedelta import relativedelta
 
     tests = {
-        relativedelta(hours=1): ['P0Y0M0DT1H0M0S', 'PT1H0M0S', 'PT1H', ],
-        relativedelta(months=18): ['P1Y6M0DT0H0M0S', 'P1Y6M0D', 'P0Y18M0DT0H0M0S', 'P18M', ],
-        relativedelta(minutes=90): ['PT1H30M', 'P0Y0M0DT1H30M0S', 'PT90M'],
+        relativedelta(hours=1): ["P0Y0M0DT1H0M0S", "PT1H0M0S", "PT1H"],
+        relativedelta(months=18): [
+            "P1Y6M0DT0H0M0S",
+            "P1Y6M0D",
+            "P0Y18M0DT0H0M0S",
+            "P18M",
+        ],
+        relativedelta(minutes=90): ["PT1H30M", "P0Y0M0DT1H30M0S", "PT90M"],
     }
     for td, td_str_list in tests.items():
         for td_str in td_str_list:
@@ -31,22 +36,39 @@ def test_parse_time_delta() -> None:
 
 def test_parse_wms_time_strings() -> None:
     import datetime as dt
+
     tests = {
-        '2018-01-10/2019-01-10': (dt.datetime(2018, 1, 10, 0, 0), dt.datetime(2019, 1, 10, 23, 23, 59, 999999)),
-        '2000/P1Y': (dt.datetime(2000, 1, 1, 0, 0), dt.datetime(2000, 12, 31, 23, 59, 59, 999999)),
-        '2018-01-10/P5D': (dt.datetime(2018, 1, 10, 0, 0), dt.datetime(2018, 1, 14, 23, 59, 59, 999999)),
-        'P1M/2018-01-10': (dt.datetime(2017, 12, 10, 0, 0, 0, 1), dt.datetime(2018, 1, 10, 23, 23, 59, 999999)),
+        "2018-01-10/2019-01-10": (
+            dt.datetime(2018, 1, 10, 0, 0),
+            dt.datetime(2019, 1, 10, 23, 23, 59, 999999),
+        ),
+        "2000/P1Y": (
+            dt.datetime(2000, 1, 1, 0, 0),
+            dt.datetime(2000, 12, 31, 23, 59, 59, 999999),
+        ),
+        "2018-01-10/P5D": (
+            dt.datetime(2018, 1, 10, 0, 0),
+            dt.datetime(2018, 1, 14, 23, 59, 59, 999999),
+        ),
+        "P1M/2018-01-10": (
+            dt.datetime(2017, 12, 10, 0, 0, 0, 1),
+            dt.datetime(2018, 1, 10, 23, 23, 59, 999999),
+        ),
     }
 
     for value, result in tests.items():
-        assert result == datacube_ows.wms_utils.parse_wms_time_strings(value.split('/'))
+        assert result == datacube_ows.wms_utils.parse_wms_time_strings(value.split("/"))
     with pytest.raises(WMSException) as e:
         result = datacube_ows.wms_utils.parse_wms_time_strings(["P1Y", "P1Y"])
     assert "Could not understand time value" in str(e.value)
 
+
 def test_parse_wms_time_strings_with_present() -> None:
     import datetime as dt
-    start, end = datacube_ows.wms_utils.parse_wms_time_strings(['2018-01-10', 'PRESENT'])
+
+    start, end = datacube_ows.wms_utils.parse_wms_time_strings(
+        ["2018-01-10", "PRESENT"]
+    )
     assert start == dt.datetime(2018, 1, 10, 0, 0)
     assert (dt.datetime.now(dt.timezone.utc) - end).total_seconds() < 60
 
@@ -59,143 +81,183 @@ def dummy_product():
 
 
 def test_parse_userbandmath(dummy_product) -> None:
-    _ = datacube_ows.wms_utils.single_style_from_args(dummy_product,
-                                                          {
-                                                              "code": "2*(red-nir)/(red+nir)",
-                                                              "colorscheme": "viridis",
-                                                              "colorscalerange": "0,2"
-                                                          })
+    _ = datacube_ows.wms_utils.single_style_from_args(
+        dummy_product,
+        {
+            "code": "2*(red-nir)/(red+nir)",
+            "colorscheme": "viridis",
+            "colorscalerange": "0,2",
+        },
+    )
 
 
 def test_parse_userbandmath_nobands(dummy_product) -> None:
     with pytest.raises(WMSException) as e:
-        _ = datacube_ows.wms_utils.single_style_from_args(dummy_product,
-                              {
-                                  "code": "2+(4.0*72)",
-                                  "colorscheme": "viridis",
-                                  "colorscalerange": "0,2"
-                              })
+        _ = datacube_ows.wms_utils.single_style_from_args(
+            dummy_product,
+            {"code": "2+(4.0*72)", "colorscheme": "viridis", "colorscalerange": "0,2"},
+        )
     assert "Code expression invalid" in str(e.value)
     assert "Expression references no bands" in str(e.value)
 
 
 def test_parse_userbandmath_banned_op(dummy_product) -> None:
     with pytest.raises(WMSException) as e:
-        _ = datacube_ows.wms_utils.single_style_from_args(dummy_product,
-                                  {
-                                      "code": "red<green",
-                                      "colorscheme": "viridis",
-                                      "colorscalerange": "0,2"
-                                  })
+        _ = datacube_ows.wms_utils.single_style_from_args(
+            dummy_product,
+            {"code": "red<green", "colorscheme": "viridis", "colorscalerange": "0,2"},
+        )
     assert "not supported" in str(e.value)
     assert "Code expression invalid" in str(e.value)
 
+
 def test_parse_userbandmath_bad_code(dummy_product) -> None:
     with pytest.raises(WMSException) as e:
-        _ = datacube_ows.wms_utils.single_style_from_args(dummy_product,
-                          {
-                              "code": "2*(red@nir)/(red#nir)",
-                              "colorscheme": "viridis",
-                              "colorscalerange": "0,2"
-                          })
+        _ = datacube_ows.wms_utils.single_style_from_args(
+            dummy_product,
+            {
+                "code": "2*(red@nir)/(red#nir)",
+                "colorscheme": "viridis",
+                "colorscalerange": "0,2",
+            },
+        )
     assert "Code expression invalid" in str(e.value)
 
 
 def test_parse_userbandmath_bad_scheme(dummy_product) -> None:
     with pytest.raises(WMSException) as e:
-        _ = datacube_ows.wms_utils.single_style_from_args(dummy_product,
-                                                              {
-                                                                  "code": "2*(red-nir)/(red+nir)",
-                                                                  "colorscheme": "i_am_not_a_matplotlib_scheme",
-                                                                  "colorscalerange": "0,2"
-                                                              })
+        _ = datacube_ows.wms_utils.single_style_from_args(
+            dummy_product,
+            {
+                "code": "2*(red-nir)/(red+nir)",
+                "colorscheme": "i_am_not_a_matplotlib_scheme",
+                "colorscalerange": "0,2",
+            },
+        )
     assert "Invalid Matplotlib ramp name:" in str(e.value)
 
 
 def test_parse_no2_colorscalerange(dummy_product) -> None:
     with pytest.raises(WMSException) as e:
-        _ = datacube_ows.wms_utils.single_style_from_args(dummy_product,
-                                                              {
-                                                                  "code": "2*(red-nir)/(red+nir)",
-                                                                  "colorscheme": "viridis",
-                                                                  "colorscalerange": "0,2,4,6,8,9,15,52"
-                                                              })
-    assert "Colorscale range must be two numbers, sorted and separated by a comma." in str(e.value)
+        _ = datacube_ows.wms_utils.single_style_from_args(
+            dummy_product,
+            {
+                "code": "2*(red-nir)/(red+nir)",
+                "colorscheme": "viridis",
+                "colorscalerange": "0,2,4,6,8,9,15,52",
+            },
+        )
+    assert (
+        "Colorscale range must be two numbers, sorted and separated by a comma."
+        in str(e.value)
+    )
     with pytest.raises(WMSException) as e:
-        _ = datacube_ows.wms_utils.single_style_from_args(dummy_product,
-                                                              {
-                                                                  "code": "2*(red-nir)/(red+nir)",
-                                                                  "colorscheme": "viridis",
-                                                                  "colorscalerange": "2"
-                                                              })
-    assert "Colorscale range must be two numbers, sorted and separated by a comma." in str(e.value)
+        _ = datacube_ows.wms_utils.single_style_from_args(
+            dummy_product,
+            {
+                "code": "2*(red-nir)/(red+nir)",
+                "colorscheme": "viridis",
+                "colorscalerange": "2",
+            },
+        )
+    assert (
+        "Colorscale range must be two numbers, sorted and separated by a comma."
+        in str(e.value)
+    )
 
 
 def test_parse_nonnumeric_colorscalerange(dummy_product) -> None:
     with pytest.raises(WMSException) as e:
-        _ = datacube_ows.wms_utils.single_style_from_args(dummy_product,
-                                                              {
-                                                                  "code": "2*(red-nir)/(red+nir)",
-                                                                  "colorscheme": "viridis",
-                                                                  "colorscalerange": "0,spam",
-                                                              })
-    assert "Colorscale range must be two numbers, sorted and separated by a comma." in str(e.value)
+        _ = datacube_ows.wms_utils.single_style_from_args(
+            dummy_product,
+            {
+                "code": "2*(red-nir)/(red+nir)",
+                "colorscheme": "viridis",
+                "colorscalerange": "0,spam",
+            },
+        )
+    assert (
+        "Colorscale range must be two numbers, sorted and separated by a comma."
+        in str(e.value)
+    )
     with pytest.raises(WMSException) as e:
-        _ = datacube_ows.wms_utils.single_style_from_args(dummy_product,
-                                                              {
-                                                                  "code": "2*(red-nir)/(red+nir)",
-                                                                  "colorscheme": "viridis",
-                                                                  "colorscalerange": "spam,2"
-                                                              })
-    assert "Colorscale range must be two numbers, sorted and separated by a comma." in str(e.value)
+        _ = datacube_ows.wms_utils.single_style_from_args(
+            dummy_product,
+            {
+                "code": "2*(red-nir)/(red+nir)",
+                "colorscheme": "viridis",
+                "colorscalerange": "spam,2",
+            },
+        )
+    assert (
+        "Colorscale range must be two numbers, sorted and separated by a comma."
+        in str(e.value)
+    )
 
 
 def test_parse_unsorted_colorscalerange(dummy_product) -> None:
     with pytest.raises(WMSException) as e:
-        _ = datacube_ows.wms_utils.single_style_from_args(dummy_product,
-                          {
-                              "code": "2*(red-nir)/(red+nir)",
-                              "colorscheme": "viridis",
-                              "colorscalerange": "0,spam",
-                          })
-    assert "Colorscale range must be two numbers, sorted and separated by a comma." in str(e.value)
+        _ = datacube_ows.wms_utils.single_style_from_args(
+            dummy_product,
+            {
+                "code": "2*(red-nir)/(red+nir)",
+                "colorscheme": "viridis",
+                "colorscalerange": "0,spam",
+            },
+        )
+    assert (
+        "Colorscale range must be two numbers, sorted and separated by a comma."
+        in str(e.value)
+    )
     with pytest.raises(WMSException) as e:
-        _ = datacube_ows.wms_utils.single_style_from_args(dummy_product,
-                            {
-                                "code": "2*(red-nir)/(red+nir)",
-                                "colorscheme": "viridis",
-                                "colorscalerange": "2,0"
-                            })
-    assert "Colorscale range must be two numbers, sorted and separated by a comma." in str(e.value)
+        _ = datacube_ows.wms_utils.single_style_from_args(
+            dummy_product,
+            {
+                "code": "2*(red-nir)/(red+nir)",
+                "colorscheme": "viridis",
+                "colorscalerange": "2,0",
+            },
+        )
+    assert (
+        "Colorscale range must be two numbers, sorted and separated by a comma."
+        in str(e.value)
+    )
+
 
 def test_parse_item_1(dummy_product) -> None:
     dummy_product.ranges = LayerExtent(
         lat=CoordRange(-0.1, 0.1),
         lon=CoordRange(-0.1, 0.1),
-        times = [
+        times=[
             datetime.date(2021, 1, 6),
             datetime.date(2021, 1, 7),
             datetime.date(2021, 1, 8),
             datetime.date(2021, 1, 9),
             datetime.date(2021, 1, 10),
         ],
-        bboxes={}
+        bboxes={},
     )
     dt = datacube_ows.wms_utils.parse_time_item("2010-01-01/2021-01-08", dummy_product)
     assert dt == dummy_product.ranges.times[0]
     dummy_product.regular_time_axis = True
     with pytest.raises(WMSException) as e:
-        _ = datacube_ows.wms_utils.parse_time_item("2010-01-01/2010-01-08", dummy_product)
+        _ = datacube_ows.wms_utils.parse_time_item(
+            "2010-01-01/2010-01-08", dummy_product
+        )
     assert "No data available for time dimension range" in str(e.value)
     dummy_product.regular_time_axis = False
     with pytest.raises(WMSException) as e:
-        _ = datacube_ows.wms_utils.parse_time_item("2010-01-01/2010-01-08", dummy_product)
+        _ = datacube_ows.wms_utils.parse_time_item(
+            "2010-01-01/2010-01-08", dummy_product
+        )
     assert "Time dimension range" in str(e.value)
     assert "not valid for this layer" in str(e.value)
     dt = datacube_ows.wms_utils.parse_time_item("", dummy_product)
     assert dt == dummy_product.ranges.times[-1]
     with pytest.raises(WMSException) as e:
-        _ = datacube_ows.wms_utils.parse_time_item("this_is_not_a_date, mate", dummy_product)
+        _ = datacube_ows.wms_utils.parse_time_item(
+            "this_is_not_a_date, mate", dummy_product
+        )
     assert "Time dimension value" in str(e.value)
     assert "not valid for this layer" in str(e.value)
 
@@ -204,16 +266,17 @@ def test_parse_item_2(dummy_product) -> None:
     dummy_product.ranges = LayerExtent(
         lat=CoordRange(-0.1, 0.1),
         lon=CoordRange(-0.1, 0.1),
-        times = [
+        times=[
             datetime.date(2021, 1, 6),
             datetime.date(2021, 1, 7),
             datetime.date(2021, 1, 8),
             datetime.date(2021, 1, 10),
         ],
-        bboxes={}
+        bboxes={},
     )
     dummy_product.time_range.return_value = (
-        datetime.date(2021, 1, 6), datetime.date(2021, 1, 10),
+        datetime.date(2021, 1, 6),
+        datetime.date(2021, 1, 10),
     )
     dummy_product.regular_time_axis = False
 
@@ -254,6 +317,7 @@ def test_parse_item_2(dummy_product) -> None:
 
 def test_get_geobox() -> None:
     from datacube_ows.ows_configuration import OWSConfig
+
     mock_cfg = MagicMock()
     OWSConfig._instance = mock_cfg
     gbox = datacube_ows.wms_utils._get_geobox(
@@ -262,7 +326,7 @@ def test_get_geobox() -> None:
             "height": "256",
             "bbox": "-43.28507087113431,146.18504300790977,-43.07072582535469,146.64289867785524",
         },
-        crs=CRS("EPSG:4326")
+        crs=CRS("EPSG:4326"),
     )
     assert gbox.affine
     assert str(gbox.crs) == "EPSG:4326"
@@ -274,49 +338,36 @@ def test_get_geobox() -> None:
                 "height": "256",
                 "bbox": "-43.28507087113431,146.18504300790977,-43.28507087113431,146.64289867785524",
             },
-            crs = CRS("EPSG:4326")
+            crs=CRS("EPSG:4326"),
         )
     assert "Bounding box must enclose a non-zero area" in str(e.value)
     OWSConfig._instance = None
 
 
 def test_get_arg() -> None:
-    val = datacube_ows.wms_utils.get_arg(
-        {
-            "myval": "Oh Yeah",
-        },
-        "myval", "My Value"
-    )
+    val = datacube_ows.wms_utils.get_arg({"myval": "Oh Yeah"}, "myval", "My Value")
     assert val == "Oh Yeah"
     val = datacube_ows.wms_utils.get_arg(
-        {
-            "myval": "Oh Yeah",
-        },
-        "myval", "My Value", lower=True
+        {"myval": "Oh Yeah"}, "myval", "My Value", lower=True
     )
     assert val == "oh yeah"
     with pytest.raises(WMSException) as e:
         _ = datacube_ows.wms_utils.get_arg(
-            {
-                "myval": "Oh Yeah",
-            },
-            "meaning_of_life", "Meaning of Life"
+            {"myval": "Oh Yeah"}, "meaning_of_life", "Meaning of Life"
         )
     assert "No Meaning of Life specified" in str(e.value)
     val = datacube_ows.wms_utils.get_arg(
-        {
-            "myval": "Oh Yeah",
-        },
-        "myval", "My Value",
+        {"myval": "Oh Yeah"},
+        "myval",
+        "My Value",
         permitted_values=["Oh Yeah", "No Way", "Meh"],
     )
     assert val == "Oh Yeah"
     with pytest.raises(WMSException) as e:
         _ = datacube_ows.wms_utils.get_arg(
-            {
-                "myval": "Yes and No",
-            },
-            "myval", "My Value",
+            {"myval": "Yes and No"},
+            "myval",
+            "My Value",
             permitted_values=["Oh Yeah", "No Way", "Meh"],
         )
     assert "Yes and No" in str(e.value)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -13,12 +13,33 @@ MOTO_PORT = "5555"
 MOTO_S3_ENDPOINT_URI = "http://127.0.0.1:" + MOTO_PORT
 
 coords = [
-    ('x', [
-        0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0,
-        10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0,
-    ]),
-    ('y', [-5.0, -4.0, -3.0, -2.0, -1.0, 0.0, 1.0, 2.0, 3.0, 4.0]),
-    ('time', [np.datetime64(datetime.date.today(), "ns")])
+    (
+        "x",
+        [
+            0.0,
+            1.0,
+            2.0,
+            3.0,
+            4.0,
+            5.0,
+            6.0,
+            7.0,
+            8.0,
+            9.0,
+            10.0,
+            11.0,
+            12.0,
+            13.0,
+            14.0,
+            15.0,
+            16.0,
+            17.0,
+            18.0,
+            19.0,
+        ],
+    ),
+    ("y", [-5.0, -4.0, -3.0, -2.0, -1.0, 0.0, 1.0, 2.0, 3.0, 4.0]),
+    ("time", [np.datetime64(datetime.date.today(), "ns")]),
 ]
 
 
@@ -33,38 +54,27 @@ def dummy_da(val, name: str, coords, attrs=None, dtype=np.float64) -> xr.DataArr
     data = np.ndarray([len(a) for n, a in coords], dtype=dtype)
     coords = dict(coords)
     data.fill(val)
-    return xr.DataArray(
-        data,
-        coords=coords,
-        dims=dims,
-        attrs=attrs,
-        name=name,
-    )
+    return xr.DataArray(data, coords=coords, dims=dims, attrs=attrs, name=name)
 
 
-def dim1_da(name: str, vals: list, coords: list, with_time: bool = True, attrs=None) -> xr.DataArray:
+def dim1_da(
+    name: str, vals: list, coords: list, with_time: bool = True, attrs=None
+) -> xr.DataArray:
     if len(vals) != len(coords):
         raise Exception("vals and coords must match len")
     if attrs is None:
         attrs = {}
     dims = ["dim"]
     shape = [len(coords)]
-    coords = {
-        'dim': coords,
-    }
+    coords = {"dim": coords}
     if with_time:
         dims.append("time")
         coords["time"] = [np.datetime64(datetime.date.today(), "ns")]
         shape.append(1)
     buff_arr = np.array(vals)
     data = np.ndarray(shape, buffer=buff_arr, dtype=buff_arr.dtype)
-    return xr.DataArray(
-        data,
-        coords=coords,
-        dims=dims,
-        attrs=attrs,
-        name=name,
-    )
+    return xr.DataArray(data, coords=coords, dims=dims, attrs=attrs, name=name)
+
 
 def dim1_da_time(name: str, vals, dates, coords, attrs=None) -> xr.DataArray:
     if len(coords) != len(vals):
@@ -74,16 +84,7 @@ def dim1_da_time(name: str, vals, dates, coords, attrs=None) -> xr.DataArray:
             raise Exception("dates and coords must match lengths")
     dims = ["dim", "time"]
     shape = [len(coords), len(dates)]
-    coords = {
-        "dim": coords,
-        "time": [np.datetime64(d, "ns") for d in dates],
-    }
+    coords = {"dim": coords, "time": [np.datetime64(d, "ns") for d in dates]}
     buff_arr = np.array(vals)
     data = np.ndarray(shape, buffer=buff_arr, dtype=buff_arr.dtype)
-    return xr.DataArray(
-        data,
-        coords=coords,
-        dims=dims,
-        attrs=attrs,
-        name=name,
-    )
+    return xr.DataArray(data, coords=coords, dims=dims, attrs=attrs, name=name)

--- a/update_ranges.py
+++ b/update_ranges.py
@@ -6,5 +6,5 @@
 
 from datacube_ows.update_ranges_impl import main
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()


### PR DESCRIPTION
Run Ruff format on everything, and put in a `.git-blame-ignore-revs` so people can avoid seeing the commit in git blame, and Github's git blame view does not show it.

This uncovered some  quadruple-quotes in doc strings, so remove that first, and then use Ruff ignores for the third-party code after I've fixed my previous misconfiguration of Ruff.

<!-- readthedocs-preview datacube-ows start -->
----
📚 Documentation preview 📚: https://datacube-ows--1261.org.readthedocs.build/en/1261/

<!-- readthedocs-preview datacube-ows end -->