### PR TITLE
Attempt to fix startup issues raised in #1404

### DIFF
--- a/datacube_ows/loading.py
+++ b/datacube_ows/loading.py
@@ -24,7 +24,7 @@ from typing_extensions import override
 
 from datacube_ows.ogc_exceptions import WMSException
 from datacube_ows.ows_configuration import OWSNamedLayer
-from datacube_ows.startup_utils import CredentialManager
+from datacube_ows.startup_utils.creds import CredentialManager
 from datacube_ows.styles import StyleDef
 from datacube_ows.utils import log_call
 from datacube_ows.wms_utils import solar_correct_data

--- a/datacube_ows/startup_utils/__init__.py
+++ b/datacube_ows/startup_utils/__init__.py
@@ -10,12 +10,13 @@ import warnings
 from collections.abc import Callable
 from logging import Logger
 from time import monotonic
-from typing import Any, TypeVar
+from typing import Any, Optional, TypeVar
 
 from flask import Flask, g, request
-from rasterio.errors import NotGeoreferencedWarning
 
-from datacube_ows.ows_configuration import OWSConfig, get_config
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from datacube_ows.ows_configuration import OWSConfig
 
 __all__ = [
     "create_app",
@@ -37,6 +38,8 @@ def initialise_logger(name: str | None = None) -> Logger:
 
 def initialise_ignorable_warnings() -> None:
     # Suppress annoying rasterio warning message every time we write to a non-georeferenced image format
+    from rasterio.errors import NotGeoreferencedWarning
+
     warnings.simplefilter("ignore", category=NotGeoreferencedWarning)
 
 
@@ -86,9 +89,11 @@ def initialise_sentry(log: Logger | None = None) -> None:
             log.info("Sentry initialised")
 
 
-def parse_config_file(log: Logger | None = None) -> OWSConfig | None:
+def parse_config_file(log: Logger | None = None) -> Optional["OWSConfig"]:
     # Cache a parsed config file object
     # (unless deferring to first request)
+    from datacube_ows.ows_configuration import get_config
+
     cfg = None
     if not os.environ.get("DEFER_CFG_PARSE"):
         cfg = get_config()
@@ -178,10 +183,10 @@ def initialise_babel(cfg, app: Flask) -> object | None:
 
 def create_app() -> Flask:
     log = initialise_logger()
+    app = initialise_flask(__name__)
     cfg = parse_config_file(log)
     initialise_ignorable_warnings()
     initialise_debugging(log)
-    app = initialise_flask(__name__)
     initialise_sentry(log)
     from datacube_ows.startup_utils.creds import initialise_aws_credentials
 

--- a/datacube_ows/startup_utils/__init__.py
+++ b/datacube_ows/startup_utils/__init__.py
@@ -9,6 +9,7 @@ import os
 import warnings
 from collections.abc import Callable
 from logging import Logger
+from threading import Lock
 from time import monotonic
 from typing import Any, TypeVar
 
@@ -95,16 +96,19 @@ def initialise_sentry(log: Logger | None = None) -> None:
         if log:
             log.info("Sentry initialised")
 
+credential_lock = Lock()
 
 class CredentialManager:
     _instance = None
 
     def __new__(cls, log: Logger | None = None) -> "CredentialManager":
+        # new/init assumed to be called with credential_lock held
         if not cls._instance:
             cls._instance = super().__new__(cls)
         return cls._instance
 
     def __init__(self, log: Logger | None = None) -> None:
+        # new/init assumed to be called with credential_lock held
         # Startup initialisation of libraries controlled by environment variables
         self.use_aws = False
         self.unsigned = False
@@ -178,8 +182,9 @@ class CredentialManager:
     @classmethod
     def check_cred(cls) -> None:
         # pylint: disable=protected-access
-        assert cls._instance is not None
-        cls._instance._check_cred()
+        with credential_lock:
+            assert cls._instance is not None
+            cls._instance._check_cred()
 
     def renew_creds(self) -> None:
         if self.use_aws:
@@ -199,8 +204,9 @@ class CredentialManager:
 
 def initialise_aws_credentials(log: Logger | None = None) -> None:
     # pylint: disable=protected-access
-    if CredentialManager._instance is None:
-        _ = CredentialManager(log)
+    with credential_lock:
+        if CredentialManager._instance is None:
+            _ = CredentialManager(log)
 
 
 def parse_config_file(log: Logger | None = None) -> OWSConfig | None:

--- a/datacube_ows/startup_utils/__init__.py
+++ b/datacube_ows/startup_utils/__init__.py
@@ -304,9 +304,9 @@ def create_app() -> Flask:
     cfg = parse_config_file(log)
     initialise_ignorable_warnings()
     initialise_debugging(log)
+    app = initialise_flask(__name__)
     initialise_sentry(log)
     initialise_aws_credentials(log)
-    app = initialise_flask(__name__)
     initialise_babel(cfg, app)
     metrics = initialise_prometheus(app, log)
     ows_ogc_metric = metrics.histogram(

--- a/datacube_ows/startup_utils/__init__.py
+++ b/datacube_ows/startup_utils/__init__.py
@@ -9,7 +9,6 @@ import os
 import warnings
 from collections.abc import Callable
 from logging import Logger
-from threading import Lock
 from time import monotonic
 from typing import Any, TypeVar
 
@@ -19,16 +18,6 @@ from rasterio.errors import NotGeoreferencedWarning
 from datacube_ows.ows_configuration import OWSConfig, get_config
 
 __all__ = [
-    "initialise_babel",
-    "initialise_logger",
-    "initialise_ignorable_warnings",
-    "initialise_debugging",
-    "initialise_sentry",
-    "initialise_aws_credentials",
-    "parse_config_file",
-    "initialise_flask",
-    "initialise_prometheus",
-    "CredentialManager",
     "create_app",
 ]
 
@@ -95,118 +84,6 @@ def initialise_sentry(log: Logger | None = None) -> None:
         )
         if log:
             log.info("Sentry initialised")
-
-credential_lock = Lock()
-
-class CredentialManager:
-    _instance = None
-
-    def __new__(cls, log: Logger | None = None) -> "CredentialManager":
-        # new/init assumed to be called with credential_lock held
-        if not cls._instance:
-            cls._instance = super().__new__(cls)
-        return cls._instance
-
-    def __init__(self, log: Logger | None = None) -> None:
-        # new/init assumed to be called with credential_lock held
-        # Startup initialisation of libraries controlled by environment variables
-        self.use_aws = False
-        self.unsigned = False
-        self.requester_pays = False
-        self.credentials = None
-        self.log = log
-
-        if log:
-            log.debug("Initialising CredentialManager")
-
-        # Boto3/AWS
-        if os.environ.get("AWS_DEFAULT_REGION") or os.environ.get("AWS_REGION"):
-            if "AWS_NO_SIGN_REQUEST" in os.environ:
-                env_nosign = os.environ["AWS_NO_SIGN_REQUEST"]
-                if env_nosign.lower() in ("y", "t", "yes", "true", "1"):
-                    unsigned = True
-                    # Workaround for rasterio bug
-                    os.environ["AWS_NO_SIGN_REQUEST"] = "yes"
-                    os.environ["AWS_ACCESS_KEY_ID"] = "fake"
-                    os.environ["AWS_SECRET_ACCESS_KEY"] = "fake"
-                else:
-                    unsigned = False
-                    # delete env variable
-                    del os.environ["AWS_NO_SIGN_REQUEST"]
-            else:
-                unsigned = False
-                if log:
-                    log.warning(
-                        "AWS_NO_SIGN_REQUEST is not set. "
-                        + "The default behaviour has recently changed to False (i.e. signed requests) "
-                        + "Please explicitly set $AWS_NO_SIGN_REQUEST to 'no' for unsigned requests."
-                    )
-            env_requester_pays = os.environ.get("AWS_REQUEST_PAYER", "")
-            requester_pays = False
-            if env_requester_pays.lower() == "requester":
-                requester_pays = True
-            self.use_aws = True
-            if log:
-                if unsigned:
-                    log.info("S3 access configured with unsigned requests")
-                else:
-                    log.info("S3 access configured with signed requests")
-            self.unsigned = unsigned
-            self.requester_pays = requester_pays
-            self.renew_creds()
-
-            if "AWS_S3_ENDPOINT" in os.environ and os.environ["AWS_S3_ENDPOINT"] == "":
-                del os.environ["AWS_S3_ENDPOINT"]
-        elif log:
-            log.warning(
-                "Environment variable $AWS_DEFAULT_REGION not set.  (This warning can be ignored if all data is stored locally.)"
-            )
-
-    def _check_cred(self) -> None:
-        from botocore.credentials import RefreshableCredentials
-        if self.credentials and isinstance(self.credentials, RefreshableCredentials):
-            if self.credentials.refresh_needed():
-                self.renew_creds()
-            elif self.log:
-                # pylint: disable=protected-access
-                self.log.info(
-                    "Credentials look OK: %s seconds remaining",
-                    str(self.credentials._seconds_remaining()),
-                )
-        elif self.log:
-            self.log.debug(
-                "Credentials of type %s - NOT RENEWING",
-                self.credentials.__class__.__name__,
-            )
-
-    @classmethod
-    def check_cred(cls) -> None:
-        # pylint: disable=protected-access
-        with credential_lock:
-            assert cls._instance is not None
-            cls._instance._check_cred()
-
-    def renew_creds(self) -> None:
-        if self.use_aws:
-            from botocore.credentials import RefreshableCredentials
-            from datacube.utils.aws import configure_s3_access
-            if self.log:
-                self.log.info("Establishing/renewing credentials")
-            self.credentials = configure_s3_access(
-                aws_unsigned=self.unsigned, requester_pays=self.requester_pays
-            )
-            if self.log and isinstance(self.credentials, RefreshableCredentials):
-                # pylint: disable=protected-access
-                self.log.debug(
-                    "%s seconds remaining", str(self.credentials._seconds_remaining())
-                )
-
-
-def initialise_aws_credentials(log: Logger | None = None) -> None:
-    # pylint: disable=protected-access
-    with credential_lock:
-        if CredentialManager._instance is None:
-            _ = CredentialManager(log)
 
 
 def parse_config_file(log: Logger | None = None) -> OWSConfig | None:
@@ -306,6 +183,8 @@ def create_app() -> Flask:
     initialise_debugging(log)
     app = initialise_flask(__name__)
     initialise_sentry(log)
+    from datacube_ows.startup_utils.creds import initialise_aws_credentials
+
     initialise_aws_credentials(log)
     initialise_babel(cfg, app)
     metrics = initialise_prometheus(app, log)

--- a/datacube_ows/startup_utils/__init__.py
+++ b/datacube_ows/startup_utils/__init__.py
@@ -12,8 +12,6 @@ from logging import Logger
 from time import monotonic
 from typing import Any, TypeVar
 
-from botocore.credentials import RefreshableCredentials
-from datacube.utils.aws import configure_s3_access
 from flask import Flask, g, request
 from rasterio.errors import NotGeoreferencedWarning
 
@@ -161,6 +159,7 @@ class CredentialManager:
             )
 
     def _check_cred(self) -> None:
