### PR TITLE
Support "rio" driver - configurable, still defaults to "legacy".

### DIFF
--- a/datacube_ows/loading.py
+++ b/datacube_ows/loading.py
@@ -453,6 +453,7 @@ class DataStacker:
                 skip_broken_datasets=skip_broken,
                 patch_url=self._layer.patch_url,
                 resampling=resampling,
+                driver=self.cfg.load_driver,
             )
         except Exception as e:
             _LOG.error("Error (%s) in load_data: %s", e.__class__.__name__, str(e))
@@ -483,6 +484,7 @@ class DataStacker:
                 skip_broken_datasets=skip_broken,
                 patch_url=self._layer.patch_url,
                 resampling=resampling,
+                driver=self.cfg.load_driver,
             )
         except Exception as e:
             _LOG.error("Error (%s) in load_data: %s", e.__class__.__name__, str(e))

--- a/datacube_ows/ows_configuration.py
+++ b/datacube_ows/ows_configuration.py
@@ -1719,6 +1719,11 @@ class OWSConfig(OWSMetadataConfig):
         self.attribution = AttributionCfg.parse(
             cast(CFG_DICT | None, cfg.get("attribution")), self
         )
+        self.load_driver = cast(str, cfg.get("load_driver", "legacy"))
+        if self.load_driver not in ["rio", "legacy"]:
+            raise ConfigException(
+                f"Invalid load_driver: {self.load_driver} Please use 'rio' or 'legacy'"
+            )
 
         def make_gml_name(name: str) -> str:
             if name.startswith("EPSG:"):

--- a/integration_tests/cfg/ows_test_cfg.py
+++ b/integration_tests/cfg/ows_test_cfg.py
@@ -596,6 +596,7 @@ ows_cfg = {
         "message_file": f"{trans_dir}/integration_tests/cfg/message.po",
         "translations_directory": f"{trans_dir}/integration_tests/cfg/translations",
         "supported_languages": ["en", "de"],
+        "load_driver": "rio",
         # URL that humans can visit to learn more about the service(s) or organization
         # should be fully qualified
         "info_url": "http://opendatacube.org",

--- a/tests/test_cfg_global.py
+++ b/tests/test_cfg_global.py
@@ -131,6 +131,20 @@ def test_no_services(minimal_global_raw_cfg) -> None:
     assert "At least one service must be active" in str(excinfo.value)
 
 
+def test_load_driver(minimal_global_raw_cfg) -> None:
+    OWSConfig._instance = None
+    cfg = OWSConfig(cfg=minimal_global_raw_cfg)
+    assert cfg.load_driver == "legacy"
+
+
+def test_invalid_load_driver(minimal_global_raw_cfg) -> None:
+    OWSConfig._instance = None
+    minimal_global_raw_cfg["global"]["load_driver"] = "flange"
+    with pytest.raises(ConfigException) as excinfo:
+        _ = OWSConfig(cfg=minimal_global_raw_cfg)
+    assert "Invalid load_driver" in str(excinfo.value)
+
+
 def test_no_published_crss(minimal_global_raw_cfg) -> None:
     del minimal_global_raw_cfg["global"]["published_CRSs"]
     with pytest.raises(ConfigException) as e:


### PR DESCRIPTION
1. `load_driver` config entry in `global` section. Must be `rio` or `legacy`, defaults to `legacy`.
2. Call `dc.load_data()` with the configured load_driver.
3. Run integration test server with rio driver.

Unsure whether to default to legacy or rio.  Probably best to default to legacy for now and switch to rio in a future release.

Supercedes #1465

<!-- readthedocs-preview datacube-ows start -->
----
📚 Documentation preview 📚: https://datacube-ows--1466.org.readthedocs.build/en/1466/

<!-- readthedocs-preview datacube-ows end -->