### PR TITLE
Doc string fixes

### DIFF
--- a/datacube_ows/config_utils.py
+++ b/datacube_ows/config_utils.py
@@ -261,10 +261,8 @@ class OWSConfigEntry:
         In the base class we just confirm that all declared-unready attributes have been initialised,
         and set the ready flag.
 
-        :param dc:
         :param args:
         :param kwargs:
-        :return:
         """
         if self._unready_attributes:
             raise OWSConfigNotReady(
@@ -778,8 +776,6 @@ class OWSFlagBand(OWSConfigEntry):
     def make_ready(self, *args: Any, **kwargs: Any) -> None:
         """
         Second round (db-aware) intialisation.
-
-        :param dc: A Datacube object
         """
         # pyre-ignore[16]
         self.pq_products: list[Product] = []
@@ -902,8 +898,6 @@ class FlagProductBands(OWSConfigEntry):
     def make_ready(self, *args, **kwargs) -> None:
         """
         Second round (db-aware) intialisation.
-
-        :param dc: A Datacube object
         """
         for fb in self.flag_bands.values():
             fb = cast(OWSFlagBand, fb)

--- a/datacube_ows/styles/base.py
+++ b/datacube_ows/styles/base.py
@@ -259,8 +259,6 @@ class StyleDefBase(OWSExtensibleConfigEntry, OWSMetadataConfig):
         Second-phase (db aware) initialisation
 
         Mostly sorting out bands, esp flag bands.
-
-        :param dc: A datacube object
         """
         # pyre-ignore[16]
         self.needed_bands: set[str] = set()

--- a/datacube_ows/styles/component.py
+++ b/datacube_ows/styles/component.py
@@ -117,8 +117,6 @@ class ComponentStyleDef(StyleDefBase):
         Second-phase (db aware) initialisation
 
         Mostly sorting out bands, esp flag bands.
-
-        :param dc: A datacube object
         """
         self.rgb_components = cast(dict[str, None | Callable | LINEAR_COMP_DICT], {})
         for band, component in self.raw_rgb_components.items():


### PR DESCRIPTION
There is no parameter called dc
in these functions any longer,
so remove the doc string for it.

<!-- readthedocs-preview datacube-ows start -->
----
📚 Documentation preview 📚: https://datacube-ows--1394.org.readthedocs.build/en/1394/

<!-- readthedocs-preview datacube-ows end -->