### PR TITLE
config_utils: fix typo in doc string

### DIFF
--- a/datacube_ows/config_utils.py
+++ b/datacube_ows/config_utils.py
@@ -190,7 +190,7 @@ class OWSConfigEntry:
 
         Handles unready attributes for two-phase intitialisation and stows the raw configuration away.
 
-        :param cfg: The congfiguration being parsed
+        :param cfg: The configuration being parsed
         :param args:
         :param kwargs:
         """


### PR DESCRIPTION


<!-- readthedocs-preview datacube-ows start -->
----
📚 Documentation preview 📚: https://datacube-ows--1357.org.readthedocs.build/en/1357/

<!-- readthedocs-preview datacube-ows end -->