### PR TITLE
Dockerfile: increase UV_HTTP_RETRIES

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
         python3-dev
 
 ENV UV_COMPILE_BYTECODE=0 \
+    UV_HTTP_RETRIES=10 \
     UV_LINK_MODE=copy \
     UV_PROJECT_ENVIRONMENT=/app \
     UV_PYTHON_DOWNLOADS=never \


### PR DESCRIPTION
This reduces the risk of intermittent
failures causing the build to fail.

<!-- readthedocs-preview datacube-ows start -->
----
📚 Documentation preview 📚: https://datacube-ows--1498.org.readthedocs.build/en/1498/

<!-- readthedocs-preview datacube-ows end -->