### PR TITLE
Improve error reporting from get_ranges.

### DIFF
--- a/datacube_ows/index/postgis/product_ranges.py
+++ b/datacube_ows/index/postgis/product_ranges.py
@@ -264,30 +264,29 @@ def sanitise_bbox(bbox: odc.geo.geom.BoundingBox) -> dict[str, float]:
 
 
 def get_ranges(layer: OWSNamedLayer) -> LayerExtent | None:
-    conn = get_sqlconn(layer.dc)
-    results = conn.execute(
-        text("""
-        SELECT *
-        FROM ows.layer_ranges
-        WHERE layer=:pname"""),
-        {"pname": layer.name},
-    )
-
-    for result in results:
-        conn.close()
-        if layer.time_resolution.is_subday():
-            dt_parser: Callable[[str], datetime | date] = (  # noqa: E731
-                lambda dts: datetime.fromisoformat(dts)
-            )
-        else:
-            dt_parser = lambda dts: datetime.strptime(dts, "%Y-%m-%d").date()  # noqa: E731
-        times = [dt_parser(d) for d in result.dates if d is not None]
-        if not times:
-            return None
-        return LayerExtent(
-            lat=CoordRange(min=float(result.lat_min), max=float(result.lat_max)),
-            lon=CoordRange(min=float(result.lon_min), max=float(result.lon_max)),
-            times=times,
-            bboxes=result.bboxes,
+    with get_sqlconn(layer.dc) as conn:
+        results = conn.execute(
+            text("""
+            SELECT *
+            FROM ows.layer_ranges
+            WHERE layer=:pname"""),
+            {"pname": layer.name},
         )
-    return None
+
+        for result in results:
+            if layer.time_resolution.is_subday():
+                dt_parser: Callable[[str], datetime | date] = (  # noqa: E731
+                    lambda dts: datetime.fromisoformat(dts)
+                )
+            else:
+                dt_parser = lambda dts: datetime.strptime(dts, "%Y-%m-%d").date()  # noqa: E731
+            times = [dt_parser(d) for d in result.dates if d is not None]
+            if not times:
+                return None
+            return LayerExtent(
+                lat=CoordRange(min=float(result.lat_min), max=float(result.lat_max)),
+                lon=CoordRange(min=float(result.lon_min), max=float(result.lon_max)),
+                times=times,
+                bboxes=result.bboxes,
+            )
+        return None

--- a/datacube_ows/index/postgres/product_ranges.py
+++ b/datacube_ows/index/postgres/product_ranges.py
@@ -235,30 +235,29 @@ def sanitise_bbox(bbox: odc.geo.geom.BoundingBox) -> dict[str, float]:
 
 
 def get_ranges(layer: OWSNamedLayer) -> LayerExtent | None:
-    conn = get_sqlconn(layer.dc)
-    results = conn.execute(
-        text("""
-        SELECT *
-        FROM ows.layer_ranges
-        WHERE layer=:pname"""),
-        {"pname": layer.name},
-    )
-
-    for result in results:
-        conn.close()
-        if layer.time_resolution.is_subday():
-            dt_parser: Callable[[str], datetime | date] = (  # noqa: E731
-                lambda dts: datetime.fromisoformat(dts)
-            )
-        else:
-            dt_parser = lambda dts: datetime.strptime(dts, "%Y-%m-%d").date()  # noqa: E731
-        times = [dt_parser(d) for d in result.dates if d is not None]
-        if not times:
-            return None
-        return LayerExtent(
-            lat=CoordRange(min=float(result.lat_min), max=float(result.lat_max)),
-            lon=CoordRange(min=float(result.lon_min), max=float(result.lon_max)),
-            times=times,
-            bboxes=result.bboxes,
+    with get_sqlconn(layer.dc) as conn:
+        results = conn.execute(
+            text("""
+            SELECT *
+            FROM ows.layer_ranges
+            WHERE layer=:pname"""),
+            {"pname": layer.name},
         )
-    return None
+
+        for result in results:
+            if layer.time_resolution.is_subday():
+                dt_parser: Callable[[str], datetime | date] = (  # noqa: E731
+                    lambda dts: datetime.fromisoformat(dts)
+                )
+            else:
+                dt_parser = lambda dts: datetime.strptime(dts, "%Y-%m-%d").date()  # noqa: E731
+            times = [dt_parser(d) for d in result.dates if d is not None]
+            if not times:
+                return None
+            return LayerExtent(
+                lat=CoordRange(min=float(result.lat_min), max=float(result.lat_max)),
+                lon=CoordRange(min=float(result.lon_min), max=float(result.lon_max)),
+                times=times,
+                bboxes=result.bboxes,
+            )
+        return None

--- a/datacube_ows/ows_configuration.py
+++ b/datacube_ows/ows_configuration.py
@@ -1200,7 +1200,7 @@ class OWSNamedLayer(OWSExtensibleConfigEntry, OWSLayer):
         elif isinstance(self.default_time_rule, datetime.date):
             _LOG.warning(
                 "default_time for named_layer %s is explicit date (%s) that is "
-                " not available for the layer. Using most recent available date instead.",
+                "not available for the layer. Using most recent available date instead.",
                 self.name,
                 self.default_time_rule.isoformat(),
             )

--- a/datacube_ows/ows_configuration.py
+++ b/datacube_ows/ows_configuration.py
@@ -1178,31 +1178,36 @@ class OWSNamedLayer(OWSExtensibleConfigEntry, OWSLayer):
             self._ranges = self.ows_index().get_ranges(self)
             if self._ranges is None:
                 return False
-            self.bboxes = self.extract_bboxes()
-            if self.default_time_rule == DEF_TIME_EARLIEST:
-                self.default_time = self._ranges.start_time
-            elif (
-                isinstance(self.default_time_rule, datetime.date)
-                and self.default_time_rule in self._ranges.time_set
-            ):
-                self.default_time = self.default_time_rule
-            elif isinstance(self.default_time_rule, datetime.date):
-                _LOG.warning(
-                    "default_time for named_layer %s is explicit date (%s) that is "
-                    " not available for the layer. Using most recent available date instead.",
-                    self.name,
-                    self.default_time_rule.isoformat(),
-                )
-                self.default_time = self._ranges.end_time
-            else:
-                self.default_time = self._ranges.end_time
-            return True
         # pylint: disable=broad-except
-        except Exception as a:
+        except Exception as e:
             if not self.global_cfg.called_from_update_ranges:
-                _LOG.warning("get_ranges failed for layer %s: %s", self.name, str(a))
+                _LOG.warning(
+                    "get_ranges failed for layer %s: %s(%s)",
+                    self.name,
+                    e.__class__.__name__,
+                    str(e)
+                )
             self.bboxes = {}
             return False
+        self.bboxes = self.extract_bboxes()
+        if self.default_time_rule == DEF_TIME_EARLIEST:
+            self.default_time = self._ranges.start_time
+        elif (
+            isinstance(self.default_time_rule, datetime.date)
+            and self.default_time_rule in self._ranges.time_set
+        ):
+            self.default_time = self.default_time_rule
+        elif isinstance(self.default_time_rule, datetime.date):
+            _LOG.warning(
+                "default_time for named_layer %s is explicit date (%s) that is "
+                " not available for the layer. Using most recent available date instead.",
+                self.name,
+                self.default_time_rule.isoformat(),
+            )
+            self.default_time = self._ranges.end_time
+        else:
+            self.default_time = self._ranges.end_time
+        return True
 
     def time_range(
         self, ranges: Optional["LayerExtent"] = None

--- a/datacube_ows/ows_configuration.py
+++ b/datacube_ows/ows_configuration.py
@@ -1185,7 +1185,7 @@ class OWSNamedLayer(OWSExtensibleConfigEntry, OWSLayer):
                     "get_ranges failed for layer %s: %s(%s)",
                     self.name,
                     e.__class__.__name__,
-                    str(e)
+                    str(e),
                 )
             self.bboxes = {}
             return False


### PR DESCRIPTION
#1375 reports uninformative error messages coming from get_ranges (possibly obscuring issues with psycopg3??).

Hopefully this will help get to the bottom of things.

<!-- readthedocs-preview datacube-ows start -->
----
📚 Documentation preview 📚: https://datacube-ows--1377.org.readthedocs.build/en/1377/

<!-- readthedocs-preview datacube-ows end -->