### PR TITLE
loading: raise exception on failure

### DIFF
--- a/datacube_ows/loading.py
+++ b/datacube_ows/loading.py
@@ -311,22 +311,26 @@ class DataStacker:
                 continue
             measurements = pbq.products[0].lookup_measurements(pbq.bands)
             fuse_func = pbq.fuse_func
-            if pbq.manual_merge and len(datasets) > 0:
-                qry_result = self.manual_data_stack(
-                    datasets,
-                    measurements,
-                    pbq.bands,
-                    skip_corrections,
-                    fuse_func=fuse_func,
+            try:
+                qry_result = (
+                    self.manual_data_stack(
+                        datasets,
+                        measurements,
+                        pbq.bands,
+                        skip_corrections,
+                        fuse_func=fuse_func,
+                    )
+                    if pbq.manual_merge and len(datasets) > 0
+                    else self.read_data(
+                        datasets,
+                        measurements,
+                        self._geobox,
+                        resampling=self._resampling,
+                        fuse_func=fuse_func,
+                    )
                 )
-            else:
-                qry_result = self.read_data(
-                    datasets,
-                    measurements,
-                    self._geobox,
-                    resampling=self._resampling,
-                    fuse_func=fuse_func,
-                )
+            except Exception as e:
+                raise WMSException("Error loading data") from e
             if qry_result is None:
                 continue
             if data is None:


### PR DESCRIPTION
Some upper layer seem to be expecting
a WMSException, so catch any exceptions
from loading data and raise a WMSException
from the exceptions from loading data.

Fixes #1449

<!-- readthedocs-preview datacube-ows start -->
----
📚 Documentation preview 📚: https://datacube-ows--1457.org.readthedocs.build/en/1457/

<!-- readthedocs-preview datacube-ows end -->