### PR TITLE
Update to latest Sphinx

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,8 @@ Homepage = "https://github.com/opendatacube/datacube-ows"
 
 [dependency-groups]
 doc = [
-    "Sphinx",
+    "Sphinx>=8.1.3; python_version<'3.11'",
+    "Sphinx>=8.2.3; python_version>='3.11'",
     "sphinx-click",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,9 @@ classifiers = [
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
 ]
 
 [project.urls]

--- a/uv.lock
+++ b/uv.lock
@@ -989,7 +989,8 @@ provides-extras = ["dev", "ops", "postgres", "setup", "test", "all"]
 
 [package.metadata.requires-dev]
 doc = [
-    { name = "sphinx" },
+    { name = "sphinx", marker = "python_full_version < '3.11'", specifier = ">=8.1.3" },
+    { name = "sphinx", marker = "python_full_version >= '3.11'", specifier = ">=8.2.3" },
     { name = "sphinx-click" },
 ]
 


### PR DESCRIPTION
Sphinx 8.2 dropped support for
Python 3.10, so use the latest
8.1.x release with Python 3.10,
and a more recent 8.2+ release
with Python 3.11+.

<!-- readthedocs-preview datacube-ows start -->
----
📚 Documentation preview 📚: https://datacube-ows--1335.org.readthedocs.build/en/1335/

<!-- readthedocs-preview datacube-ows end -->