### PR TITLE
Fix mosaic date stacking order

### DIFF
--- a/datacube_ows/feature_info.py
+++ b/datacube_ows/feature_info.py
@@ -231,7 +231,14 @@ def feature_info(args: dict[str, str]) -> FlaskResponse:
 
                 # Get accurate timestamp from dataset
                 assert ds.time is not None  # For type checker
-                if params.layer.time_resolution.is_summary():
+                if params.layer.mosaic_date_func is not None:
+                    start, end = params.layer.mosaic_date_func(
+                        params.layer.ranges.times
+                    )
+                    date_info["time"] = (
+                        start.strftime("%Y-%m-%d") + " - " + end.strftime("%Y-%m-%d")
+                    )
+                elif params.layer.time_resolution.is_summary():
                     date_info["time"] = ds.time.begin.strftime("%Y-%m-%d")
                 else:
                     date_info["time"] = dataset_center_time(ds).strftime(
@@ -295,7 +302,9 @@ def feature_info(args: dict[str, str]) -> FlaskResponse:
                 if ds.extent and ds.extent.contains(pt_native):
                     # tolist() converts a numpy datetime64 to a python datatime
                     dt = Timestamp(stacker.group_by.group_by_func(ds)).to_pydatetime()
-                    if params.layer.time_resolution.is_subday():
+                    if params.layer.mosaic_date_func is not None:
+                        pass
+                    elif params.layer.time_resolution.is_subday():
                         cast(
                             list[RAW_CFG], feature_json["data_available_for_dates"]
                         ).append(dt.isoformat())

--- a/datacube_ows/ogc_utils.py
+++ b/datacube_ows/ogc_utils.py
@@ -26,7 +26,7 @@ _LOG: logging.Logger = logging.getLogger(__name__)
 
 
 @deprecat(
-    reason="The 'rolling_windows_ndays' mosaicing function has moved to 'datacube.time_utils' - "
+    reason="The 'rolling_windows_ndays' mosaicing function has moved to 'datacube_ows.time_utils' - "
     "please import it from there.",
     version="1.9.0",
 )

--- a/datacube_ows/utils.py
+++ b/datacube_ows/utils.py
@@ -16,6 +16,7 @@ from datacube import Datacube
 from datacube.api.query import GroupBy, solar_day
 from datacube.model import Dataset
 from numpy import datetime64 as npdt64
+from numpy import timedelta64 as npdelt64
 from sqlalchemy.engine.base import Connection
 
 F = TypeVar("F", bound=Callable[..., Any])
@@ -115,20 +116,29 @@ def group_by_solar(pnames: list[str] | None = None) -> GroupBy:
     )
 
 
+# NB Epoch is arbitrary - could be any date in past or future.
+epoch = npdt64("1970-01-01", "ns")
+
+
 def group_by_mosaic(pnames: list[str] | None = None) -> GroupBy:
+    # Need to sort in reverse date order to ensure that latest data is always rendered.
+    # (see definition of _default_fuser() in datacube.storage._loader._default_fuser)
+    def reverse_solar_day_sortkey(ds: Dataset) -> npdelt64:
+        return epoch - solar_day(ds)
+
     base_sort_key = lambda ds: ds.time.begin  # noqa: E731
     if pnames:
         index = {pn: i for i, pn in enumerate(pnames)}
         sort_key: Callable[[Dataset], tuple] = lambda ds: (  # noqa: E731
-            solar_day(ds),
+            reverse_solar_day_sortkey(ds),
             index.get(ds.product.name),
             base_sort_key(ds),
         )
     else:
-        sort_key = lambda ds: (solar_day(ds), base_sort_key(ds))  # noqa: E731
+        sort_key = lambda ds: (reverse_solar_day_sortkey(ds), base_sort_key(ds))  # noqa: E731
     return GroupBy(
         dimension="time",
-        group_by_func=lambda n: npdt64(datetime.datetime(1970, 1, 1), "ns"),
+        group_by_func=lambda n: epoch,
         units="seconds since 1970-01-01 00:00:00",
         sort_key=sort_key,
     )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -137,7 +137,6 @@ def test_group_by_stat(datasets_for_sorting) -> None:
         "K",
         "L",
     ]
-
     gby = group_by_begin_datetime(["prod_c", "prod_b", "prod_a"], truncate_dates=False)
     date_only = Datacube.group_datasets(datasets_for_sorting, gby)
     assert len(date_only) == 2
@@ -198,6 +197,8 @@ def test_group_by_mosaic(datasets_for_sorting) -> None:
     assert len(date_only) == 1
     arrays = date_only.values
     assert [ds.id for ds in arrays[0]] == [
+        "H",
+        "L",
         "A",
         "B",
         "E",
@@ -208,8 +209,6 @@ def test_group_by_mosaic(datasets_for_sorting) -> None:
         "D",
         "G",
         "K",
-        "H",
-        "L",
     ]
 
     gby = group_by_mosaic(["prod_c", "prod_b", "prod_a"])
@@ -217,6 +216,8 @@ def test_group_by_mosaic(datasets_for_sorting) -> None:
     assert len(date_only) == 1
     arrays = date_only.values
     assert [ds.id for ds in arrays[0]] == [
+        "L",
+        "H",
         "I",
         "J",
         "K",
@@ -227,8 +228,6 @@ def test_group_by_mosaic(datasets_for_sorting) -> None:
         "B",
         "C",
         "D",
-        "L",
-        "H",
     ]
 
 


### PR DESCRIPTION
Mosaic dates were being sorted in forward solar-date order.  Due to the way `_default_fuser` works, this results in older data being rendered..  This PR changes to reverse solar-date order, which results in the most recent data for each pixel being rendered.

I've also tweaked the feature info output to return more useful date info for mosaic layers (the range of dates being displayed is included, and the "data available for" section is suppressed)

<!-- readthedocs-preview datacube-ows start -->
----
📚 Documentation preview 📚: https://datacube-ows--1363.org.readthedocs.build/en/1363/

<!-- readthedocs-preview datacube-ows end -->