### PR TITLE
datacube-ows-update: detect OperationalError

### DIFF
--- a/datacube_ows/ows_configuration.py
+++ b/datacube_ows/ows_configuration.py
@@ -33,6 +33,7 @@ from odc.geo import CRS, CRSError
 from odc.geo.geobox import GeoBox
 from ows import Version
 from slugify import slugify
+from sqlalchemy.exc import OperationalError
 from typing_extensions import override
 
 from datacube_ows.config_utils import (
@@ -364,6 +365,8 @@ class OWSLayer(OWSMetadataConfig):
             try:
                 self._dc = Datacube(env=self._local_env, app=self.global_cfg.odc_app)
                 return self._dc
+            except OperationalError:
+                raise
             except Exception as e:
                 raise ODCInitException(str(e)) from None
 

--- a/datacube_ows/update_ranges_impl.py
+++ b/datacube_ows/update_ranges_impl.py
@@ -11,6 +11,7 @@ import sys
 import click
 import sqlalchemy
 from datacube import Datacube
+from sqlalchemy.exc import OperationalError
 
 from datacube_ows import __version__
 from datacube_ows.config_utils import OWSConfigNotReady
@@ -157,8 +158,11 @@ def main(
         sys.exit(1)
 
     initialise_debugging()
-
-    cfg = get_config(called_from_update_ranges=True)
+    try:
+        cfg = get_config(called_from_update_ranges=True)
+    except OperationalError as e:
+        click.echo(f"ERROR: {e}", err=True)
+        sys.exit(1)
     app = cfg.odc_app + "-update"
     errors: bool = False
     if schema or cleanup or views:


### PR DESCRIPTION
This makes datacube-ows-update print:

ERROR: (psycopg2.OperationalError) connection to server at "postgres" (172.18.0.2), port 35434 failed: FATAL:  sorry, too many clients already

(Background on this error at: https://sqlalche.me/e/20/e3q8)

earlier, and then stopping, instead
of printing a dozen of these errors.

Refs #1387

<!-- readthedocs-preview datacube-ows start -->
----
📚 Documentation preview 📚: https://datacube-ows--1395.org.readthedocs.build/en/1395/

<!-- readthedocs-preview datacube-ows end -->