### PR TITLE
Set User-Agent for requests

### DIFF
--- a/datacube_ows/legend_utils.py
+++ b/datacube_ows/legend_utils.py
@@ -30,6 +30,14 @@ def make_session(max_retries: Retry) -> Session:
     session = Session()
     session.mount("http://", HTTPAdapter(max_retries=max_retries))
     session.mount("https://", HTTPAdapter(max_retries=max_retries))
+    session.headers.update(
+        [
+            (
+                "User-Agent",
+                "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:147.0) Gecko/20100101 Firefox/147.0",
+            )
+        ]
+    )
     return session
 
 

--- a/integration_tests/utils.py
+++ b/integration_tests/utils.py
@@ -416,9 +416,15 @@ class HttpResolver(Resolver):
 
 
 def get_xsd(name: str) -> XMLSchema:
-    xsd_f = request.urlopen("https://schemas.opengis.net/" + name)
+    req = request.Request("https://schemas.opengis.net/" + name)
+    req.add_header(
+        "User-Agent",
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:147.0) Gecko/20100101 Firefox/147.0",
+    )
     parser = XMLParser(load_dtd=True, no_network=False)
     parser.resolvers.add(HttpResolver())
+    # FIXME: this should probably use a with-statement so urlopen() gets closed.
+    xsd_f = request.urlopen(req)
     return XMLSchema(parse(xsd_f, parser))
 
 


### PR DESCRIPTION
Impersonate a Firefox on Windows
to not get caught up in the CloudFlare
firewall.

Have not seen it happen yet, but
it happened to pystac:
https://github.com/stac-utils/pystac/issues/1575

<!-- readthedocs-preview datacube-ows start -->
----
📚 Documentation preview 📚: https://datacube-ows--1451.org.readthedocs.build/en/1451/

<!-- readthedocs-preview datacube-ows end -->