### PR TITLE
compose: speed up database

### DIFF
--- a/docker-compose.db.yaml
+++ b/docker-compose.db.yaml
@@ -14,7 +14,7 @@ services:
       - ./docker/files/create-pg-databases.sh:/docker-entrypoint-initdb.d/create-pg-databases.sh
       - type: tmpfs
         target: /var/lib/postgresql
-    command: -c fsync=off -c full_page_writes=off
+    command: -c fsync=off -c full_page_writes=off -c synchronous_commit=off
     healthcheck:
       test: ["CMD", "pg_isready", "-h", "postgres", "-q", "--port", "35434", "-d", "$POSTGRES_DB", "-U", "$POSTGRES_USER"]
       timeout: 45s

--- a/docker-compose.db.yaml
+++ b/docker-compose.db.yaml
@@ -14,7 +14,7 @@ services:
       - ./docker/files/create-pg-databases.sh:/docker-entrypoint-initdb.d/create-pg-databases.sh
       - type: tmpfs
         target: /var/lib/postgresql
-    command: -c fsync=off
+    command: -c fsync=off -c full_page_writes=off
     healthcheck:
       test: ["CMD", "pg_isready", "-h", "postgres", "-q", "--port", "35434", "-d", "$POSTGRES_DB", "-U", "$POSTGRES_USER"]
       timeout: 45s

--- a/docker-compose.db.yaml
+++ b/docker-compose.db.yaml
@@ -14,6 +14,7 @@ services:
       - ./docker/files/create-pg-databases.sh:/docker-entrypoint-initdb.d/create-pg-databases.sh
       - type: tmpfs
         target: /var/lib/postgresql
+    command: -c fsync=off
     healthcheck:
       test: ["CMD", "pg_isready", "-h", "postgres", "-q", "--port", "35434", "-d", "$POSTGRES_DB", "-U", "$POSTGRES_USER"]
       timeout: 45s


### PR DESCRIPTION
This is a test-db-server, so turn off some things that ensure data integrity to make it go faster.

<!-- readthedocs-preview datacube-ows start -->
----
📚 Documentation preview 📚: https://datacube-ows--1423.org.readthedocs.build/en/1423/

<!-- readthedocs-preview datacube-ows end -->