### PR TITLE
compose: default to Dockerfile command

### DIFF
--- a/.github/workflows/test-prod.yaml
+++ b/.github/workflows/test-prod.yaml
@@ -65,7 +65,7 @@ jobs:
           export LOCAL_UID=$(id -u $USER)
           export LOCAL_GID=$(id -g $USER)
           export $(grep -v '^#' .env_simple | xargs)
-          docker compose -f docker-compose.yaml -f docker-compose.db.yaml -f docker-compose.prod.yaml up --quiet-pull -d --wait
+          docker compose -f docker-compose.yaml -f docker-compose.db.yaml up --quiet-pull -d --wait
           docker compose -f docker-compose.yaml -f docker-compose.db.yaml exec -T ows /bin/sh -c "cd /src && ./check-code-all.sh --no-test"
 
       # Run some tests on the images

--- a/README.rst
+++ b/README.rst
@@ -123,9 +123,13 @@ To start ows with a pre-indexed database::
 
   docker compose -f docker-compose.yaml -f docker-compose.db.yaml up
 
+To start ows with db and flask (development)::
+
+  docker compose -f docker-compose.yaml -f docker-compose.override.yaml -f docker-compose.db.yaml up
+
 To start ows with db and gunicorn instead of flask (production)::
 
-  docker compose -f docker-compose.yaml -f docker-compose.db.yaml -f docker-compose.prod.yaml up
+  docker compose -f docker-compose.yaml -f docker-compose.db.yaml up
 
 The default environment variables (in .env file) can be overriden by setting local environment variables::
 

--- a/docker-compose.override.yaml
+++ b/docker-compose.override.yaml
@@ -1,0 +1,5 @@
+# override default compose to change the launch command
+
+services:
+  ows:
+    command: ["flask", "run", "--host=0.0.0.0", "--port=8000"]

--- a/docker-compose.prod.yaml
+++ b/docker-compose.prod.yaml
@@ -1,5 +1,0 @@
-# override default compose to change the launch command
-
-services:
-  ows:
-    command: gunicorn -b '0.0.0.0:8000' --workers=3 -k gevent --timeout 121 --pid /home/ubuntu/gunicorn.pid --log-level info --worker-tmp-dir /dev/shm --config python:datacube_ows.gunicorn_config "datacube_ows.startup_utils:create_app()"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -48,4 +48,3 @@ services:
       - ./:/src/
       - ./artifacts:/mnt/artifacts
     # restart: always
-    command: ["flask", "run", "--host=0.0.0.0", "--port=8000"]


### PR DESCRIPTION
Put the flask command in
docker-compose.override.yaml, which
will load automatically if docker compose
is run without specifying -f.

<!-- readthedocs-preview datacube-ows start -->
----
📚 Documentation preview 📚: https://datacube-ows--1424.org.readthedocs.build/en/1424/

<!-- readthedocs-preview datacube-ows end -->