### PR TITLE
Use odc-loader for loading

### DIFF
--- a/datacube_ows/loading.py
+++ b/datacube_ows/loading.py
@@ -452,6 +452,7 @@ class DataStacker:
                 fuse_func=fuse_func,
                 skip_broken_datasets=skip_broken,
                 patch_url=self._layer.patch_url,
+                driver="rio",
                 resampling=resampling,
             )
         except Exception as e:
@@ -482,6 +483,7 @@ class DataStacker:
                 fuse_func=fuse_func,
                 skip_broken_datasets=skip_broken,
                 patch_url=self._layer.patch_url,
+                driver="rio",
                 resampling=resampling,
             )
         except Exception as e:


### PR DESCRIPTION
After the latest fixes by Paul
it's now possible to switch
OWS to using the odc-loader
for loading datasets. This
should be faster than
the legacy loader.

<!-- readthedocs-preview datacube-ows start -->
----
📚 Documentation preview 📚: https://datacube-ows--1465.org.readthedocs.build/en/1465/

<!-- readthedocs-preview datacube-ows end -->