### PR TITLE
Serialise matplotlib access

### DIFF
--- a/datacube_ows/styles/base.py
+++ b/datacube_ows/styles/base.py
@@ -7,6 +7,7 @@
 import io
 import logging
 from collections.abc import Iterable, Mapping, MutableMapping, Sized
+from threading import Lock
 from typing import Any, Optional, Union, cast
 
 import datacube.model
@@ -15,7 +16,6 @@ import xarray as xr
 from flask_babel import get_locale
 from PIL import Image
 from typing_extensions import override
-from threading import Lock
 
 import datacube_ows.band_utils
 from datacube_ows.config_utils import (

--- a/datacube_ows/styles/base.py
+++ b/datacube_ows/styles/base.py
@@ -15,6 +15,7 @@ import xarray as xr
 from flask_babel import get_locale
 from PIL import Image
 from typing_extensions import override
+from threading import Lock
 
 import datacube_ows.band_utils
 from datacube_ows.config_utils import (
@@ -37,6 +38,10 @@ from datacube_ows.legend_utils import get_image_from_url
 from datacube_ows.ogc_exceptions import WMSException
 
 _LOG: logging.Logger = logging.getLogger(__name__)
+
+
+# Matplotlib is not thread safe. Add a lock to serialise access to it.
+mpl_lock = Lock()
 
 
 class LegendBase(OWSConfigEntry):
@@ -434,7 +439,8 @@ class StyleDefBase(OWSExtensibleConfigEntry, OWSMetadataConfig):
 
     def render_legend(self, dates: int | list[Any]) -> Image.Image | None:
         """
-        Render legend, if possible
+        Render legend, if possible.
+
         :param dates: The number of dates to render the legend for (e.g. for delta)
         :return: A PIL Image object, or None.
         """
@@ -453,7 +459,9 @@ class StyleDefBase(OWSExtensibleConfigEntry, OWSMetadataConfig):
         if not legend.style_or_mdh.auto_legend:
             return None
         bytesio = io.BytesIO()
-        legend.render(bytesio)
+        # Serialise Matplotlib access
+        with mpl_lock:
+            legend.render(bytesio)
         bytesio.seek(0)
         return Image.open(bytesio)
 


### PR DESCRIPTION
Matplotlib is known to be not threadsafe (see also #1062)

This PR wraps legend generation that uses matplotlib in a thread lock.

MPL is also called at startup, when the configuration is parsed, but this should only be done once at startup.

<!-- readthedocs-preview datacube-ows start -->
----
📚 Documentation preview 📚: https://datacube-ows--1421.org.readthedocs.build/en/1421/

<!-- readthedocs-preview datacube-ows end -->