### PR TITLE
update_ranges_impl: catch OWSConfigNotReady

### DIFF
--- a/datacube_ows/update_ranges_impl.py
+++ b/datacube_ows/update_ranges_impl.py
@@ -13,6 +13,7 @@ import sqlalchemy
 from datacube import Datacube
 
 from datacube_ows import __version__
+from datacube_ows.config_utils import OWSConfigNotReady
 from datacube_ows.index import AbortRun, LayerSignature, ows_index
 from datacube_ows.ows_configuration import OWSConfig, get_config
 from datacube_ows.startup_utils import initialise_debugging
@@ -221,6 +222,9 @@ def main(
             sys.exit(1)
         else:
             raise e
+    except OWSConfigNotReady as e:
+        click.echo(f"ERROR: {e}", err=True)
+        sys.exit(1)
     if errors:
         sys.exit(1)
 


### PR DESCRIPTION
Print the error message from the exception
instead of a long backtrace.

<!-- readthedocs-preview datacube-ows start -->
----
📚 Documentation preview 📚: https://datacube-ows--1348.org.readthedocs.build/en/1348/

<!-- readthedocs-preview datacube-ows end -->