### PR TITLE
Fix netcdf export in WCS 1 & 2.

### DIFF
--- a/datacube_ows/wcs1_utils.py
+++ b/datacube_ows/wcs1_utils.py
@@ -531,6 +531,9 @@ def get_netcdf(req, data: xr.Dataset) -> bytes:
             del v.attrs["spectral_definition"]
         if "flags_definition" in v.attrs:
             del v.attrs["flags_definition"]
+        # Why is this only needed with rio loader??
+        if "grid_mapping" in v.attrs:
+            del v.attrs["grid_mapping"]
     if "time" in data and "units" in data["time"].attrs:
         del data["time"].attrs["units"]
 

--- a/datacube_ows/wcs2_utils.py
+++ b/datacube_ows/wcs2_utils.py
@@ -443,6 +443,9 @@ def get_netcdf(request, data: xr.Dataset, crs) -> bytes:
             del v.attrs["spectral_definition"]
         if "flags_definition" in v.attrs:
             del v.attrs["flags_definition"]
+        # Why is this only needed with rio loader??
+        if "grid_mapping" in v.attrs:
+            del v.attrs["grid_mapping"]
     if "time" in data and "units" in data["time"].attrs:
         del data["time"].attrs["units"]
 


### PR DESCRIPTION
NetCDF exports were broken by this:  https://github.com/opendatacube/datacube-core/pull/2369

It's not clear why as the grid_mapping attribute that this fix PR manually removes to make things work again with the rio driver are also present with the legacy driver (where netcdf exports work fine without this patch).

Very odd, but this seems like the correct thing to do.

<!-- readthedocs-preview datacube-ows start -->
----
📚 Documentation preview 📚: https://datacube-ows--1505.org.readthedocs.build/en/1505/

<!-- readthedocs-preview datacube-ows end -->