+        from botocore.credentials import RefreshableCredentials
         if self.credentials and isinstance(self.credentials, RefreshableCredentials):
             if self.credentials.refresh_needed():
                 self.renew_creds()
@@ -184,6 +183,8 @@ class CredentialManager:
 
     def renew_creds(self) -> None:
         if self.use_aws:
+            from botocore.credentials import RefreshableCredentials
+            from datacube.utils.aws import configure_s3_access
             if self.log:
                 self.log.info("Establishing/renewing credentials")
             self.credentials = configure_s3_access(

--- a/datacube_ows/startup_utils/creds.py
+++ b/datacube_ows/startup_utils/creds.py
@@ -1,0 +1,119 @@
+import os
+from logging import Logger
+from threading import Lock
+
+from datacube.utils.aws import configure_s3_access
+
+credential_lock = Lock()
+
+
+class CredentialManager:
+    _instance = None
+
+    def __new__(cls, log: Logger | None = None) -> "CredentialManager":
+        # new/init assumed to be called with credential_lock held
+        if not cls._instance:
+            cls._instance = super().__new__(cls)
+        return cls._instance
+
+    def __init__(self, log: Logger | None = None) -> None:
+        # new/init assumed to be called with credential_lock held
+        # Startup initialisation of libraries controlled by environment variables
+        self.use_aws = False
+        self.unsigned = False
+        self.requester_pays = False
+        self.credentials = None
+        self.log = log
+
+        if log:
+            log.debug("Initialising CredentialManager")
+
+        # Boto3/AWS
+        if os.environ.get("AWS_DEFAULT_REGION") or os.environ.get("AWS_REGION"):
+            if "AWS_NO_SIGN_REQUEST" in os.environ:
+                env_nosign = os.environ["AWS_NO_SIGN_REQUEST"]
+                if env_nosign.lower() in ("y", "t", "yes", "true", "1"):
+                    unsigned = True
+                    # Workaround for rasterio bug
+                    os.environ["AWS_NO_SIGN_REQUEST"] = "yes"
+                    os.environ["AWS_ACCESS_KEY_ID"] = "fake"
+                    os.environ["AWS_SECRET_ACCESS_KEY"] = "fake"
+                else:
+                    unsigned = False
+                    # delete env variable
+                    del os.environ["AWS_NO_SIGN_REQUEST"]
+            else:
+                unsigned = False
+                if log:
+                    log.warning(
+                        "AWS_NO_SIGN_REQUEST is not set. "
+                        + "The default behaviour has recently changed to False (i.e. signed requests) "
+                        + "Please explicitly set $AWS_NO_SIGN_REQUEST to 'no' for unsigned requests."
+                    )
+            env_requester_pays = os.environ.get("AWS_REQUEST_PAYER", "")
+            requester_pays = False
+            if env_requester_pays.lower() == "requester":
+                requester_pays = True
+            self.use_aws = True
+            if log:
+                if unsigned:
+                    log.info("S3 access configured with unsigned requests")
+                else:
+                    log.info("S3 access configured with signed requests")
+            self.unsigned = unsigned
+            self.requester_pays = requester_pays
+            self.renew_creds()
+
+            if "AWS_S3_ENDPOINT" in os.environ and os.environ["AWS_S3_ENDPOINT"] == "":
+                del os.environ["AWS_S3_ENDPOINT"]
+        elif log:
+            log.warning(
+                "Environment variable $AWS_DEFAULT_REGION not set.  (This warning can be ignored if all data is stored locally.)"
+            )
+
+    def _check_cred(self) -> None:
+        from botocore.credentials import RefreshableCredentials
+
+        if self.credentials and isinstance(self.credentials, RefreshableCredentials):
+            if self.credentials.refresh_needed():
+                self.renew_creds()
+            elif self.log:
+                # pylint: disable=protected-access
+                self.log.info(
+                    "Credentials look OK: %s seconds remaining",
+                    str(self.credentials._seconds_remaining()),
+                )
+        elif self.log:
+            self.log.debug(
+                "Credentials of type %s - NOT RENEWING",
+                self.credentials.__class__.__name__,
+            )
+
+    @classmethod
+    def check_cred(cls) -> None:
+        # pylint: disable=protected-access
+        with credential_lock:
+            assert cls._instance is not None
+            cls._instance._check_cred()
+
+    def renew_creds(self) -> None:
+        if self.use_aws:
+            from botocore.credentials import RefreshableCredentials
+
+            if self.log:
+                self.log.info("Establishing/renewing credentials")
+            self.credentials = configure_s3_access(
+                aws_unsigned=self.unsigned, requester_pays=self.requester_pays
+            )
+            if self.log and isinstance(self.credentials, RefreshableCredentials):
+                # pylint: disable=protected-access
+                self.log.debug(
+                    "%s seconds remaining", str(self.credentials._seconds_remaining())
+                )
+
+
+def initialise_aws_credentials(log: Logger | None = None) -> None:
+    # pylint: disable=protected-access
+    with credential_lock:
+        if CredentialManager._instance is None:
+            _ = CredentialManager(log)

--- a/tests/test_startup.py
+++ b/tests/test_startup.py
@@ -14,30 +14,8 @@ import pytest
 
 
 def test_fake_creds(monkeypatch) -> None:
-    from datacube_ows.startup_utils import CredentialManager, initialise_aws_credentials
-
-    CredentialManager._instance = None
-    log = MagicMock()
-    monkeypatch.setenv("AWS_DEFAULT_REGION", "")
-    initialise_aws_credentials(log=log)
-    CredentialManager._instance = None
-    monkeypatch.setenv("AWS_DEFAULT_REGION", "us-west-1")
-    monkeypatch.setenv("AWS_NO_SIGN_REQUEST", "false")
-    monkeypatch.setenv("AWS_REQUEST_PAYER", "requester")
-    with patch("datacube_ows.startup_utils.configure_s3_access") as s3a:
-        s3a.return_value = None
-        initialise_aws_credentials(log=log)
-        assert os.getenv("AWS_NO_SIGN_REQUEST") is None
-        CredentialManager._instance = None
-        monkeypatch.setenv("AWS_NO_SIGN_REQUEST", "yes")
-        initialise_aws_credentials()
-        assert os.getenv("AWS_ACCESS_KEY_ID") == "fake"
-
-
-def test_renewable_creds(monkeypatch) -> None:
-    from datacube_ows.startup_utils import (
+    from datacube_ows.startup_utils.creds import (
         CredentialManager,
-        RefreshableCredentials,
         initialise_aws_credentials,
     )
 
@@ -49,7 +27,33 @@ def test_renewable_creds(monkeypatch) -> None:
     monkeypatch.setenv("AWS_DEFAULT_REGION", "us-west-1")
     monkeypatch.setenv("AWS_NO_SIGN_REQUEST", "false")
     monkeypatch.setenv("AWS_REQUEST_PAYER", "requester")
-    with patch("datacube_ows.startup_utils.configure_s3_access") as s3a:
+    with patch("datacube_ows.startup_utils.creds.configure_s3_access") as s3a:
+        s3a.return_value = None
+        initialise_aws_credentials(log=log)
+        assert os.getenv("AWS_NO_SIGN_REQUEST") is None
+        CredentialManager._instance = None
+        monkeypatch.setenv("AWS_NO_SIGN_REQUEST", "yes")
+        initialise_aws_credentials()
+        assert os.getenv("AWS_ACCESS_KEY_ID") == "fake"
+
+
+def test_renewable_creds(monkeypatch) -> None:
+    from botocore.credentials import RefreshableCredentials
+
+    from datacube_ows.startup_utils.creds import (
+        CredentialManager,
+        initialise_aws_credentials,
+    )
+
+    CredentialManager._instance = None
+    log = MagicMock()
+    monkeypatch.setenv("AWS_DEFAULT_REGION", "")
+    initialise_aws_credentials(log=log)
+    CredentialManager._instance = None
+    monkeypatch.setenv("AWS_DEFAULT_REGION", "us-west-1")
+    monkeypatch.setenv("AWS_NO_SIGN_REQUEST", "false")
+    monkeypatch.setenv("AWS_REQUEST_PAYER", "requester")
+    with patch("datacube_ows.startup_utils.creds.configure_s3_access") as s3a:
         mock_creds = MagicMock(spec=RefreshableCredentials)
         s3a.return_value = mock_creds
         initialise_aws_credentials(log=log)
@@ -59,7 +63,10 @@ def test_renewable_creds(monkeypatch) -> None:
 
 
 def test_s3_endpoint_default(monkeypatch) -> None:
-    from datacube_ows.startup_utils import CredentialManager, initialise_aws_credentials
+    from datacube_ows.startup_utils.creds import (
+        CredentialManager,
+        initialise_aws_credentials,
+    )
 
     CredentialManager._instance = None
     log = MagicMock()


### PR DESCRIPTION
Trying to ensure flask starts up in a minimal and thread-safe environment - hopefully fixes #1404.

- Conditional/delayed imports
- thread lock around CredentialManager
- Initialise Flask earlier in the startup chain.

<!-- readthedocs-preview datacube-ows start -->
----
📚 Documentation preview 📚: https://datacube-ows--1411.org.readthedocs.build/en/1411/

<!-- readthedocs-preview datacube-ows end -->