### PR TITLE
psycopg3: install c extras

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,6 +53,7 @@ RUN --mount=type=cache,id=opendatacube-uv-cache,target=/root/.cache \
       --no-binary-package fiona \
       --no-binary-package netcdf4 \
       --no-binary-package psycopg \
+      --no-binary-package psycopg-c \
       --no-binary-package psycopg2 \
       --no-binary-package rasterio \
       --no-binary-package shapely

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,7 @@ ops = [
     "gunicorn[gevent]",
     "prometheus_client",
     "psycopg2",
-    "psycopg",
+    "psycopg[c]",
     "sentry_sdk",
 ]
 postgres = ["psycopg2"]

--- a/uv.lock
+++ b/uv.lock
@@ -870,7 +870,7 @@ all = [
     { name = "mypy" },
     { name = "owslib" },
     { name = "prometheus-client" },
-    { name = "psycopg" },
+    { name = "psycopg", extra = ["c"] },
     { name = "psycopg2" },
     { name = "pydevd-pycharm" },
     { name = "pylint" },
@@ -899,7 +899,7 @@ ops = [
     { name = "gevent" },
     { name = "gunicorn", extra = ["gevent"] },
     { name = "prometheus-client" },
-    { name = "psycopg" },
+    { name = "psycopg", extra = ["c"] },
     { name = "psycopg2" },
     { name = "sentry-sdk" },
 ]
@@ -959,7 +959,7 @@ requires-dist = [
     { name = "pillow", specifier = ">=10.2.0" },
     { name = "prometheus-client", marker = "extra == 'ops'" },
     { name = "prometheus-flask-exporter" },
-    { name = "psycopg", marker = "extra == 'ops'" },
+    { name = "psycopg", extras = ["c"], marker = "extra == 'ops'" },
     { name = "psycopg2", marker = "extra == 'ops'" },
     { name = "psycopg2", marker = "extra == 'postgres'" },
     { name = "psycopg2", marker = "extra == 'test'" },
@@ -2621,6 +2621,17 @@ sdist = { url = "https://files.pythonhosted.org/packages/18/ed/3a30e8ef82d4128c7
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b6/f3/0b4a4c25a47c2d907afa97674287dab61bc9941c9ac3972a67100e33894d/psycopg-3.3.1-py3-none-any.whl", hash = "sha256:e44d8eae209752efe46318f36dd0fdf5863e928009338d736843bb1084f6435c", size = 212760, upload-time = "2025-12-02T21:02:36.029Z" },
 ]
+
+[package.optional-dependencies]
+c = [
+    { name = "psycopg-c", marker = "implementation_name != 'pypy'" },
+]
+
+[[package]]
+name = "psycopg-c"
+version = "3.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9c/69/3605f5408951e21c227ea5c8d031e974f0000c17ac1d5b24ea4735abf98b/psycopg_c-3.3.1.tar.gz", hash = "sha256:0c49958297578e5dbf9a7e7dabe7a03cac0290b70dd612ece5fa9f10ae6a0dea", size = 623972, upload-time = "2025-12-02T21:09:56.89Z" }
 
 [[package]]
 name = "psycopg2"


### PR DESCRIPTION
This is apparently the extra
now that makes psycopg3
correspond to the old
psycopg2 non-binary version.

<!-- readthedocs-preview datacube-ows start -->
----
📚 Documentation preview 📚: https://datacube-ows--1398.org.readthedocs.build/en/1398/

<!-- readthedocs-preview datacube-ows end -->