### PR TITLE
tests: sync po files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,9 @@ repos:
     hooks:
     -   id: check-yaml
     -   id: end-of-file-fixer
+        exclude: '^integration_tests/cfg/translations/'
     -   id: trailing-whitespace
+        exclude: '^integration_tests/cfg/translations/'
 -   repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.14.6
     hooks:

--- a/integration_tests/cfg/translations/de/LC_MESSAGES/ows_cfg.po
+++ b/integration_tests/cfg/translations/de/LC_MESSAGES/ows_cfg.po
@@ -32,3 +32,4 @@ msgstr "Simple RGB"
 
 msgid "layer.s2_l2a.bands.B03"
 msgstr "gruen"
+

--- a/integration_tests/cfg/translations/en/LC_MESSAGES/ows_cfg.po
+++ b/integration_tests/cfg/translations/en/LC_MESSAGES/ows_cfg.po
@@ -31,3 +31,4 @@ msgstr "Simple RGB"
 
 msgid "layer.s2_l2a.bands.B03"
 msgstr "greenish"
+


### PR DESCRIPTION
I get these changes locally after running
the tests in the Docker container.

<!-- readthedocs-preview datacube-ows start -->
----
📚 Documentation preview 📚: https://datacube-ows--1360.org.readthedocs.build/en/1360/

<!-- readthedocs-preview datacube-ows end -->