### PR TITLE
datacube-ows-update: fix help output

### DIFF
--- a/datacube_ows/update_ranges_impl.py
+++ b/datacube_ows/update_ranges_impl.py
@@ -80,18 +80,6 @@ def main(
     * datacube-ows-update --schema
         Create (re-create) the OWS schema (including materialised views)
 
-    * datacube-ows-update --read-role role1 --read-role role2 --write-role role3
-        Grants read or read/write permissions to the OWS tables and views to the indicated role(s).
-
-        The --read-role and --write-role options can also be passed in combination with the --schema option
-        described above.
-
-        Read permissions are required for the database role that the datacube-ows service uses.
-
-        Write permissions are required for the database role used to run the Data Management actions below.
-
-        (These schema management actions require higher level permissions.)
-
     * datacube-ows-update --cleanup
         Clean up (drop) any datacube-ows 1.8.x database entities.
 

--- a/datacube_ows/update_ranges_impl.py
+++ b/datacube_ows/update_ranges_impl.py
@@ -93,7 +93,7 @@ def main(
         (These schema management actions require higher level permissions.)
 
     * datacube-ows-update --cleanup
-        Clean up (drop) any datcube-ows 1.8.x database entities.
+        Clean up (drop) any datacube-ows 1.8.x database entities.
 
         The --cleanup option can also be passed in combination with the --schema option described above.
 

--- a/datacube_ows/wsgi.py
+++ b/datacube_ows/wsgi.py
@@ -12,7 +12,7 @@ import sys
 # This is the directory of the source code that the web app will run from
 sys.path.append("/opt")
 
-# The location of the datcube config file.
+# The location of the datacube config file.
 if os.path.isfile("/opt/odc/.datacube.conf.local"):
     os.environ.setdefault("ODC_CONFIG_PATH", "/opt/odc/.datacube.conf.local")
 


### PR DESCRIPTION
Remove the large help text about
the now removed --read-role
and --write-role parameters.

<!-- readthedocs-preview datacube-ows start -->
----
📚 Documentation preview 📚: https://datacube-ows--1390.org.readthedocs.build/en/1390/

<!-- readthedocs-preview datacube-ows end -->