### PR TITLE
pyproject: use datacube < 1.10.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
     "affine",
     "antimeridian",
     "click",
-    "datacube[performance,s3]>=1.9.10",
+    "datacube[performance,s3]>=1.9.10,<1.10.0",
     "deepdiff",
     "flask",
     "fsspec",

--- a/uv.lock
+++ b/uv.lock
@@ -934,7 +934,7 @@ requires-dist = [
     { name = "babel" },
     { name = "blinker", marker = "extra == 'ops'" },
     { name = "click" },
-    { name = "datacube", extras = ["performance", "s3"], specifier = ">=1.9.10" },
+    { name = "datacube", extras = ["performance", "s3"], specifier = ">=1.9.10,<1.10.0" },
     { name = "datacube-ows", extras = ["dev", "ops", "test"], marker = "extra == 'all'" },
     { name = "deepdiff" },
     { name = "flask" },


### PR DESCRIPTION
This will keep the package working
even after the next API breaking
datacube version is released.

<!-- readthedocs-preview datacube-ows start -->
----
📚 Documentation preview 📚: https://datacube-ows--1340.org.readthedocs.build/en/1340/

<!-- readthedocs-preview datacube-ows end -->