### PR TITLE
CI: fetch tags for release

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,6 +54,7 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 0
+          fetch-tags: true
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1


### PR DESCRIPTION
The tags are required for setuptools-scm
to figure out the right version.

I don't know if uploading to PyPi worked
in the previous workflow, but I broke it
when I migrated the task to this workflow.

<!-- readthedocs-preview datacube-ows start -->
----
📚 Documentation preview 📚: https://datacube-ows--1320.org.readthedocs.build/en/1320/

<!-- readthedocs-preview datacube-ows end -->