### PR TITLE
wms_utils: catch IndexError

### DIFF
--- a/datacube_ows/feature_info.py
+++ b/datacube_ows/feature_info.py
@@ -227,7 +227,7 @@ def feature_info(args: dict[str, str]) -> FlaskResponse:
 
                 # Extract data pixel
                 #       Mypy complains locally about this ignore being unused,
-                #       but mypy on github fails without it.
+                #       but mypy on GitHub fails without it.
                 pixel_ds: xarray.Dataset = td.isel(**isel_kwargs)  # type: ignore[arg-type]
 
                 # Get accurate timestamp from dataset

--- a/datacube_ows/wms_utils.py
+++ b/datacube_ows/wms_utils.py
@@ -131,11 +131,15 @@ def img_coords_to_geopoint(geobox, i, j) -> geom.Geometry:
     cfg = get_config()
     h_coord = cfg.published_CRSs[str(geobox.crs)]["horizontal_coord"]
     v_coord = cfg.published_CRSs[str(geobox.crs)]["vertical_coord"]
-    return geom.point(
-        geobox.coordinates[h_coord].values[int(i)],
-        geobox.coordinates[v_coord].values[int(j)],
-        geobox.crs,
-    )
+    try:
+        x = geobox.coordinates[h_coord].values[int(i)]
+    except IndexError as e:
+        raise WMSException(f"Horizontal coordinate: {e}") from None
+    try:
+        y = geobox.coordinates[v_coord].values[int(j)]
+    except IndexError as e:
+        raise WMSException(f"Vertical coordinate: {e}") from None
+    return geom.point(x, y, geobox.crs)
 
 
 def get_layer_from_arg(args, argname: str = "layers") -> OWSNamedLayer:


### PR DESCRIPTION
A WMS request containing width=1472
and height=804 but with i=314 and
j=879 will cause an IndexError.
Catch that and raise a WMSException
instead.

<!-- readthedocs-preview datacube-ows start -->
----
📚 Documentation preview 📚: https://datacube-ows--1521.org.readthedocs.build/en/1521/

<!-- readthedocs-preview datacube-ows end -->