### PR TITLE
CI: fix non-primary branch name

### DIFF
--- a/.github/workflows/complementary-config-test.yaml
+++ b/.github/workflows/complementary-config-test.yaml
@@ -4,7 +4,7 @@ name: Complementary config test
 on:
   pull_request:
     branches: &branches
-      - 'develop-1.9'
+      - 'develop-1.8'
       - 'develop'
     paths: &paths
       - '**'

--- a/.github/workflows/dockerfile-lint.yml
+++ b/.github/workflows/dockerfile-lint.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
     branches: &branches
       - 'develop'
-      - 'develop-1.9'
+      - 'develop-1.8'
     paths: &paths
       - 'Dockerfile'
       - '.github/workflows/dockerfile-lint.yml'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
     branches: &branches
       - 'develop'
-      - 'develop-1.9'
+      - 'develop-1.8'
     paths: &paths
       - '**'
       - '!docs/**'

--- a/.github/workflows/pyspy-profiling.yaml
+++ b/.github/workflows/pyspy-profiling.yaml
@@ -5,7 +5,7 @@ on:
   pull_request:
     branches: &branches
       - 'develop'
-      - 'develop-1.9'
+      - 'develop-1.8'
     paths: &paths
       - '**'
       - '!docs/**'

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -5,7 +5,7 @@ on:
   push:
     branches: &branches
       - develop
-      - develop-1.9
+      - develop-1.8
     paths: &paths
       - ".github/workflows/scan.yml"
       - "Dockerfile"

--- a/.github/workflows/spellcheck.yaml
+++ b/.github/workflows/spellcheck.yaml
@@ -5,7 +5,7 @@ on:
   pull_request:
     branches: &branches
       - 'develop'
-      - 'develop-1.9'
+      - 'develop-1.8'
     paths: &paths
       - 'docs/**'
       - '*.md'

--- a/.github/workflows/test-prod.yaml
+++ b/.github/workflows/test-prod.yaml
@@ -5,7 +5,7 @@ on:
   pull_request:
     branches: &branches
       - 'develop'
-      - 'develop-1.9'
+      - 'develop-1.8'
     paths: &paths
       - '**'
       - '!docs/**'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
     branches: &branches
       - 'develop'
-      - 'develop-1.9'
+      - 'develop-1.8'
     paths: &paths
       - '**'
       - '!docs/**'


### PR DESCRIPTION
There is no develop-1.9 branch
any longer, so switch to using
the develop-1.8 branch instead.

<!-- readthedocs-preview datacube-ows start -->
----
📚 Documentation preview 📚: https://datacube-ows--1496.org.readthedocs.build/en/1496/

<!-- readthedocs-preview datacube-ows end -->