### PR TITLE
datacube-ows-update: print exception

### DIFF
--- a/datacube_ows/update_ranges_impl.py
+++ b/datacube_ows/update_ranges_impl.py
@@ -11,6 +11,7 @@ import sys
 import click
 import sqlalchemy
 from datacube import Datacube
+from sqlalchemy.exc import OperationalError, ProgrammingError
 
 from datacube_ows import __version__
 from datacube_ows.config_utils import OWSConfigNotReady
@@ -163,12 +164,11 @@ def main(
     errors: bool = False
     if schema or cleanup or views:
         try:
-            if cfg.default_env and env is None:
-                dc = Datacube(env=cfg.default_env, app=app)
-            else:
-                dc = Datacube(env=env, app=app)
-        except Exception:
-            click.echo(f"Unable to connect to the {env or cfg.default_env} database.")
+            dc = Datacube(
+                env=cfg.default_env if cfg.default_env and env is None else env, app=app
+            )
+        except (OperationalError, ProgrammingError) as e:
+            click.echo(f"ERROR: {e}", err=True)
             sys.exit(1)
 
         click.echo(


### PR DESCRIPTION
Narrow the except clause to the errors
that can be reasonably expected, and
print the exception when it happens.

If someone gets an exception we are
not expecting, they will get a backtrace
and hopefully report it so we can fix
the problem.

Refs #1387

<!-- readthedocs-preview datacube-ows start -->
----
📚 Documentation preview 📚: https://datacube-ows--1396.org.readthedocs.build/en/1396/

<!-- readthedocs-preview datacube-ows end -->