### PR TITLE
Use common psql (where not using explicit SQL files)

### DIFF
--- a/datacube_ows/index/postgis/api.py
+++ b/datacube_ows/index/postgis/api.py
@@ -13,6 +13,7 @@ from uuid import UUID
 import click
 from antimeridian import fix_shape
 from datacube import Datacube
+from datacube.drivers.common_psql import as_role
 from datacube.model import Dataset, Product, Range
 from odc.geo import CRS, Geometry
 from sqlalchemy import text
@@ -65,8 +66,8 @@ class OWSPostgisIndex(OWSAbstractIndex):
         else:
             from psycopg2.errors import ProgrammingError
         try:
-            with get_sqlconn(dc) as conn:
-                conn.execute(text(f"set role odc_{group}"))
+            with get_sqlconn(dc) as conn, as_role(conn, f"odc_{group}"):
+                pass
         except ProgrammingError:
             raise InsufficientDbPrivileges(
                 f"db user {dc.index.environment.db_username} does not have odc_{group} privileges"

--- a/datacube_ows/index/postgres/api.py
+++ b/datacube_ows/index/postgres/api.py
@@ -63,7 +63,7 @@ class OWSPostgresIndex(OWSAbstractIndex):
         else:
             from psycopg2.errors import ProgrammingError
         try:
-            with get_sqlconn(dc) as conn, as_role(conn, f"agdc_{group}") as conn:
+            with get_sqlconn(dc) as conn, as_role(conn, f"agdc_{group}"):
                 pass
         except ProgrammingError as e:
             raise InsufficientDbPrivileges(

--- a/datacube_ows/index/postgres/api.py
+++ b/datacube_ows/index/postgres/api.py
@@ -11,6 +11,7 @@ from uuid import UUID
 
 import click
 from datacube import Datacube
+from datacube.drivers.common_psql import as_role
 from datacube.model import Dataset, Product
 from odc.geo import CRS, Geometry
 from sqlalchemy import text
@@ -62,8 +63,8 @@ class OWSPostgresIndex(OWSAbstractIndex):
         else:
             from psycopg2.errors import ProgrammingError
         try:
-            with get_sqlconn(dc) as conn:
-                conn.execute(text(f"set role agdc_{group}"))
+            with get_sqlconn(dc) as conn, as_role(conn, f"agdc_{group}") as conn:
+                pass
         except ProgrammingError as e:
             raise InsufficientDbPrivileges(
                 f"db user {dc.index.environment.db_username} does not have agdc_{group} privileges: {e}"

--- a/datacube_ows/index/sql.py
+++ b/datacube_ows/index/sql.py
@@ -69,8 +69,10 @@ def run_sql(dc: Datacube, path: str, **params: str) -> bool:
                 sql = sql.format(**kwargs)
             if isolated:
                 conn.commit()
-                with get_sqlconn(dc) as iso_conn:
-                    iso_conn.execution_options(isolation_level="AUTOCOMMIT")
+                with (
+                    get_sqlconn(dc) as _conn,
+                    _conn.execution_options(isolation_level="AUTOCOMMIT") as iso_conn,
+                ):
                     run_sql_statement(sql, comment, fname, iso_conn, dc.index)
             else:
                 run_sql_statement(sql, comment, fname, conn, dc.index)

--- a/datacube_ows/index/sql.py
+++ b/datacube_ows/index/sql.py
@@ -69,9 +69,8 @@ def run_sql(dc: Datacube, path: str, **params: str) -> bool:
                 sql = sql.format(**kwargs)
             if isolated:
                 conn.commit()
-                with get_sqlconn(dc).execution_options(
-                    isolation_level="AUTOCOMMIT"
-                ) as iso_conn:
+                with get_sqlconn(dc) as iso_conn:
+                    iso_conn.execution_options(isolation_level="AUTOCOMMIT")
                     run_sql_statement(sql, comment, fname, iso_conn, dc.index)
             else:
                 run_sql_statement(sql, comment, fname, conn, dc.index)

--- a/datacube_ows/utils.py
+++ b/datacube_ows/utils.py
@@ -6,7 +6,8 @@
 
 import datetime
 import logging
-from collections.abc import Callable
+from collections.abc import Callable, Generator
+from contextlib import contextmanager
 from functools import wraps
 from time import monotonic
 from typing import Any, TypeVar, cast
@@ -144,15 +145,16 @@ def group_by_mosaic(pnames: list[str] | None = None) -> GroupBy:
     )
 
 
-def get_sqlconn(dc: Datacube) -> Connection:
+@contextmanager
+def get_sqlconn(dc: Datacube) -> Generator[Connection]:
     """
     Extracts a SQLAlchemy database connection from a Datacube object.
 
     :param dc: An initialised Datacube object
     :return: A SQLAlchemy database connection object.
     """
-    # pylint: disable=protected-access
-    return dc.index._db._engine.connect()  # type: ignore[attr-defined]
+    with dc.index._db._engine.connect() as conn:  # type: ignore[attr-defined]
+        yield conn
 
 
 def get_driver_name(index: Index) -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
     "affine",
     "antimeridian",
     "click",
-    "datacube[performance,s3]>=1.9.13,<1.10.0",
+    "datacube[performance,s3]>=1.9.14,<1.10.0",
     "deepdiff",
     "flask",
     "fsspec",

--- a/uv.lock
+++ b/uv.lock
@@ -807,7 +807,7 @@ requires-dist = [
     { name = "babel" },
     { name = "blinker", marker = "extra == 'ops'" },
     { name = "click" },
-    { name = "datacube", extras = ["performance", "s3"], specifier = ">=1.9.13,<1.10.0" },
+    { name = "datacube", extras = ["performance", "s3"], specifier = ">=1.9.14,<1.10.0" },
     { name = "datacube-ows", extras = ["dev", "ops", "test"], marker = "extra == 'all'" },
     { name = "deepdiff" },
     { name = "flask" },


### PR DESCRIPTION
Pin to datacube>=1.9.14 and make some basic usage of common_psql functions.

More extensive use of common_psql will require a larger refactor of schema management code, currently implemented as directories of files containing explicit SQL commands.

<!-- readthedocs-preview datacube-ows start -->
----
📚 Documentation preview 📚: https://datacube-ows--1463.org.readthedocs.build/en/1463/

<!-- readthedocs-preview datacube-ows end -->