### PR TITLE
CI: make twine check strict

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -105,7 +105,7 @@ jobs:
       - name: Build Packages
         run: |
           uv build
-          uv tool run twine check dist/*
+          uv tool run twine check --strict dist/*
 
       # Uses to OIDC identification between GitHub and PyPI
       - name: Upload package to PyPI on GitHub Release

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
     "xarray",
 ]
 requires-python = ">=3.10.0"
-readme = "README.md"
+readme = "README.rst"
 license = "Apache-2.0"
 keywords = ["datacube", "wms", "wcs"]
 classifiers = [


### PR DESCRIPTION
This will cause the job to fail
if there are package warnings.

<!-- readthedocs-preview datacube-ows start -->
----
📚 Documentation preview 📚: https://datacube-ows--1273.org.readthedocs.build/en/1273/

<!-- readthedocs-preview datacube-ows end -->