### PR TITLE
Updates fail cleanly on misconfigured layers.

### DIFF
--- a/datacube_ows/ows_configuration.py
+++ b/datacube_ows/ows_configuration.py
@@ -1093,7 +1093,7 @@ class OWSNamedLayer(OWSExtensibleConfigEntry, OWSLayer):
         if self.global_cfg.wcs and self.wcs:
             # Prepare Rectified Grids
             try:
-                native_bounding_box = self.bboxes[self.native_CRS]
+                native_bounding_box = cast(dict[str, int | float], self.bboxes[self.native_CRS])
             except KeyError:
                 if not self.global_cfg.called_from_update_ranges:
                     _LOG.warning(
@@ -1154,7 +1154,7 @@ class OWSNamedLayer(OWSExtensibleConfigEntry, OWSLayer):
                     }
                 else:
                     try:
-                        bbox = self.bboxes[crs]
+                        bbox = cast(dict[str, int | float], self.bboxes[crs])
                     except KeyError:
                         continue
                     self.grids[crs] = {

--- a/datacube_ows/ows_configuration.py
+++ b/datacube_ows/ows_configuration.py
@@ -1093,7 +1093,9 @@ class OWSNamedLayer(OWSExtensibleConfigEntry, OWSLayer):
         if self.global_cfg.wcs and self.wcs:
             # Prepare Rectified Grids
             try:
-                native_bounding_box = cast(dict[str, int | float], self.bboxes[self.native_CRS])
+                native_bounding_box = cast(
+                    dict[str, int | float], self.bboxes[self.native_CRS]
+                )
             except KeyError:
                 if not self.global_cfg.called_from_update_ranges:
                     _LOG.warning(

--- a/datacube_ows/ows_configuration.py
+++ b/datacube_ows/ows_configuration.py
@@ -794,7 +794,7 @@ class OWSNamedLayer(OWSExtensibleConfigEntry, OWSLayer):
                 self.low_res_products.append(product)
         self.product = self.products[0]
         self.definition = self.product.definition
-        self.force_range_update()
+        ranges_ok = self.force_range_update()
         self.band_idx.make_ready()
         self.resource_limits.make_ready()
         self.all_flag_band_names: set[str] = set()
@@ -816,6 +816,10 @@ class OWSNamedLayer(OWSExtensibleConfigEntry, OWSLayer):
 
         if not self.hide:
             super().make_ready(*args, **kwargs)
+
+        if not ranges_ok:
+            # Hide layers that are ready except that no ranges are available.
+            self.hide = True
 
     # pylint: disable=attribute-defined-outside-init
     def parse_image_processing(self, cfg: CFG_DICT) -> None:
@@ -1167,8 +1171,7 @@ class OWSNamedLayer(OWSExtensibleConfigEntry, OWSLayer):
     def parse_pq_names(self, cfg: CFG_DICT):
         raise NotImplementedError()
 
-    def force_range_update(self) -> None:
-        self.hide = False
+    def force_range_update(self) -> bool:
         try:
             self._ranges = self.ows_index().get_ranges(self)
             if self._ranges is None:
@@ -1191,13 +1194,13 @@ class OWSNamedLayer(OWSExtensibleConfigEntry, OWSLayer):
                 self.default_time = self._ranges.end_time
             else:
                 self.default_time = self._ranges.end_time
-
+            return True
         # pylint: disable=broad-except
         except Exception as a:
             if not self.global_cfg.called_from_update_ranges:
                 _LOG.warning("get_ranges failed for layer %s: %s", self.name, str(a))
-            self.hide = True
             self.bboxes = {}
+            return False
 
     def time_range(
         self, ranges: Optional["LayerExtent"] = None
@@ -1219,7 +1222,10 @@ class OWSNamedLayer(OWSExtensibleConfigEntry, OWSLayer):
     @property
     def ranges(self) -> "LayerExtent":
         if self.dynamic:
-            self.force_range_update()
+            ranges_ok = self.force_range_update()
+        if not ranges_ok:
+            self.hide = True
+            raise ConfigException(f"No ranges found for layer {self.name}")
         assert self._ranges is not None  # For type checker
         return self._ranges
 

--- a/datacube_ows/ows_configuration.py
+++ b/datacube_ows/ows_configuration.py
@@ -1223,9 +1223,9 @@ class OWSNamedLayer(OWSExtensibleConfigEntry, OWSLayer):
     def ranges(self) -> "LayerExtent":
         if self.dynamic:
             ranges_ok = self.force_range_update()
-        if not ranges_ok:
-            self.hide = True
-            raise ConfigException(f"No ranges found for layer {self.name}")
+            if not ranges_ok:
+                self.hide = True
+                raise ConfigException(f"No ranges found for layer {self.name}")
         assert self._ranges is not None  # For type checker
         return self._ranges
 

--- a/datacube_ows/ows_configuration.py
+++ b/datacube_ows/ows_configuration.py
@@ -695,9 +695,9 @@ class OWSNamedLayer(OWSExtensibleConfigEntry, OWSLayer):
 
         self.dynamic = cfg.get("dynamic", False)
 
-        self.declare_unready("default_time")
-        self.declare_unready("_ranges")
-        self.declare_unready("bboxes")
+        self._ranges: LayerExtent | None = None
+        self.bboxes: CFG_DICT = {}
+        self.default_time: datetime.datetime | datetime.date | None = None
         self.band_idx = BandIndex(self, cast(CFG_DICT, cfg.get("bands")))
         self.cfg_native_resolution = cfg.get("native_resolution")
         self.cfg_native_crs = cast(str, cfg.get("native_crs"))
@@ -819,6 +819,7 @@ class OWSNamedLayer(OWSExtensibleConfigEntry, OWSLayer):
 
         if not ranges_ok:
             # Hide layers that are ready except that no ranges are available.
+            _LOG.warning("Layer %s is ready but no ranges are available.", self.name)
             self.hide = True
 
     # pylint: disable=attribute-defined-outside-init
@@ -980,11 +981,11 @@ class OWSNamedLayer(OWSExtensibleConfigEntry, OWSLayer):
         self.declare_unready("native_CRS_def")
 
         # Rectified Grids
-        self.declare_unready("origin_x")
-        self.declare_unready("origin_y")
-        self.declare_unready("grid_high_x")
-        self.declare_unready("grid_high_y")
-        self.declare_unready("grids")
+        self.origin_x: int | float = 0
+        self.origin_y: int | float = 0
+        self.grid_high_x: int | float = 0
+        self.grid_high_y: int | float = 0
+        self.grids: dict = {}
         # Band management
         if cfg.get("default_bands"):
             _LOG.warning(
@@ -1100,7 +1101,6 @@ class OWSNamedLayer(OWSExtensibleConfigEntry, OWSLayer):
                         self.name,
                         self.native_CRS,
                     )
-                self.hide = True
                 return
             self.origin_x = native_bounding_box["left"]
             self.origin_y = native_bounding_box["bottom"]
@@ -1175,7 +1175,7 @@ class OWSNamedLayer(OWSExtensibleConfigEntry, OWSLayer):
         try:
             self._ranges = self.ows_index().get_ranges(self)
             if self._ranges is None:
-                raise Exception("Null product range")
+                return False
             self.bboxes = self.extract_bboxes()
             if self.default_time_rule == DEF_TIME_EARLIEST:
                 self.default_time = self._ranges.start_time

--- a/datacube_ows/update_ranges_impl.py
+++ b/datacube_ows/update_ranges_impl.py
@@ -252,7 +252,7 @@ def add_ranges(cfg: OWSConfig, layer_names: list[str]) -> bool:
             errors = True
             continue
         layer = cfg.layer_index[name]
-        if layer.hide or not layer.ready:
+        if layer.hide and not layer.ready:
             click.echo(
                 f"Layer '{name}' cannot currently be loaded - skipping"
             )

--- a/datacube_ows/update_ranges_impl.py
+++ b/datacube_ows/update_ranges_impl.py
@@ -252,7 +252,7 @@ def add_ranges(cfg: OWSConfig, layer_names: list[str]) -> bool:
             errors = True
             continue
         layer = cfg.layer_index[name]
-        if layer.hide and not layer.ready:
+        if not layer.ready:
             click.echo(f"Layer '{name}' cannot currently be loaded - skipping")
             errors = True
             continue

--- a/datacube_ows/update_ranges_impl.py
+++ b/datacube_ows/update_ranges_impl.py
@@ -252,6 +252,12 @@ def add_ranges(cfg: OWSConfig, layer_names: list[str]) -> bool:
             errors = True
             continue
         layer = cfg.layer_index[name]
+        if layer.hide or not layer.ready:
+            click.echo(
+                f"Layer '{name}' cannot currently be loaded - skipping"
+            )
+            errors = True
+            continue
         layer.ows_index().create_range_entry(layer, cache)
 
     click.echo("Done.")

--- a/datacube_ows/update_ranges_impl.py
+++ b/datacube_ows/update_ranges_impl.py
@@ -253,9 +253,7 @@ def add_ranges(cfg: OWSConfig, layer_names: list[str]) -> bool:
             continue
         layer = cfg.layer_index[name]
         if layer.hide and not layer.ready:
-            click.echo(
-                f"Layer '{name}' cannot currently be loaded - skipping"
-            )
+            click.echo(f"Layer '{name}' cannot currently be loaded - skipping")
             errors = True
             continue
         layer.ows_index().create_range_entry(layer, cache)

--- a/integration_tests/cfg/ows_test_cfg.py
+++ b/integration_tests/cfg/ows_test_cfg.py
@@ -932,7 +932,44 @@ ows_cfg = {
                             "abstract": """Deliberately broken layer - should be silently ignored
                                         """,
                             "product_name": "spaghetti_gateaux",
-                            "low_res_product_name": "spaghetti_geteaux_mosaic",
+                            "low_res_product_name": "spaghetti_gateaux_mosaic",
+                            "bands": bands_sentinel2_ard_nbart,
+                            "resource_limits": reslim_for_sentinel2,
+                            "native_crs": "EPSG:3577",
+                            "native_resolution": [10.0, -10.0],
+                            "image_processing": {
+                                "extent_mask_func": "datacube_ows.ogc_utils.mask_by_val",
+                                "always_fetch_bands": [],
+                                "manual_merge": False,
+                            },
+                            "flags": [
+                                {
+                                    "band": "fmask_alias",
+                                    "product": "spaghetti_gateaux",
+                                    "ignore_time": False,
+                                    "ignore_info_flags": [],
+                                },
+                                {
+                                    "band": "land",
+                                    "product": "spaghetti_gateaux",
+                                    "ignore_time": True,
+                                    "ignore_info_flags": [],
+                                },
+                            ],
+                            "time_axis": {"time_interval": 1},
+                            "styling": {
+                                "default_style": "ndci",
+                                "styles": styles_s2_ga_list,
+                            },
+                        },
+                        {
+                            "title": "A Broken Postgis Layer",
+                            "name": "broken_layer_postgis",
+                            "abstract": """Deliberately broken postgis layer - should be silently ignored
+                                        """,
+                            "product_name": "spaghetti_gateaux",
+                            "low_res_product_name": "spaghetti_gateaux_mosaic",
+                            "env": "owspostgis",
                             "bands": bands_sentinel2_ard_nbart,
                             "resource_limits": reslim_for_sentinel2,
                             "native_crs": "EPSG:3577",

--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -106,8 +106,13 @@ def representative_bbox(
 
 
 @pytest.fixture
-def product_name() -> str:
+def layer_name() -> str:
     return "s2_l2a"
+
+
+@pytest.fixture
+def postgis_layer_name() -> str:
+    return "s2_l2a_postgis"
 
 
 @pytest.fixture

--- a/integration_tests/test_i18n.py
+++ b/integration_tests/test_i18n.py
@@ -27,11 +27,11 @@ def test_wcs1_i18n(ows_server) -> None:
     assert "German translation" in resp.text
 
 
-def test_wcs1_bands_i18n(ows_server, product_name: str) -> None:
+def test_wcs1_bands_i18n(ows_server, layer_name: str) -> None:
     resp = retrying_requests.get(
         ows_server.url
         + "/wcs?request=DescribeCoverage&service=WCS&version=1.0.0&coverageid="
-        + product_name,
+        + layer_name,
         timeout=10,
         headers={"Accept-Language": "de"},
     )
@@ -49,11 +49,11 @@ def test_wcs2_i18n(ows_server) -> None:
     assert "German translation" in resp.text
 
 
-def test_wcs2_bands_i18n(ows_server, product_name: str) -> None:
+def test_wcs2_bands_i18n(ows_server, layer_name: str) -> None:
     resp = retrying_requests.get(
         ows_server.url
         + "/wcs?request=DescribeCoverage&service=WCS&version=2.0.1&coverageid="
-        + product_name,
+        + layer_name,
         timeout=10,
         headers={"Accept-Language": "de"},
     )

--- a/integration_tests/test_layers.py
+++ b/integration_tests/test_layers.py
@@ -80,7 +80,7 @@ def test_metadata_file_ignore(monkeypatch) -> None:
         OWSConfig._msg_src = cached_catalog
 
 
-def test_metadata_read(monkeypatch, product_name: str) -> None:
+def test_metadata_read(monkeypatch, layer_name: str) -> None:
     cached_cfg = OWSConfig._instance
     monkeypatch.chdir(src_dir)
     try:
@@ -98,7 +98,7 @@ def test_metadata_read(monkeypatch, product_name: str) -> None:
         assert "Over-ridden" in folder.abstract
         assert "bunny-rabbit" in folder.abstract
 
-        lyr = cfg.layer_index[product_name]
+        lyr = cfg.layer_index[layer_name]
         assert "Over-ridden" in lyr.title
         assert "chook" in lyr.title
 

--- a/integration_tests/test_update_ranges.py
+++ b/integration_tests/test_update_ranges.py
@@ -30,6 +30,11 @@ def test_update_ranges_cleanup(runner) -> None:
     assert "Insufficient Privileges" not in result.output
     assert "Cannot find SQL resource" not in result.output
     assert result.exit_code == 0, f"Output: {result.output}"
+    result = runner.invoke(main, ["-E", "owspostgis", "--cleanup"])
+    assert "appear to be missing" not in result.output
+    assert "Insufficient Privileges" not in result.output
+    assert "Cannot find SQL resource" not in result.output
+    assert result.exit_code == 0, f"Output: {result.output}"
 
 
 def test_update_ranges_views(runner) -> None:
@@ -46,13 +51,19 @@ def test_update_version(runner) -> None:
     assert result.exit_code == 0, f"Output: {result.output}"
 
 
-def test_update_ranges_product(runner, product_name: str) -> None:
-    result = runner.invoke(main, [product_name])
+def test_update_ranges_postgres_layer(runner, layer_name: str) -> None:
+    result = runner.invoke(main, [layer_name])
     assert "ERROR" not in result.output
     assert result.exit_code == 0, f"Output: {result.output}"
 
 
-def test_update_ranges_bad_product(runner, product_name: str) -> None:
+def test_update_ranges_postgis_layer(runner, postgis_layer_name: str) -> None:
+    result = runner.invoke(main, [postgis_layer_name])
+    assert "ERROR" not in result.output
+    assert result.exit_code == 0, f"Output: {result.output}"
+
+
+def test_update_ranges_bad_product(runner) -> None:
     result = runner.invoke(main, ["not_a_real_product_name"])
     assert "not_a_real_product_name" in result.output
     assert "does not exist in the OWS configuration - skipping" in result.output

--- a/integration_tests/test_wms_server.py
+++ b/integration_tests/test_wms_server.py
@@ -150,14 +150,14 @@ def test_wms_getmap(ows_server) -> None:
         assert img.info()["Content-Type"] == "image/png"
 
 
-def test_wms_getmap_requests(ows_server, product_name: str) -> None:
+def test_wms_getmap_requests(ows_server, layer_name: str) -> None:
     resp = retrying_requests.get(
         ows_server.url + "/wms",
         params={
             "service": "WMS",
             "version": "1.3.0",
             "request": "GetMap",
-            "layers": product_name,
+            "layers": layer_name,
             "width": "150",
             "height": "150",
             "crs": "EPSG:4326",
@@ -212,14 +212,14 @@ def test_wms_getmap_bad_requests(ows_server) -> None:
     assert "Layer not_a_real_layer is not defined" in resp.text
 
 
-def test_wms_getmap_qprof(ows_server, product_name: str) -> None:
+def test_wms_getmap_qprof(ows_server, layer_name: str) -> None:
     resp = retrying_requests.get(
         ows_server.url + "/wms",
         params={
             "service": "WMS",
             "version": "1.3.0",
             "request": "GetMap",
-            "layers": product_name,
+            "layers": layer_name,
             "width": "150",
             "height": "150",
             "crs": "EPSG:4326",
@@ -355,10 +355,10 @@ def test_wms_getfeatureinfo(ows_server) -> None:
             assert response.info()["Content-Type"] == "text/html"
 
 
-def test_custom_feature_info(ows_server, product_name: str) -> None:
+def test_custom_feature_info(ows_server, layer_name: str) -> None:
     wms = WebMapService(url=ows_server.url + "/wms", version="1.3.0", timeout=300)
 
-    test_layer = wms.contents[product_name]
+    test_layer = wms.contents[layer_name]
     query_times = ["2021-12-21T02:01:19", "2021-12-26T02:01:29"]
     bbox = test_layer.boundingBoxWGS84
     response = retrying_requests.get(
@@ -367,7 +367,7 @@ def test_custom_feature_info(ows_server, product_name: str) -> None:
             "service": "WMS",
             "version": "1.3.0",
             "request": "GetFeatureInfo",
-            "query_layers": product_name,
+            "query_layers": layer_name,
             "width": "256",
             "height": "256",
             "crs": "EPSG:4326",


### PR DESCRIPTION
1. Allow layers to be "ready" but "hidden" when no range data is available (i.e. datacube-ows-update has not been run since the layers are created.
2. Check layers are "ready" before updating, preventing crashes on layers with products that don't exist in the ODC index.

Fixes: #1354


<!-- readthedocs-preview datacube-ows start -->
----
📚 Documentation preview 📚: https://datacube-ows--1356.org.readthedocs.build/en/1356/

<!-- readthedocs-preview datacube-ows end -->