### PR TITLE
dependabot: add 10 day cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,8 @@ updates:
     actions-deps:
       patterns:
         - "*"
+  cooldown:
+    default-days: "10"
 - package-ecosystem: docker
   directory: "/"
   schedule:


### PR DESCRIPTION
This makes Dependabot wait for
10 days before generating the PR
for a release. This gives
authors of actions some time
to retract a release if there
is a supply chain compromise.

<!-- readthedocs-preview datacube-ows start -->
----
📚 Documentation preview 📚: https://datacube-ows--1379.org.readthedocs.build/en/1379/

<!-- readthedocs-preview datacube-ows end -->