### PR TITLE
Normalise native spec CRS

### DIFF
--- a/datacube_ows/ows_configuration.py
+++ b/datacube_ows/ows_configuration.py
@@ -696,7 +696,7 @@ class OWSNamedLayer(OWSExtensibleConfigEntry, OWSLayer):
         self.declare_unready("bboxes")
         self.band_idx = BandIndex(self, cast(CFG_DICT, cfg.get("bands")))
         self.cfg_native_resolution = cfg.get("native_resolution")
-        self.cfg_native_crs: str = cfg.get("native_crs")
+        self.cfg_native_crs = cast(str, cfg.get("native_crs"))
         self.declare_unready("resolution_x")
         self.declare_unready("resolution_y")
         self.resource_limits = OWSResourceManagementRules(
@@ -956,11 +956,11 @@ class OWSNamedLayer(OWSExtensibleConfigEntry, OWSLayer):
         if "native_crs" in cfg:
             if not self.cfg_native_crs:
                 _LOG.warning(
-                    "Specifying native_crs in wcs section of layer %s is now deprecated, pleas move to "
+                    "Specifying native_crs in wcs section of layer %s is now deprecated, please move to "
                     "main layer section if required",
                     self.name,
                 )
-                self.cfg_native_crs = cfg["native_crs"]
+                self.cfg_native_crs = cast(str, cfg["native_crs"])
             else:
                 _LOG.warning(
                     "native_crs in wcs section of layer %s ignored in favour of value in "

--- a/datacube_ows/ows_configuration.py
+++ b/datacube_ows/ows_configuration.py
@@ -29,7 +29,7 @@ from datacube import Datacube
 from datacube.api.query import GroupBy
 from datacube.cfg import ODCConfig, ODCEnvironment
 from datacube.model import Measurement, Product
-from odc.geo import CRS
+from odc.geo import CRS, CRSError
 from odc.geo.geobox import GeoBox
 from ows import Version
 from slugify import slugify
@@ -1008,7 +1008,7 @@ class OWSNamedLayer(OWSExtensibleConfigEntry, OWSLayer):
             except CRSError:
                 raise ConfigException(
                     f"Product {self.product_name} in layer {self.name} specifies an invalid CRS: {product_native_specs['crs']}"
-                )
+                ) from None
             if self.cfg_native_crs == self.native_CRS:
                 _LOG.debug(
                     "Native crs for layer %s is specified in ODC metadata and does not need to be specified in configuration",

--- a/datacube_ows/ows_configuration.py
+++ b/datacube_ows/ows_configuration.py
@@ -1002,9 +1002,8 @@ class OWSNamedLayer(OWSExtensibleConfigEntry, OWSLayer):
         )
         # Native CRS
         if product_native_specs is not None and "crs" in product_native_specs:
-            self.native_CRS = str(
-                CRS(product_native_specs["crs"])
-            )  # normalise CRS string to avoid case difference issues
+            # normalise CRS string to avoid case difference issues
+            self.native_CRS = str(CRS(product_native_specs["crs"]))
             if self.cfg_native_crs == self.native_CRS:
                 _LOG.debug(
                     "Native crs for layer %s is specified in ODC metadata and does not need to be specified in configuration",

--- a/datacube_ows/ows_configuration.py
+++ b/datacube_ows/ows_configuration.py
@@ -1002,7 +1002,7 @@ class OWSNamedLayer(OWSExtensibleConfigEntry, OWSLayer):
         )
         # Native CRS
         if product_native_specs is not None and "crs" in product_native_specs:
-            self.native_CRS = product_native_specs["crs"]
+            self.native_CRS = str(CRS(product_native_specs["crs"]))  # normalise CRS string to avoid case difference issues
             if self.cfg_native_crs == self.native_CRS:
                 _LOG.debug(
                     "Native crs for layer %s is specified in ODC metadata and does not need to be specified in configuration",

--- a/datacube_ows/ows_configuration.py
+++ b/datacube_ows/ows_configuration.py
@@ -696,7 +696,7 @@ class OWSNamedLayer(OWSExtensibleConfigEntry, OWSLayer):
         self.declare_unready("bboxes")
         self.band_idx = BandIndex(self, cast(CFG_DICT, cfg.get("bands")))
         self.cfg_native_resolution = cfg.get("native_resolution")
-        self.cfg_native_crs = cfg.get("native_crs")
+        self.cfg_native_crs: str = cfg.get("native_crs")
         self.declare_unready("resolution_x")
         self.declare_unready("resolution_y")
         self.resource_limits = OWSResourceManagementRules(
@@ -1003,7 +1003,10 @@ class OWSNamedLayer(OWSExtensibleConfigEntry, OWSLayer):
         # Native CRS
         if product_native_specs is not None and "crs" in product_native_specs:
             # normalise CRS string to avoid case difference issues
-            self.native_CRS = str(CRS(product_native_specs["crs"]))
+            try:
+                self.native_CRS = str(CRS(product_native_specs["crs"]))
+            except CRSError:
+                raise ConfigException(f"Product {self.product_name} in layer {self.name} specifies an invalid CRS: {product_native_specs['crs']}")
             if self.cfg_native_crs == self.native_CRS:
                 _LOG.debug(
                     "Native crs for layer %s is specified in ODC metadata and does not need to be specified in configuration",
@@ -1245,7 +1248,7 @@ class OWSNamedLayer(OWSExtensibleConfigEntry, OWSLayer):
         if not geobox:
             bbox = self.ranges.bboxes[self.native_CRS]
             geobox = create_geobox(
-                self.native_CRS,
+                CRS(self.native_CRS),
                 bbox["left"],
                 bbox["bottom"],
                 bbox["right"],

--- a/datacube_ows/ows_configuration.py
+++ b/datacube_ows/ows_configuration.py
@@ -1006,7 +1006,9 @@ class OWSNamedLayer(OWSExtensibleConfigEntry, OWSLayer):
             try:
                 self.native_CRS = str(CRS(product_native_specs["crs"]))
             except CRSError:
-                raise ConfigException(f"Product {self.product_name} in layer {self.name} specifies an invalid CRS: {product_native_specs['crs']}")
+                raise ConfigException(
+                    f"Product {self.product_name} in layer {self.name} specifies an invalid CRS: {product_native_specs['crs']}"
+                )
             if self.cfg_native_crs == self.native_CRS:
                 _LOG.debug(
                     "Native crs for layer %s is specified in ODC metadata and does not need to be specified in configuration",

--- a/datacube_ows/ows_configuration.py
+++ b/datacube_ows/ows_configuration.py
@@ -1002,7 +1002,9 @@ class OWSNamedLayer(OWSExtensibleConfigEntry, OWSLayer):
         )
         # Native CRS
         if product_native_specs is not None and "crs" in product_native_specs:
-            self.native_CRS = str(CRS(product_native_specs["crs"]))  # normalise CRS string to avoid case difference issues
+            self.native_CRS = str(
+                CRS(product_native_specs["crs"])
+            )  # normalise CRS string to avoid case difference issues
             if self.cfg_native_crs == self.native_CRS:
                 _LOG.debug(
                     "Native crs for layer %s is specified in ODC metadata and does not need to be specified in configuration",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -68,7 +68,7 @@ def minimal_dc():
         if "nonativecrs" in s:
             pass
         elif "badnativecrs" in s:
-            mprod.definition["storage"]["crs"] = "EPSG:9999"
+            mprod.definition["storage"]["crs"] = "EPSG:32756"
         elif "nativecrs" in s:
             mprod.definition["storage"]["crs"] = "EPSG:4326"
         else:

--- a/tests/test_cfg_layer.py
+++ b/tests/test_cfg_layer.py
@@ -800,8 +800,8 @@ def test_native_crs_unpublished(
         "EPSG": {"top": 1, "bottom": -1, "left": -1, "right": 1}
     }
     with pytest.raises(ConfigException) as excinfo:
-        lyr.make_ready(minimal_dc)
-    assert "EPSG:9999" in str(excinfo.value)
+        lyr.make_ready(minimal_dc)  # getting CRSError (originating l.1006)
+    assert "EPSG:32756" in str(excinfo.value)
     assert "a_layer" in str(excinfo.value)
     assert "not in published CRSs" in str(excinfo.value)
 


### PR DESCRIPTION
The logic for retrieving `self.native_CRS_def` is case-sensitive, meaning that if a product spec defines its CRS in lowercase, it is not found amongst the published CRSs, raising a `ConfigException`.
Normalise the product spec CRS string with `odc.geo.CRS` to avoid this issue (it may also be worth normalising the values retrieved from the config).

<!-- readthedocs-preview datacube-ows start -->
----
📚 Documentation preview 📚: https://datacube-ows--1298.org.readthedocs.build/en/1298/

<!-- readthedocs-preview datacube-ows end -->