### PR TITLE
docker-compose: use postgis image

### DIFF
--- a/.env_simple
+++ b/.env_simple
@@ -4,16 +4,16 @@
 ################
 # ODC DB Config
 # ##############
-ODC_DEFAULT_DB_URL=postgresql://opendatacubeusername:opendatacubepassword@postgres:5432/odc_postgres
-ODC_OWSPOSTGIS_DB_URL=postgresql://opendatacubeusername:opendatacubepassword@postgres:5432/odc_postgis
+ODC_DEFAULT_DB_URL=postgresql://opendatacubeusername:opendatacubepassword@postgres:35434/odc_postgres
+ODC_OWSPOSTGIS_DB_URL=postgresql://opendatacubeusername:opendatacubepassword@postgres:35434/odc_postgis
 
 # Needed for docker db image and db readiness probe.
-POSTGRES_PORT=5432
+POSTGRES_PORT=35434
 POSTGRES_HOSTNAME=postgres
 POSTGRES_USER=opendatacubeusername
 SERVER_DB_USERNAME=opendatacubeusername
 POSTGRES_PASSWORD=opendatacubepassword
-POSTGRES_DB="odc_postgres,odc_postgis"
+POSTGRES_DB=opendatacubeusername
 
 #################
 # OWS CFG Config

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -151,7 +151,7 @@ indexing and create db dump
 
   # return to index container
   docker exec -it index_index_1 bash # if using chained docker compose the container name is datacube-ows_index_1
-  pg_dump -U localhost -p 5432 -h localhost odc > dump.sql
+  pg_dump -U localhost -p 35434 -h localhost odc > dump.sql
   # enter password on prompt: mysecretpassword or check .env file
   exit
 

--- a/README.rst
+++ b/README.rst
@@ -157,7 +157,7 @@ To run the standard Docker image, create a docker volume containing your ows con
         -e AWS_DEFAULT_REGION=ap-southeast-2 \                     # AWS Default Region (supply even if NOT accessing files on S3! See Issue #151)
         -e SENTRY_DSN=https://key@sentry.local/projid \            # Key for Sentry logging (optional)
         \ # Database connection URL: postgresql://<username>:<password>@<hostname>:<port>/<database>
-        -e ODC_DEFAULT_DB_URL=postgresql://myuser:mypassword@172.17.0.1:5432/mydb \
+        -e ODC_DEFAULT_DB_URL=postgresql://myuser:mypassword@172.17.0.1:35434/mydb \
         -e PYTHONPATH=/code                                        # The default PATH is under env, change this to target /code
         -p 8080:8000 \                                             # Publish the gunicorn port (8000) on the Docker
         \                                                          # container at port 8008 on the host machine.

--- a/complementary_config_test/.env_complementary_config_dea_dev
+++ b/complementary_config_test/.env_complementary_config_dea_dev
@@ -3,16 +3,16 @@
 ################
 # ODC DB Config
 # ##############
-ODC_DEFAULT_DB_URL=postgresql://opendatacubeusername:opendatacubepassword@postgres:5432/odc_postgres
-ODC_OWSPOSTGIS_DB_URL=postgresql://opendatacubeusername:opendatacubepassword@postgres:5432/odc_postgis
+ODC_DEFAULT_DB_URL=postgresql://opendatacubeusername:opendatacubepassword@postgres:35434/odc_postgres
+ODC_OWSPOSTGIS_DB_URL=postgresql://opendatacubeusername:opendatacubepassword@postgres:35434/odc_postgis
 
 # Needed for Docker db image and db readiness probe.
 POSTGRES_HOSTNAME=postgres
-POSTGRES_PORT=5434
+POSTGRES_PORT=35434
 POSTGRES_USER=opendatacubeusername
 SERVER_DB_USERNAME=opendatacubeusername
 POSTGRES_PASSWORD=opendatacubepassword
-POSTGRES_DB="odc_postgres,odc_postgis"
+POSTGRES_DB=opendatacubeusername
 READY_PROBE_DB=odc_postgis
 
 #################

