### PR TITLE
postgis: fix comment typo

### DIFF
--- a/datacube_ows/sql/postgis/ows_schema/bootstrap/010_layer_range_owner_isolated.sql
+++ b/datacube_ows/sql/postgis/ows_schema/bootstrap/010_layer_range_owner_isolated.sql
@@ -1,4 +1,4 @@
--- Confirm owner of layer_ranfes table (if it already exists)
+-- Confirm owner of layer_ranges table (if it already exists)
 
 -- Note "bootstrap" scripts need to be run by a database superuser
 


### PR DESCRIPTION
This is displayed when running
datacube-ows.

<!-- readthedocs-preview datacube-ows start -->
----
📚 Documentation preview 📚: https://datacube-ows--1385.org.readthedocs.build/en/1385/

<!-- readthedocs-preview datacube-ows end -->