### PR TITLE
api: re-use existing datacube

### DIFF
--- a/datacube_ows/index/api.py
+++ b/datacube_ows/index/api.py
@@ -233,7 +233,7 @@ def check_perms(
             from datacube_ows.ows_configuration import OWSNamedLayer
 
             if isinstance(dcl, OWSNamedLayer):
-                dc = Datacube(env=dcl.local_env)
+                dc = dcl.dc
             elif isinstance(dcl, Datacube):
                 dc = dcl
             else:

--- a/datacube_ows/index/api.py
+++ b/datacube_ows/index/api.py
@@ -224,7 +224,7 @@ def ows_index(odc: Datacube | AbstractIndex) -> OWSAbstractIndex:
 
 
 def check_perms(
-    group: Literal["user", "admin", "manage"],
+    group: Literal["admin", "manage"],
 ) -> Callable[[Callable], Callable]:
     def outer(f: Callable) -> Callable:
         def inner(

--- a/datacube_ows/index/postgis/api.py
+++ b/datacube_ows/index/postgis/api.py
@@ -59,9 +59,7 @@ class OWSPostgisIndex(OWSAbstractIndex):
         return db_ok
 
     @override
-    def _check_perms(
-        self, dc: Datacube, group: Literal["user", "manage", "admin"]
-    ) -> None:
+    def _check_perms(self, dc: Datacube, group: Literal["manage", "admin"]) -> None:
         if get_driver_name(dc.index) == "psycopg":
             from psycopg.errors import ProgrammingError
         else:
@@ -111,7 +109,6 @@ class OWSPostgisIndex(OWSAbstractIndex):
         create_range_entry_impl(layer, cache)
 
     @override
-    @check_perms("user")
     def get_ranges(self, layer: OWSNamedLayer) -> LayerExtent | None:
         return get_ranges_impl(layer)
 
@@ -169,7 +166,6 @@ class OWSPostgisIndex(OWSAbstractIndex):
         return query
 
     @override
-    @check_perms("user")
     def ds_search(
         self,
         layer: OWSNamedLayer,
@@ -182,7 +178,6 @@ class OWSPostgisIndex(OWSAbstractIndex):
         )
 
     @override
-    @check_perms("user")
     def dsid_search(
         self,
         layer: OWSNamedLayer,
@@ -196,7 +191,6 @@ class OWSPostgisIndex(OWSAbstractIndex):
             yield ds.id  # type: ignore[attr-defined]
 
     @override
-    @check_perms("user")
     def count(
         self,
         layer: OWSNamedLayer,
@@ -209,7 +203,6 @@ class OWSPostgisIndex(OWSAbstractIndex):
         )
 
     @override
-    @check_perms("user")
     def extent(
         self,
         layer: OWSNamedLayer,

--- a/datacube_ows/index/postgres/api.py
+++ b/datacube_ows/index/postgres/api.py
@@ -56,9 +56,7 @@ class OWSPostgresIndex(OWSAbstractIndex):
         return db_ok
 
     @override
-    def _check_perms(
-        self, dc: Datacube, group: Literal["user", "manage", "admin"]
-    ) -> None:
+    def _check_perms(self, dc: Datacube, group: Literal["manage", "admin"]) -> None:
         if get_driver_name(dc.index) == "psycopg":
             from psycopg.errors import ProgrammingError
         else:
@@ -106,12 +104,10 @@ class OWSPostgresIndex(OWSAbstractIndex):
         create_range_entry_impl(layer, cache)
 
     @override
-    @check_perms("user")
     def get_ranges(self, layer: OWSNamedLayer) -> LayerExtent | None:
         return get_ranges_impl(layer)
 
     @override
-    @check_perms("user")
     def ds_search(
         self,
         layer: OWSNamedLayer,
@@ -131,7 +127,6 @@ class OWSPostgresIndex(OWSAbstractIndex):
         )
 
     @override
-    @check_perms("user")
     def dsid_search(
         self,
         layer: OWSNamedLayer,
@@ -151,7 +146,6 @@ class OWSPostgresIndex(OWSAbstractIndex):
         )
 
     @override
-    @check_perms("user")
     def count(
         self,
         layer: OWSNamedLayer,
@@ -171,7 +165,6 @@ class OWSPostgresIndex(OWSAbstractIndex):
         )
 
     @override
-    @check_perms("user")
     def extent(
         self,
         layer: OWSNamedLayer,

--- a/integration_tests/test_mv_index.py
+++ b/integration_tests/test_mv_index.py
@@ -15,6 +15,7 @@ from datacube_ows.time_utils import local_solar_date_range
 def test_full_layer() -> None:
     cfg = get_config()
     lyr = next(iter(cfg.layer_index.values()))
+    assert lyr.dc.index.environment.index_driver in ("postgres", "default")
     sel = mv_search(lyr.dc, MVSelectOpts.COUNT, products=lyr.products)
     assert sel > 0
 
@@ -22,6 +23,7 @@ def test_full_layer() -> None:
 def test_select_all() -> None:
     cfg = get_config()
     lyr = next(iter(cfg.layer_index.values()))
+    assert lyr.dc.index.environment.index_driver in ("postgres", "default")
     rows = mv_search(lyr.dc, MVSelectOpts.ALL, products=lyr.products)
     for row in rows:
         assert len(row) > 1
@@ -30,14 +32,13 @@ def test_select_all() -> None:
 def test_no_products() -> None:
     cfg = get_config()
     lyr = next(iter(cfg.layer_index.values()))
+    assert lyr.dc.index.environment.index_driver in ("postgres", "default")
     with pytest.raises(Exception) as e:
         _ = mv_search(lyr.dc, MVSelectOpts.COUNT)
     assert "Must filter by product/layer" in str(e.value)
 
 
 def test_bad_set_opt() -> None:
-    cfg = get_config()
-    _ = next(iter(cfg.layer_index.values()))
     with pytest.raises(ValueError):
         _ = MVSelectOpts("INVALID")
 
@@ -53,6 +54,7 @@ class MockGeobox:
 def test_time_search() -> None:
     cfg = get_config()
     lyr = next(iter(cfg.layer_index.values()))
+    assert lyr.dc.index.environment.index_driver in ("postgres", "default")
     time = lyr.ranges.end_time
     geom = box(
         lyr.bboxes["EPSG:4326"]["left"],
@@ -70,6 +72,7 @@ def test_time_search() -> None:
 def test_count() -> None:
     cfg = get_config()
     lyr = next(iter(cfg.layer_index.values()))
+    assert lyr.dc.index.environment.index_driver in ("postgres", "default")
     count = mv_search(lyr.dc, MVSelectOpts.COUNT, products=lyr.products)
     ids = mv_search(lyr.dc, MVSelectOpts.IDS, products=lyr.products)
     assert len(ids) == count
@@ -78,6 +81,7 @@ def test_count() -> None:
 def test_datasets() -> None:
     cfg = get_config()
     lyr = next(iter(cfg.layer_index.values()))
+    assert lyr.dc.index.environment.index_driver in ("postgres", "default")
     dss = mv_search(lyr.dc, MVSelectOpts.DATASETS, products=lyr.products)
     ids = mv_search(lyr.dc, MVSelectOpts.IDS, products=lyr.products)
     assert len(ids) == len(dss)
@@ -88,6 +92,7 @@ def test_datasets() -> None:
 def test_extent_and_spatial() -> None:
     cfg = get_config()
     lyr = next(iter(cfg.layer_index.values()))
+    assert lyr.dc.index.environment.index_driver in ("postgres", "default")
     layer_ext_bbx = (
         lyr.bboxes["EPSG:4326"]["left"],
         lyr.bboxes["EPSG:4326"]["bottom"],


### PR DESCRIPTION
This will use the connection pool
from the existing datacube instead
of creating another one. Since
this could be done for each thread,
the reduced number of connections
can be significant.

As an additional bonus, this also
makes OWS connections present themselves
as "datacube-ows odc-1.9.11" instead
of just "odc-1.9.11".

<!-- readthedocs-preview datacube-ows start -->
----
📚 Documentation preview 📚: https://datacube-ows--1400.org.readthedocs.build/en/1400/

<!-- readthedocs-preview datacube-ows end -->