--- a/docker-compose.cleandb.yaml
+++ b/docker-compose.cleandb.yaml
@@ -1,21 +1,23 @@
 services:
   postgres:
     # clean postgis db
-    image: kartoza/postgis:16
+    image: postgis/postgis:17-3.5
     hostname: postgres
     environment:
       - POSTGRES_DB
       - POSTGRES_PORT
+      - PGPORT=35434
       - POSTGRES_PASSWORD
       - POSTGRES_USER
     ports:
-      - "${POSTGRES_PORT}:5432"
+      - "${POSTGRES_PORT}:35434"
     restart: always
     volumes:
+      - ./docker/files/create-pg-databases.sh:/docker-entrypoint-initdb.d/create-pg-databases.sh
       - type: tmpfs
-        target: /var/lib/postgresql
+        target: /var/lib/postgresql/data
     healthcheck:
-      test: ["CMD", "pg_isready", "-h", "postgres", "-q", "-d", "$POSTGRES_DB", "-U", "$POSTGRES_USER"]
+      test: ["CMD", "pg_isready", "-h", "postgres", "-q", "--port", "35434", "-d", "$POSTGRES_DB", "-U", "$POSTGRES_USER"]
       timeout: 45s
       interval: 10s
       retries: 10
@@ -24,7 +26,7 @@ services:
     ports:
       - "8000:8000"
     environment:
-      POSTGRES_PORT: 5432
+      POSTGRES_PORT: 35434
     depends_on:
       postgres:
         condition: service_healthy

--- a/docker-compose.db.yaml
+++ b/docker-compose.db.yaml
@@ -1,20 +1,21 @@
 services:
   postgres:
-    # db
-    build: docker/database/
+    image: postgis/postgis:17-3.5
     hostname: postgres
     environment:
       - POSTGRES_DB=${POSTGRES_DB}
+      - PGPORT=35434
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
       - POSTGRES_USER=${POSTGRES_USER}
     ports:
       - "${POSTGRES_PORT}:${POSTGRES_PORT}"
     restart: always
     volumes:
+      - ./docker/files/create-pg-databases.sh:/docker-entrypoint-initdb.d/create-pg-databases.sh
       - type: tmpfs
-        target: /var/lib/postgresql
+        target: /var/lib/postgresql/data
     healthcheck:
-      test: ["CMD", "pg_isready", "-h", "postgres", "-q", "-d", "$POSTGRES_DB", "-U", "$POSTGRES_USER"]
+      test: ["CMD", "pg_isready", "-h", "postgres", "-q", "--port", "35434", "-d", "$POSTGRES_DB", "-U", "$POSTGRES_USER"]
       timeout: 45s
       interval: 10s
       retries: 10

--- a/docker-compose.index.yaml
+++ b/docker-compose.index.yaml
@@ -3,7 +3,7 @@ services:
     image: opendatacube/datacube-index:latest
     environment:
       DB_HOSTNAME: ${DB_HOSTNAME}
-      DB_PORT: 5432
+      DB_PORT: 35434
       DB_USERNAME: ${DB_USERNAME}
       DB_PASSWORD: ${DB_PASSWORD}
       DB_DATABASE: ${DB_DATABASE}

--- a/docker/database/Dockerfile
+++ b/docker/database/Dockerfile
@@ -1,1 +1,0 @@
-FROM kartoza/postgis:16

--- a/docker/files/create-pg-databases.sh
+++ b/docker/files/create-pg-databases.sh
@@ -1,0 +1,8 @@
+#!/bin/bash -e
+
+for db in "odc_postgres" "odc_postgis"; do
+  psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" <<-EOF
+    CREATE DATABASE $db;
+    GRANT ALL PRIVILEGES ON DATABASE $db TO opendatacubeusername;
+EOF
+done


### PR DESCRIPTION
This aligns the database configuration
with Explorer and datacube-core.

Also use a unique database port,
so the docker compose environments
for core, Explorer, and OWS can
run at the same time on a computer.

<!-- readthedocs-preview datacube-ows start -->
----
📚 Documentation preview 📚: https://datacube-ows--1274.org.readthedocs.build/en/1274/

<!-- readthedocs-preview datacube-ows end -->