### PR TITLE
Allow schema update operations to occur without an OWS configuration 

### DIFF
--- a/datacube_ows/index/api.py
+++ b/datacube_ows/index/api.py
@@ -14,7 +14,6 @@ from uuid import UUID
 
 from datacube import Datacube
 from datacube.cfg import ODCEnvironment
-from datacube.index.abstract import AbstractIndex
 from datacube.model import Dataset, Product
 from odc.geo.crs import CRS
 from odc.geo.geom import Geometry, polygon
@@ -209,12 +208,11 @@ class OWSAbstractIndexDriver(ABC):
     def ows_index(cls) -> OWSAbstractIndex: ...
 
 
-def ows_index(odc: Datacube | AbstractIndex | ODCEnvironment) -> OWSAbstractIndex:
+def ows_index(odc: Datacube | ODCEnvironment) -> OWSAbstractIndex:
     if isinstance(odc, ODCEnvironment):
         env = odc
     else:
-        index = odc if isinstance(odc, AbstractIndex) else odc.index
-        env = index.environment
+        env = odc.index.environment
 
     from datacube_ows.index.driver import ows_index_driver_by_name
 

--- a/datacube_ows/index/api.py
+++ b/datacube_ows/index/api.py
@@ -13,6 +13,7 @@ from typing import Any, Literal, NamedTuple, TypeAlias, Union
 from uuid import UUID
 
 from datacube import Datacube
+from datacube.cfg import ODCEnvironment
 from datacube.index.abstract import AbstractIndex
 from datacube.model import Dataset, Product
 from odc.geo.crs import CRS
@@ -208,9 +209,13 @@ class OWSAbstractIndexDriver(ABC):
     def ows_index(cls) -> OWSAbstractIndex: ...
 
 
-def ows_index(odc: Datacube | AbstractIndex) -> OWSAbstractIndex:
-    index = odc if isinstance(odc, AbstractIndex) else odc.index
-    env = index.environment
+def ows_index(odc: Datacube | AbstractIndex | ODCEnvironment) -> OWSAbstractIndex:
+    if isinstance(odc, ODCEnvironment):
+        env = odc
+    else:
+        index = odc if isinstance(odc, AbstractIndex) else odc.index
+        env = index.environment
+
     from datacube_ows.index.driver import ows_index_driver_by_name
 
     idx_drv_name = (

--- a/datacube_ows/index/api.py
+++ b/datacube_ows/index/api.py
@@ -13,7 +13,6 @@ from typing import Any, Literal, NamedTuple, TypeAlias, Union
 from uuid import UUID
 
 from datacube import Datacube
-from datacube.cfg import ODCEnvironment
 from datacube.model import Dataset, Product
 from odc.geo.crs import CRS
 from odc.geo.geom import Geometry, polygon
@@ -208,14 +207,10 @@ class OWSAbstractIndexDriver(ABC):
     def ows_index(cls) -> OWSAbstractIndex: ...
 
 
-def ows_index(odc: Datacube | ODCEnvironment) -> OWSAbstractIndex:
-    if isinstance(odc, ODCEnvironment):
-        env = odc
-    else:
-        env = odc.index.environment
-
+def ows_index(odc: Datacube) -> OWSAbstractIndex:
     from datacube_ows.index.driver import ows_index_driver_by_name
 
+    env = odc.index.environment
     idx_drv_name = (
         "postgres" if env.index_driver in ("default", "legacy") else env.index_driver
     )

--- a/datacube_ows/ows_configuration.py
+++ b/datacube_ows/ows_configuration.py
@@ -90,16 +90,20 @@ def read_config(path: str | None = None) -> CFG_DICT:
         except ImportError:
             raise ConfigException(
                 "No fallback default datacube_ows.ows_cfg module found."
-            )
+            ) from None
     elif "/" in cfg_env or cfg_env.endswith(".json"):
         # Looks a JSON file path
         try:
             cfg = load_json_obj(cfg_env)
             cwd = get_file_loc(cfg_env)
