### PR TITLE
CI: do not fail fast

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -32,6 +32,7 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python-version: ["3.10"]
         lintcommand:


### PR DESCRIPTION
Let the other jobs complete
even if one job fails.

<!-- readthedocs-preview datacube-ows start -->
----
📚 Documentation preview 📚: https://datacube-ows--1370.org.readthedocs.build/en/1370/

<!-- readthedocs-preview datacube-ows end -->