### PR TITLE
Log arguments triggering exceptions

### DIFF
--- a/datacube_ows/ogc.py
+++ b/datacube_ows/ogc.py
@@ -133,6 +133,7 @@ def ogc_svc_impl(svc):
             "Internal server error.", http_response=500
         ).exception_response()
     except Exception as e:  # pylint: disable=broad-except
+        _LOG.error(f"Arguments for unexpected error: {nocase_args}")
         _LOG.exception(e)
         tb = sys.exc_info()[2]
         ogc_e = version_support.exception_class(


### PR DESCRIPTION
This makes it easier to reproduce
errors found in the logs.

<!-- readthedocs-preview datacube-ows start -->
----
📚 Documentation preview 📚: https://datacube-ows--1480.org.readthedocs.build/en/1480/

<!-- readthedocs-preview datacube-ows end -->