### PR TITLE
Fix fuse functions in driver based loads

### DIFF
--- a/datacube_ows/config_utils.py
+++ b/datacube_ows/config_utils.py
@@ -758,9 +758,16 @@ class OWSFlagBand(OWSConfigEntry):
         self.pq_band = str(cfg["band"])
         self.canonical_band_name = self.pq_band  # Update for aliasing on make_ready
         if "fuse_func" in cfg:
-            self.pq_fuse_func: FunctionWrapper | None = FunctionWrapper(
-                self.layer, cast(CFG_DICT, cfg["fuse_func"])
-            )
+            if self.layer.global_cfg.load_driver == "legacy":
+                self.pq_fuse_func: FunctionWrapper | str | None = FunctionWrapper(
+                    self.layer, cast(CFG_DICT, cfg["fuse_func"])
+                )
+            elif isinstance(cfg["fuse_func"], str):
+                self.pq_fuse_func = cfg["fuse_func"]
+            else:
+                raise ConfigException(
+                    f"Flag fuse_func must be a string for driver-based loads (in layer {self.layer.name})"
+                )
         else:
             self.pq_fuse_func = None
         self.pq_ignore_time = bool(cfg.get("ignore_time", False))

--- a/datacube_ows/loading.py
+++ b/datacube_ows/loading.py
@@ -40,7 +40,7 @@ class ProductBandQuery:
         main: bool = False,
         manual_merge: bool = False,
         ignore_time: bool = False,
-        fuse_func: FuserFunc | None = None,
+        fuse_func: FuserFunc | str | None = None,
     ) -> None:
         self.products = products
         self.bands = set(bands)
@@ -132,7 +132,7 @@ class ProductBandQuery:
         layer: OWSNamedLayer,
         bands: Iterable[str],
         manual_merge: bool = False,
-        fuse_func: FuserFunc | None = None,
+        fuse_func: FuserFunc | str | None = None,
         resource_limited: bool = False,
     ) -> "ProductBandQuery":
         main_products = layer.low_res_products if resource_limited else layer.products
@@ -387,7 +387,7 @@ class DataStacker:
         measurements: Mapping[str, Measurement],
         bands: set[str],
         skip_corrections: bool,
-        fuse_func: FuserFunc | None,
+        fuse_func: FuserFunc | str | None,
     ) -> xarray.Dataset | None:
         # pylint: disable=too-many-locals, too-many-branches
         # manual merge
@@ -444,7 +444,7 @@ class DataStacker:
         geobox: GeoBox,
         skip_broken: bool = True,
         resampling: Resampling = "nearest",
-        fuse_func: FuserFunc | None = None,
+        fuse_func: FuserFunc | str | None = None,
     ) -> xarray.Dataset:
         CredentialManager.check_cred()
         return datacube.Datacube.load_data(
@@ -467,7 +467,7 @@ class DataStacker:
         geobox: GeoBox,
         skip_broken: bool = True,
         resampling: Resampling = "nearest",
-        fuse_func: FuserFunc | None = None,
+        fuse_func: FuserFunc | str | None = None,
     ) -> xarray.Dataset:
         return self.read_data(
             datacube.Datacube.group_datasets(

--- a/datacube_ows/ows_configuration.py
+++ b/datacube_ows/ows_configuration.py
@@ -858,7 +858,9 @@ class OWSNamedLayer(OWSExtensibleConfigEntry, OWSLayer):
             elif isinstance(cfg["fuse_func"], str):
                 self.fuse_func = cfg["fuse_func"]
             else:
-                raise ConfigException(f"fuse_func must be a string for driver-based loads (in layer {self.name})")
+                raise ConfigException(
+                    f"fuse_func must be a string for driver-based loads (in layer {self.name})"
+                )
         else:
             self.fuse_func = None
 

--- a/datacube_ows/ows_configuration.py
+++ b/datacube_ows/ows_configuration.py
@@ -851,9 +851,14 @@ class OWSNamedLayer(OWSExtensibleConfigEntry, OWSLayer):
             )
 
         if cfg.get("fuse_func"):
-            self.fuse_func: FunctionWrapper | None = FunctionWrapper(
-                self, cast(str | CFG_DICT, cfg["fuse_func"])
-            )
+            if self.global_cfg.load_driver == "legacy":
+                self.fuse_func: FunctionWrapper | str | None = FunctionWrapper(
+                    self, cast(str | CFG_DICT, cfg["fuse_func"])
+                )
+            elif isinstance(cfg["fuse_func"], str):
+                self.fuse_func = cfg["fuse_func"]
+            else:
+                raise ConfigException(f"fuse_func must be a string for driver-based loads (in layer {self.name})")
         else:
             self.fuse_func = None
 

--- a/docs/cfg_global.rst
+++ b/docs/cfg_global.rst
@@ -23,8 +23,20 @@ You can override this with the ``env`` global config entry::
 
     "env": "dev"
 
-Future releases will allow this to be over-ridden at the layer level, allowing one OWS instance to serve data
+Note that this can be over-ridden at the layer level, allowing one OWS instance to serve data
 from multiple indexes.
+
+Loader Driver
+=============
+
+Specifies the ODC loader driver to use.  Currently the default is "legacy".  Set to
+"rio" to use the rio loader driver from odc-loader.
+
+Notes:
+
+1. "rio" will become the default in a future release.
+2. For non-legacy loader drivers, fuser functions must be specified as a string (fully
+   qualified Python name).
 
 Metadata Separation and Internationalisation
 ============================================

--- a/docs/cfg_layers.rst
+++ b/docs/cfg_layers.rst
@@ -979,7 +979,12 @@ Fuse Function (fuse_func)
 +++++++++++++++++++++++++
 
 Determines how multiple dataset arrays are compressed into a
-single time array. Specified using OWS's :doc:`function configuration
+single time array.
+
+If the global "load_driver" is set to "rio", ``fuse_func`` must be a string
+representing an importable, fully-qualified python function name (or None).
+
+For the legacy loader only, ``fuse_func`` can be Specified using OWS's :doc:`function configuration
 format <cfg_functions>`.
 
 The fuse function is passed through to directly to the datacube
@@ -1139,6 +1144,13 @@ Flag Fuse Function (fuse_func)
 Only applies if the flag band is read from a separate product
 (or product).  Equivalent to the `fuse function in the
 image_processing section <#fuse-function-fuse-func>`_.
+
+If the global "load_driver" is set to "rio", ``fuse_func`` must be a string
+representing an importable, fully-qualified python function name (or None).
+
+For the legacy loader only, ``fuse_func`` can be Specified using OWS's :doc:`function configuration
+format <cfg_functions>`.
+
 Always optional - defaults to None.
 
 Manual Flag Merge (manual_merge)


### PR DESCRIPTION
OWS was not passing fuse functions to driver-based loads correctly.

1. Ensure fuse_functions are only supplied as strings, and are passed as strings to `load_data` when the `load_driver` is not "legacy".
2. Document above behaviour.

<!-- readthedocs-preview datacube-ows start -->
----
📚 Documentation preview 📚: https://datacube-ows--1518.org.readthedocs.build/en/1518/

<!-- readthedocs-preview datacube-ows end -->