-        except FileNotFoundError as e:
-            raise ConfigException(f"Could not open json config file {cfg_env}: {e}")
+        except (FileNotFoundError, PermissionError) as e:
+            raise ConfigException(
+                f"Could not open json config file {cfg_env}: {e}"
+            ) from None
         except json.JSONDecodeError as e:
-            raise ConfigException(f"Could not parse json config file {cfg_env}: {e}")
+            raise ConfigException(
+                f"Could not parse json config file {cfg_env}: {e}"
+            ) from None
     elif "." in cfg_env:
         # Looks like a python object
         cfg = import_python_obj(cfg_env)
@@ -108,7 +112,7 @@ def read_config(path: str | None = None) -> CFG_DICT:
         try:
             cfg = json.loads(cfg_env)
         except json.JSONDecodeError as e:
-            raise ConfigException(f"Could not parse raw json config: {e}")
+            raise ConfigException(f"Could not parse raw json config: {e}") from None
         cwd = os.path.dirname(os.getcwd())
     else:
         try:
@@ -117,7 +121,7 @@ def read_config(path: str | None = None) -> CFG_DICT:
         except (AttributeError, ModuleNotFoundError) as e:
             raise ConfigException(
                 f"Could not open fallback default config file (datacube_ows.ows_cfg.{cfg_env}): {e})"
-            )
+            ) from None
     expansion = cfg_expand(cfg, cwd=cwd)
     if isinstance(expansion, dict):
         return expansion
@@ -1963,12 +1967,17 @@ class OWSConfig(OWSMetadataConfig):
 def get_config(
     refresh: bool = False,
     called_from_update_ranges: bool = False,
-    make_ready: bool = True,
+    make_ready: bool = True
 ) -> OWSConfig:
     cfg = OWSConfig(
         refresh=refresh, called_from_update_ranges=called_from_update_ranges
     )
     if make_ready and not cfg.ready:
-        with contextlib.suppress(ODCInitException):
-            cfg.make_ready()
+        try:
+            with contextlib.suppress(ODCInitException):
+                cfg.make_ready()
+        except OperationalError as e:
+            raise ConfigException(
+                f"Database outage while reading configuration: {e}."
+            ) from None
     return cfg

--- a/datacube_ows/ows_configuration.py
+++ b/datacube_ows/ows_configuration.py
@@ -70,6 +70,15 @@ _LOG: logging.Logger = logging.getLogger(__name__)
 
 
 def read_config(path: str | None = None) -> CFG_DICT:
+    """
+    Read the OWS configuration and perform expansions.
+
+    Returns either a CFG_DICT suitable for passing to the OWSConfig constructor,
+    or raises a ConfigException.
+
+    :param path: A str path descriptor.  If None or not set, reads path
+                 from the $DATACUBE_OWS_CFG environment variable.
+    """
     cwd = None
     if path:
         cfg_env: str | None = path
@@ -83,6 +92,7 @@ def read_config(path: str | None = None) -> CFG_DICT:
                 "No fallback default datacube_ows.ows_cfg module found."
             )
     elif "/" in cfg_env or cfg_env.endswith(".json"):
+        # Looks a JSON file path
         try:
             cfg = load_json_obj(cfg_env)
             cwd = get_file_loc(cfg_env)
@@ -91,8 +101,10 @@ def read_config(path: str | None = None) -> CFG_DICT:
         except json.JSONDecodeError as e:
             raise ConfigException(f"Could not parse json config file {cfg_env}: {e}")
     elif "." in cfg_env:
+        # Looks like a python object
         cfg = import_python_obj(cfg_env)
     elif cfg_env.startswith("{"):
+        # Looks like raw JSON
         try:
             cfg = json.loads(cfg_env)
         except json.JSONDecodeError as e:

--- a/datacube_ows/ows_configuration.py
+++ b/datacube_ows/ows_configuration.py
@@ -13,6 +13,7 @@
 #
 import contextlib
 import datetime
+import enum
 import json
 import logging
 import math
@@ -68,6 +69,12 @@ if TYPE_CHECKING:
 _LOG: logging.Logger = logging.getLogger(__name__)
 
 
