### PR TITLE
CI: use anchors for branches & paths

### DIFF
--- a/.github/workflows/complementary-config-test.yaml
+++ b/.github/workflows/complementary-config-test.yaml
@@ -3,10 +3,10 @@ name: Complementary config test
 
 on:
   pull_request:
-    branches:
+    branches: &branches
       - 'develop-1.9'
       - 'develop'
-    paths:
+    paths: &paths
       - '**'
       - '!docs/**'
       - '!*.rst'
@@ -16,17 +16,8 @@ on:
       - '.github/workflows/complementary-config-test.yaml'
 
   push:
-    branches:
-      - 'develop-1.9'
-      - 'develop'
-    paths:
-      - '**'
-      - '!docs/**'
-      - '!*.rst'
-      - '!*.md'
-      - '!datacube_ows/__init__.py'
-      - '!.github/**'
-      - '.github/workflows/complementary-config-test.yaml'
+    branches: *branches
+    paths: *paths
 
 env:
   DOCKER_IMAGE: ghcr.io/opendatacube/ows:tests

--- a/.github/workflows/dockerfile-lint.yml
+++ b/.github/workflows/dockerfile-lint.yml
@@ -3,19 +3,16 @@ name: dockerfile Linting
 
 on:
   pull_request:
-    branches:
+    branches: &branches
       - 'develop'
       - 'develop-1.9'
-    paths:
+    paths: &paths
       - 'Dockerfile'
       - '.github/workflows/dockerfile-lint.yml'
 
   push:
-    branches:
-      - 'develop'
-    paths:
-      - 'Dockerfile'
-      - '.github/workflows/dockerfile-lint.yml'
+    branches: *branches
+    paths: *paths
 
 permissions: {}
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,10 +3,10 @@ name: Code Linting
 
 on:
   pull_request:
-    branches:
+    branches: &branches
       - 'develop'
       - 'develop-1.9'
-    paths:
+    paths: &paths
       - '**'
       - '!docs/**'
       - '!*.rst'
@@ -16,17 +16,8 @@ on:
       - '.github/workflows/lint.yml'
 
   push:
-    branches:
-      - 'develop'
-      - 'develop-1.9'
-    paths:
-      - '**'
-      - '!docs/**'
-      - '!*.rst'
-      - '!*.md'
-      - '!datacube_ows/__init__.py'
-      - '!.github/**'
-      - '.github/workflows/lint.yml'
+    branches: *branches
+    paths: *paths
 
 permissions: {}
 

--- a/.github/workflows/pyspy-profiling.yaml
+++ b/.github/workflows/pyspy-profiling.yaml
@@ -3,10 +3,10 @@ name: Pyspy Profiling Test
 
 on:
   pull_request:
-    branches:
+    branches: &branches
       - 'develop'
       - 'develop-1.9'
-    paths:
+    paths: &paths
       - '**'
       - '!docs/**'
       - '!*.rst'
@@ -16,17 +16,8 @@ on:
       - '.github/workflows/pyspy-profiling.yaml'
 
   push:
-    branches:
-      - 'develop'
-      - 'develop-1.9'
-    paths:
-      - '**'
-      - '!docs/**'
-      - '!*.rst'
-      - '!*.md'
-      - '!datacube_ows/__init__.py'
-      - '!.github/**'
-      - '.github/workflows/pyspy-profiling.yaml'
+    branches: *branches
+    paths: *paths
 
 env:
   DOCKER_IMAGE: ghcr.io/opendatacube/ows:tests

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -3,20 +3,16 @@ name: Scan
 
 on:
   push:
-    branches:
+    branches: &branches
       - develop
       - develop-1.9
-    paths:
+    paths: &paths
       - ".github/workflows/scan.yml"
       - "Dockerfile"
 
   pull_request:
-    branches:
-      - develop
-      - develop-1.9
-    paths:
-      - ".github/workflows/scan.yml"
-      - "Dockerfile"
+    branches: *branches
+    paths: *paths
 
   schedule:
     - cron: '0 0 * * *'

--- a/.github/workflows/spellcheck.yaml
+++ b/.github/workflows/spellcheck.yaml
@@ -3,25 +3,18 @@ name: Spell check
 
 on:
   pull_request:
-    branches:
+    branches: &branches
       - 'develop'
       - 'develop-1.9'
-    paths:
+    paths: &paths
       - 'docs/**'
       - '*.md'
       - '*.rst'
       - '.github/workflows/spellcheck.yaml'
-
 
   push:
-    branches:
-      - 'develop'
-      - 'develop-1.9'
-    paths:
-      - 'docs/**'
-      - '*.md'
-      - '*.rst'
-      - '.github/workflows/spellcheck.yaml'
+    branches: *branches
+    paths: *paths
 
 permissions: {}
 

--- a/.github/workflows/test-prod.yaml
+++ b/.github/workflows/test-prod.yaml
@@ -3,10 +3,10 @@ name: Prod dockercompose test
 
 on:
   pull_request:
-    branches:
+    branches: &branches
       - 'develop'
       - 'develop-1.9'
-    paths:
+    paths: &paths
       - '**'
       - '!docs/**'
       - '!*.rst'
@@ -16,17 +16,8 @@ on:
       - '.github/workflows/test-prod.yaml'
 
   push:
-    branches:
-      - 'develop'
-      - 'develop-1.9'
-    paths:
-      - '**'
-      - '!docs/**'
-      - '!*.rst'
-      - '!*.md'
-      - '!datacube_ows/__init__.py'
-      - '!.github/**'
-      - '.github/workflows/test-prod.yaml'
+    branches: *branches
+    paths: *paths
 
 env:
   DOCKER_IMAGE: ghcr.io/opendatacube/ows:tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,10 +3,10 @@ name: Tests
 
 on:
   pull_request:
-    branches:
+    branches: &branches
       - 'develop'
       - 'develop-1.9'
-    paths:
+    paths: &paths
       - '**'
       - '!docs/**'
       - '!*.rst'
@@ -16,17 +16,8 @@ on:
       - '.github/workflows/test.yml'
 
   push:
-    branches:
-      - 'develop'
-      - 'develop-1.9'
-    paths:
-      - '**'
-      - '!docs/**'
-      - '!*.rst'
-      - '!*.md'
-      - '!datacube_ows/__init__.py'
-      - '!.github/**'
-      - '.github/workflows/test.yml'
+    branches: *branches
+    paths: *paths
 
   release:
     types:


### PR DESCRIPTION
The branch list and path list are meant
to be identical, so use the new yaml
anchors to ensure that.

<!-- readthedocs-preview datacube-ows start -->
----
📚 Documentation preview 📚: https://datacube-ows--1344.org.readthedocs.build/en/1344/

<!-- readthedocs-preview datacube-ows end -->