### PR TITLE
Fix hybrid style xarray merge.

### DIFF
--- a/datacube_ows/styles/hybrid.py
+++ b/datacube_ows/styles/hybrid.py
@@ -63,7 +63,8 @@ class HybridStyleDef(ColorRampDef, ComponentStyleDef):
         """
         # pylint: disable=too-many-locals
         if self.index_function is not None:
-            data["index_function"] = (data.dims, self.index_function(data).data)
+            idx_data = self.index_function(data)
+            data["index_function"] = (idx_data.dims, idx_data.data)
 
         imgdata = Dataset(coords=data)
 


### PR DESCRIPTION
There's a bug in dimension handling in Hybrid styles.  Works fine with the legacy loader, but fails in the rio driver.

This PR fixes it so it works with both loaders.

There's still another issue in core to be resolved before OWS can use the rio loader driver.