+class Sources(enum.Enum):
+    READ_JSON_FILE = 0
+    LOAD_PYTHON_OBJECT = 1
+    READ_RAW_JSON = 2
+
+
 def read_config(path: str | None = None) -> CFG_DICT:
     """
     Read the OWS configuration and perform expansions.
@@ -83,30 +90,24 @@ def read_config(path: str | None = None) -> CFG_DICT:
         cfg_env: str | None = path
     else:
         cfg_env = os.environ.get("DATACUBE_OWS_CFG")
-    if not cfg_env:
-        raise ConfigException(
-            "DATACUBE_OWS_CFG environment variable not set. "
-        ) from None
 
+    if not cfg_env:
+        raise ConfigException("DATACUBE_OWS_CFG environment variable not set. ")
     if "/" in cfg_env or cfg_env.endswith(".json"):
-        # Looks a JSON file path
-        attempt_json_read_from_fs = True
+        # Looks like a URL or file path
+        src = Sources.READ_JSON_FILE
     elif "." in cfg_env:
         # Looks like a python object
-        cfg = import_python_obj(cfg_env)
+        src = Sources.LOAD_PYTHON_OBJECT
     elif cfg_env.startswith("{"):
         # Looks like raw JSON
-        try:
-            cfg = json.loads(cfg_env)
-        except json.JSONDecodeError as e:
-            raise ConfigException(f"Could not parse raw json config: {e}") from None
-        cwd = os.path.dirname(os.getcwd())
+        src = Sources.READ_RAW_JSON
     else:
-        # Doesn't look anything much - try it as a json file path
-        attempt_json_read_from_fs = True
+        # ?? - Default to parsing as a json file.
+        src = Sources.READ_JSON_FILE
 
-    if attempt_json_read_from_fs:
-        # Attempt to load as JSON file.
+    if src == Sources.READ_JSON_FILE:
+        # Attempt to load as JSON file from file system or S3
         try:
             cfg = load_json_obj(cfg_env)
             cwd = get_file_loc(cfg_env)
@@ -118,13 +119,26 @@ def read_config(path: str | None = None) -> CFG_DICT:
             raise ConfigException(
                 f"Could not parse json config file {cfg_env}: {e}"
             ) from None
+    elif src == Sources.LOAD_PYTHON_OBJECT:
+        # Attempt to import a python object.
+        cfg = import_python_obj(cfg_env)
+    else:
+        # Attempt to read raw JSON config
+        try:
+            cfg = json.loads(cfg_env)
+        except json.JSONDecodeError as e:
+            raise ConfigException(f"Could not parse raw json config: {e}") from None
 
+    if not isinstance(cfg, dict):
+        raise ConfigException(
+            f"Unexpended top level config must be a dict: {cfg!r} ({cfg.__class__.__name__})"
+        )
     expansion = cfg_expand(cfg, cwd=cwd)
-    if isinstance(expansion, dict):
-        return expansion
-    raise ConfigException(
-        f"Top level config must be a dict: {expansion!r} ({expansion.__class__.__name__})"
-    )
+    if not isinstance(expansion, dict):
+        raise ConfigException(
+            f"Top level config must be a dict: {expansion!r} ({expansion.__class__.__name__})"
+        )
+    return expansion
 
 
 class BandIndex(OWSMetadataConfig):
@@ -1964,7 +1978,7 @@ class OWSConfig(OWSMetadataConfig):
 def get_config(
     refresh: bool = False,
     called_from_update_ranges: bool = False,
-    make_ready: bool = True
+    make_ready: bool = True,
 ) -> OWSConfig:
     cfg = OWSConfig(
         refresh=refresh, called_from_update_ranges=called_from_update_ranges

--- a/datacube_ows/ows_configuration.py
+++ b/datacube_ows/ows_configuration.py
@@ -76,19 +76,36 @@ def read_config(path: str | None = None) -> CFG_DICT:
     else:
         cfg_env = os.environ.get("DATACUBE_OWS_CFG")
     if not cfg_env:
-        from datacube_ows.ows_cfg import ows_cfg as cfg
+        try:
+            from datacube_ows.ows_cfg import ows_cfg as cfg
+        except ImportError:
+            raise ConfigException(
+                "No fallback default datacube_ows.ows_cfg module found."
+            )
     elif "/" in cfg_env or cfg_env.endswith(".json"):
-        cfg = load_json_obj(cfg_env)
-        cwd = get_file_loc(cfg_env)
+        try:
+            cfg = load_json_obj(cfg_env)
+            cwd = get_file_loc(cfg_env)
+        except FileNotFoundError as e:
+            raise ConfigException(f"Could not open json config file {cfg_env}: {e}")
+        except json.JSONDecodeError as e:
+            raise ConfigException(f"Could not parse json config file {cfg_env}: {e}")
     elif "." in cfg_env:
         cfg = import_python_obj(cfg_env)
     elif cfg_env.startswith("{"):
-        cfg = json.loads(cfg_env)
-        abs_path = os.path.abspath(cfg_env)
-        cwd = os.path.dirname(abs_path)
+        try:
+            cfg = json.loads(cfg_env)
+        except json.JSONDecodeError as e:
+            raise ConfigException(f"Could not parse raw json config: {e}")
+        cwd = os.path.dirname(os.getcwd())
     else:
-        mod = import_module("datacube_ows.ows_cfg")
-        cfg = getattr(mod, cfg_env)
+        try:
+            mod = import_module("datacube_ows.ows_cfg")
+            cfg = getattr(mod, cfg_env)
+        except (AttributeError, ModuleNotFoundError) as e:
+            raise ConfigException(
+                f"Could not open fallback default config file (datacube_ows.ows_cfg.{cfg_env}): {e})"
+            )
     expansion = cfg_expand(cfg, cwd=cwd)
     if isinstance(expansion, dict):
         return expansion

--- a/datacube_ows/ows_configuration.py
+++ b/datacube_ows/ows_configuration.py
@@ -19,7 +19,6 @@ import math
 import os
 from collections.abc import Iterable, Mapping
 from enum import Enum
-from importlib import import_module
 from typing import Any, Optional, Union, cast
 
 import numpy
@@ -85,25 +84,13 @@ def read_config(path: str | None = None) -> CFG_DICT:
     else:
         cfg_env = os.environ.get("DATACUBE_OWS_CFG")
     if not cfg_env:
-        try:
-            from datacube_ows.ows_cfg import ows_cfg as cfg
-        except ImportError:
-            raise ConfigException(
-                "No fallback default datacube_ows.ows_cfg module found."
-            ) from None
-    elif "/" in cfg_env or cfg_env.endswith(".json"):
+        raise ConfigException(
+            "DATACUBE_OWS_CFG environment variable not set. "
+        ) from None
+
+    if "/" in cfg_env or cfg_env.endswith(".json"):
         # Looks a JSON file path
-        try:
-            cfg = load_json_obj(cfg_env)
-            cwd = get_file_loc(cfg_env)
-        except (FileNotFoundError, PermissionError) as e:
-            raise ConfigException(
-                f"Could not open json config file {cfg_env}: {e}"
-            ) from None
-        except json.JSONDecodeError as e:
-            raise ConfigException(
-                f"Could not parse json config file {cfg_env}: {e}"
-            ) from None
+        attempt_json_read_from_fs = True
     elif "." in cfg_env:
         # Looks like a python object
         cfg = import_python_obj(cfg_env)
@@ -115,13 +102,23 @@ def read_config(path: str | None = None) -> CFG_DICT:
             raise ConfigException(f"Could not parse raw json config: {e}") from None
         cwd = os.path.dirname(os.getcwd())
     else:
+        # Doesn't look anything much - try it as a json file path
+        attempt_json_read_from_fs = True
+
+    if attempt_json_read_from_fs:
+        # Attempt to load as JSON file.
         try:
-            mod = import_module("datacube_ows.ows_cfg")
-            cfg = getattr(mod, cfg_env)
-        except (AttributeError, ModuleNotFoundError) as e:
+            cfg = load_json_obj(cfg_env)
+            cwd = get_file_loc(cfg_env)
+        except (FileNotFoundError, PermissionError) as e:
             raise ConfigException(
-                f"Could not open fallback default config file (datacube_ows.ows_cfg.{cfg_env}): {e})"
+                f"Could not open json config file {cfg_env}: {e}"
             ) from None
+        except json.JSONDecodeError as e:
+            raise ConfigException(
+                f"Could not parse json config file {cfg_env}: {e}"
+            ) from None
+
     expansion = cfg_expand(cfg, cwd=cwd)
     if isinstance(expansion, dict):
         return expansion

--- a/datacube_ows/update_ranges_impl.py
+++ b/datacube_ows/update_ranges_impl.py
@@ -10,6 +10,7 @@ import sys
 
 import click
 from datacube import Datacube
+from datacube.cfg import ODCEnvironment
 from datacube.index import IndexSetupError
 from sqlalchemy.exc import OperationalError, ProgrammingError
 
@@ -64,7 +65,7 @@ from datacube_ows.startup_utils import initialise_debugging
 @click.argument("layers", nargs=-1)
 def main(
     layers: list[str],
-    env: str | None,
+    env: ODCEnvironment | str | None,
     schema: bool,
     read_role: list[str],
     write_role: list[str],
@@ -160,21 +161,25 @@ def main(
     initialise_debugging()
     db_maintenance = schema or cleanup or views
     try:
-        cfg = get_config(called_from_update_ranges=True, make_ready=not db_maintenance)
+        cfg: OWSConfig | None = get_config(
+            called_from_update_ranges=True,
+            make_ready=not db_maintenance
+        )
+        assert cfg is not None  # type check nudge
+        app = cfg.odc_app + "-update"
     except OperationalError as e:
         click.echo(f"ERROR: {e}", err=True)
         sys.exit(1)
     app = cfg.odc_app + "-update"
     errors: bool = False
     if db_maintenance:
+        if cfg is not None:
+            env = cfg.default_env if cfg.default_env and env is None else env
         try:
-            dc = Datacube(
-                env=cfg.default_env if cfg.default_env and env is None else env, app=app
-            )
+            dc = Datacube(env=env, app=app)
         except (IndexSetupError, OperationalError, ProgrammingError) as e:
             click.echo(f"ERROR: {e}", err=True)
             sys.exit(1)
-
         click.echo(
             f"Applying database schema updates to the {dc.index.environment.db_database} database:..."
         )
@@ -189,13 +194,20 @@ def main(
                 click.echo("Cleaning up datacube-1.8.x range tables and views...")
                 ows_index(dc).cleanup_schema(dc)
         except AbortRun as e:
-            click.echo(f"Aborting schema update: {e}")
+            if schema:
+                action = "schema update"
+            elif views:
+                action = "materialised view update"
+            else:
+                action = "schema cleanup"
+            click.echo(f"Aborting {action}: {e}")
             errors = True
         click.echo("Done")
         if errors:
             sys.exit(1)
         return 0
 
+    assert cfg is not None  # type check nudge
     click.echo("Deriving extents from materialised views and/or spatial indexes")
     try:
         errors = add_ranges(cfg, layers)

--- a/datacube_ows/update_ranges_impl.py
+++ b/datacube_ows/update_ranges_impl.py
@@ -15,7 +15,7 @@ from datacube.index import IndexSetupError
 from sqlalchemy.exc import OperationalError, ProgrammingError
 
 from datacube_ows import __version__
-from datacube_ows.config_utils import OWSConfigNotReady
+from datacube_ows.config_utils import ConfigException, OWSConfigNotReady
 from datacube_ows.index import AbortRun, LayerSignature, ows_index
 from datacube_ows.index.api import InsufficientDbPrivileges
 from datacube_ows.ows_configuration import OWSConfig, get_config
@@ -65,7 +65,7 @@ from datacube_ows.startup_utils import initialise_debugging
 @click.argument("layers", nargs=-1)
 def main(
     layers: list[str],
-    env: ODCEnvironment | str | None,
+    env: str | None,
     schema: bool,
     read_role: list[str],
     write_role: list[str],
@@ -159,24 +159,24 @@ def main(
         sys.exit(1)
 
     initialise_debugging()
+
     db_maintenance = schema or cleanup or views
-    try:
-        cfg: OWSConfig | None = get_config(
-            called_from_update_ranges=True,
-            make_ready=not db_maintenance
-        )
-        assert cfg is not None  # type check nudge
-        app = cfg.odc_app + "-update"
-    except OperationalError as e:
-        click.echo(f"ERROR: {e}", err=True)
-        sys.exit(1)
-    app = cfg.odc_app + "-update"
     errors: bool = False
     if db_maintenance:
-        if cfg is not None:
-            env = cfg.default_env if cfg.default_env and env is None else env
+        app = "datacube-ows-update"
+        if env is None:
+            # No explicit env provided, check for a config file
+            try:
+                cfg = get_config(called_from_update_ranges=True, make_ready=False)
+                app = cfg.odc_app + "-update"
+                update_env: ODCEnvironment | str | None = cfg.default_env or None
+            except ConfigException:
+                # No env provided, no config file, use default
+                update_env = None
+        else:
+            update_env = env
         try:
-            dc = Datacube(env=env, app=app)
+            dc = Datacube(env=update_env, app=app)
         except (IndexSetupError, OperationalError, ProgrammingError) as e:
             click.echo(f"ERROR: {e}", err=True)
             sys.exit(1)
@@ -194,12 +194,13 @@ def main(
                 click.echo("Cleaning up datacube-1.8.x range tables and views...")
                 ows_index(dc).cleanup_schema(dc)
         except AbortRun as e:
-            if schema:
-                action = "schema update"
-            elif views:
-                action = "materialised view update"
-            else:
-                action = "schema cleanup"
+            action = (
+                "schema update"
+                if schema
+                else "materialised view update"
+                if views
+                else "schema cleanup"
+            )
             click.echo(f"Aborting {action}: {e}")
             errors = True
         click.echo("Done")
@@ -207,7 +208,12 @@ def main(
             sys.exit(1)
         return 0
 
-    assert cfg is not None  # type check nudge
+    try:
+        cfg = get_config(called_from_update_ranges=True)
+    except ConfigException as e:
+        click.echo(f"ERROR reading configuration file: {e}", err=True)
+        sys.exit(1)
+
     click.echo("Deriving extents from materialised views and/or spatial indexes")
     try:
         errors = add_ranges(cfg, layers)

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -48,8 +48,8 @@ configuration file. <#general-config-structure>`_
 Where is Configuration Read From?
 ---------------------------------
 
-Configuration is read by default from the ``ows_cfg object`` in ``datacube_ows/ows_cfg.py``
-but this can be overridden by setting the ``$DATACUBE_OWS_CFG`` environment variable.
+Configuration is read by default from a location determined by the
+the ``$DATACUBE_OWS_CFG`` environment variable, which must be set.
 
 Configuration can be read from a Python file, a JSON file, or a collection of python
 and/or JSON files.
@@ -100,9 +100,10 @@ alternative applies):
 
    Imported as **python** from named object in ``datacube_ows/ows_cfg.py``
 
-8. Blank or not set
+8. Other
 
-   Default to import ows_cfg object in ``datacube_ows/ows_cfg.py`` as described above.
+   If ``$DATACUBE_OWS_CFG`` matches none of the above, it is treated as the filename
+   of a JSON file in the current working directory.
 
 .. _inclusion:
 


### PR DESCRIPTION
datacube-ows-update always insists on having an OWS configuration defined, even for schema altering operations that don't need to read from config.

This PR ensures that `--schema`, `--views` and `--cleanup` operations can all be run without an OWS configuration present.

Includes a lot of refactoring of config reading code.

Backwards incompatibility:  The old default config location (`datacube_ows.ows_cfg`) has been removed.  This is not useful default behaviour.  There is now no default location for configuration - the DATACUBE_OWS_CFG environment variable must be set.   The docs have been updated accordingly.

<!-- readthedocs-preview datacube-ows start -->
----
📚 Documentation preview 📚: https://datacube-ows--1524.org.readthedocs.build/en/1524/

<!-- readthedocs-preview datacube-ows end -->