### PR TITLE
Pass config from create_app

### DIFF
--- a/datacube_ows/data.py
+++ b/datacube_ows/data.py
@@ -3,6 +3,7 @@
 #
 # Copyright (c) 2017-2024 OWS Contributors
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import logging
 from datetime import date, datetime, timedelta
@@ -17,17 +18,22 @@ from pandas import Timestamp
 from rasterio.features import rasterize
 from rasterio.io import MemoryFile
 
-from datacube_ows.http_utils import FlaskResponse, json_response, png_response
+from datacube_ows.http_utils import json_response, png_response
 from datacube_ows.loading import DataStacker
 from datacube_ows.ogc_exceptions import WMSException
 from datacube_ows.ogc_utils import xarray_image_as_png
-from datacube_ows.ows_configuration import OWSNamedLayer
+from datacube_ows.ows_configuration import OWSConfig, OWSNamedLayer
 from datacube_ows.query_profiler import QueryProfiler
 from datacube_ows.resource_limits import ResourceLimited
 from datacube_ows.styles import StyleDef
 from datacube_ows.time_utils import solar_date, tz_for_geometry
 from datacube_ows.utils import default_to_utc, log_call
 from datacube_ows.wms_utils import GetMapParameters
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from datacube_ows.protocol_versions import FlaskResponse
+
 
 _LOG: logging.Logger = logging.getLogger(__name__)
 
@@ -75,11 +81,11 @@ class EmptyResponse(Exception):
 
 
 @log_call
-def get_map(args: dict[str, str]) -> FlaskResponse:
+def get_map(cfg: OWSConfig, args: dict[str, str]) -> FlaskResponse:
     # pylint: disable=too-many-nested-blocks, too-many-branches, too-many-statements, too-many-locals
     # Parse GET parameters
     try:
-        params = GetMapParameters(args)
+        params = GetMapParameters(cfg, args)
     except ValueError as e:
         # See #1478 for one example that brings us here.
         raise WMSException("Failed to get map parameters") from e
@@ -230,9 +236,10 @@ def get_map(args: dict[str, str]) -> FlaskResponse:
         qprof.end_event("write")
 
     if params.ows_stats:
-        return json_response(qprof.profile())
+        return json_response(qprof.profile(), cfg)
     return png_response(
         body,
+        cfg,
         extra_headers=params.layer.resource_limits.wms_cache_rules.cache_headers(
             n_datasets
         ),

--- a/datacube_ows/feature_info.py
+++ b/datacube_ows/feature_info.py
@@ -3,6 +3,7 @@
 #
 # Copyright (c) 2017-2024 OWS Contributors
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import logging
 import re
@@ -21,13 +22,17 @@ from odc.geo.geobox import GeoBox
 from pandas import Timestamp
 
 from datacube_ows.config_utils import CFG_DICT, RAW_CFG, ConfigException
-from datacube_ows.http_utils import FlaskResponse, html_json_response, json_response
+from datacube_ows.http_utils import html_json_response, json_response
 from datacube_ows.loading import DataStacker, ProductBandQuery
-from datacube_ows.ows_configuration import OWSNamedLayer, get_config
+from datacube_ows.ows_configuration import OWSConfig, OWSNamedLayer
 from datacube_ows.styles import StyleDef
 from datacube_ows.time_utils import dataset_center_time
 from datacube_ows.utils import log_call
 from datacube_ows.wms_utils import GetFeatureInfoParameters, img_coords_to_geopoint
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from datacube_ows.protocol_versions import FlaskResponse
 
 
 @log_call
@@ -149,13 +154,13 @@ def geobox_is_point(geobox: GeoBox) -> bool:
 
 
 @log_call
-def feature_info(args: dict[str, str]) -> FlaskResponse:
+def feature_info(cfg: OWSConfig, args: dict[str, str]) -> FlaskResponse:
     # pylint: disable=too-many-nested-blocks, too-many-branches, too-many-statements, too-many-locals
     # Parse GET parameters
-    params = GetFeatureInfoParameters(args)
+    params = GetFeatureInfoParameters(cfg, args)
     feature_json: CFG_DICT = {}
 
-    geo_point = img_coords_to_geopoint(params.geobox, params.i, params.j)
+    geo_point = img_coords_to_geopoint(cfg, params.geobox, params.i, params.j)
     # shrink geobox to point
     # Prepare to extract feature info
     if geobox_is_point(params.geobox):
@@ -168,7 +173,6 @@ def feature_info(args: dict[str, str]) -> FlaskResponse:
         )
     stacker = DataStacker(params.layer, geo_point_geobox, params.times)
     # --- Begin code section requiring datacube.
-    cfg = get_config()
     all_time_datasets = stacker.datasets_all_time(point=geo_point_geobox.extent)
 
     # Taking the data as a single point so our indexes into the data should be 0,0

--- a/datacube_ows/http_utils.py
+++ b/datacube_ows/http_utils.py
@@ -3,10 +3,10 @@
 #
 # Copyright (c) 2017-2024 OWS Contributors
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import json
 from collections.abc import Mapping
-from typing import Optional
 from urllib.parse import urlparse
 
 from flask import Request, render_template, request
@@ -16,20 +16,17 @@ from datacube_ows.config_utils import CFG_DICT
 TYPE_CHECKING = False
 if TYPE_CHECKING:
     from datacube_ows.ows_configuration import OWSConfig
+    from datacube_ows.protocol_versions import FlaskResponse
 
-FlaskResponse = tuple[str | bytes, int, dict[str, str]]
 
-
-def resp_headers(d: dict[str, str]) -> dict[str, str]:
+def resp_headers(cfg: OWSConfig, d: dict[str, str]) -> dict[str, str]:
     """
     Take a dictionary of http response headers and all required response headers from the configuration.
 
     :param d:
     :return:
     """
-    from datacube_ows.ows_configuration import get_config
-
-    return get_config().response_headers(d)
+    return cfg.response_headers(d)
 
 
 def parse_for_base_url(url: str) -> str:
@@ -105,12 +102,7 @@ def lower_get_args() -> dict[str, str | None]:
     return d
 
 
-def json_response(result: CFG_DICT, cfg: Optional["OWSConfig"] = None) -> FlaskResponse:
-    from datacube_ows.ows_configuration import get_config
-
-    if not cfg:
-        cfg = get_config()
-    assert cfg is not None  # for type checker
+def json_response(result: CFG_DICT, cfg: OWSConfig) -> FlaskResponse:
     return (
         json.dumps(result),
         200,
@@ -118,28 +110,16 @@ def json_response(result: CFG_DICT, cfg: Optional["OWSConfig"] = None) -> FlaskR
     )
 
 
-def html_json_response(
-    result: CFG_DICT, cfg: Optional["OWSConfig"] = None
-) -> FlaskResponse:
-    from datacube_ows.ows_configuration import get_config
-
-    if not cfg:
-        cfg = get_config()
-    assert cfg is not None  # for type checker
+def html_json_response(result: CFG_DICT, cfg: OWSConfig) -> FlaskResponse:
     html_content = render_template("html_feature_info.html", result=result)
     return html_content, 200, cfg.response_headers({"Content-Type": "text/html"})
 
 
 def png_response(
     body: bytes,
-    cfg: Optional["OWSConfig"] = None,
+    cfg: OWSConfig,
     extra_headers: Mapping[str, str] | None = None,
 ) -> FlaskResponse:
-    from datacube_ows.ows_configuration import get_config
-
-    if not cfg:
-        cfg = get_config()
-    assert cfg is not None  # For type checker
     if extra_headers is None:
         extra_headers = {}
     headers = {"Content-Type": "image/png"}

--- a/datacube_ows/legend_generator.py
+++ b/datacube_ows/legend_generator.py
@@ -3,6 +3,7 @@
 #
 # Copyright (c) 2017-2024 OWS Contributors
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import io
 import logging
@@ -17,6 +18,10 @@ from datacube_ows.http_utils import resp_headers
 from datacube_ows.ogc_exceptions import WMSException
 from datacube_ows.wms_utils import GetLegendGraphicParameters
 
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from datacube_ows.ows_configuration import OWSConfig
+
 # Do not use X Server backend
 
 matplotlib.use("Agg")
@@ -24,25 +29,25 @@ matplotlib.use("Agg")
 _LOG: logging.Logger = logging.getLogger(__name__)
 
 
-def legend_graphic(args) -> tuple[bytes, int, dict[str, str]] | None:
-    params = GetLegendGraphicParameters(args)
-    img = create_legends_from_styles(params.styles, ndates=len(params.times))
+def legend_graphic(cfg: OWSConfig, args) -> tuple[bytes, int, dict[str, str]]:
+    params = GetLegendGraphicParameters(cfg, args)
+    img = create_legends_from_styles(cfg, params.styles, ndates=len(params.times))
     if img is None:
         raise WMSException("No legend is available for this request", http_response=404)
     return img
 
 
 def create_legend_for_style(
-    product, style_name: str, ndates: int = 0
+    cfg: OWSConfig, product, style_name: str, ndates: int = 0
 ) -> tuple[bytes, int, dict[str, str]] | None:
     if style_name not in product.style_index:
         return None
     style = product.style_index[style_name]
-    return create_legends_from_styles([style], ndates)
+    return create_legends_from_styles(cfg, [style], ndates)
 
 
 def create_legends_from_styles(
-    styles, ndates: int = 0
+    cfg: OWSConfig, styles, ndates: int = 0
 ) -> tuple[bytes, int, dict[str, str]] | None:
     # Run through all values in style cfg and generate
     imgs = []
@@ -61,4 +66,4 @@ def create_legends_from_styles(
     # legend = make_response(b.getvalue())
     # legend.mimetype = 'image/png'
     # b.close()
-    return b.getvalue(), 200, resp_headers({"Content-Type": "image/png"})
+    return b.getvalue(), 200, resp_headers(cfg, {"Content-Type": "image/png"})

--- a/datacube_ows/ogc.py
+++ b/datacube_ows/ogc.py
@@ -3,6 +3,8 @@
 #
 # Copyright (c) 2017-2024 OWS Contributors
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
 import logging
 import traceback
 from logging import Logger
@@ -20,10 +22,14 @@ from datacube_ows.http_utils import (
 from datacube_ows.index.api import ows_index
 from datacube_ows.legend_generator import create_legend_for_style
 from datacube_ows.ogc_exceptions import OGCException, WMSException
-from datacube_ows.ows_configuration import get_config
 from datacube_ows.protocol_versions import SupportedSvc, supported_versions
 from datacube_ows.wcs1 import WCS_REQUESTS
 from datacube_ows.wms import WMS_REQUESTS
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from datacube_ows.ows_configuration import OWSConfig
+    from datacube_ows.protocol_versions import FlaskResponse
 
 _LOG: Logger = logging.getLogger(__name__)
 
@@ -33,13 +39,12 @@ OWS_SUPPORTED: dict[str, SupportedSvc] = supported_versions()
 
 # Flask Routes
 # (Note that actual route declarations take place in startup_utils.py)
-def ogc_impl():
+def ogc_impl(cfg: OWSConfig):
     # pylint: disable=too-many-branches
     nocase_args = capture_headers(request, lower_get_args())
-    service = nocase_args.get("service", "").upper()
-
+    service = nocase_args.get("service", "").upper()  # type: ignore[union-attr]
     if service:
-        return ogc_svc_impl(service.lower())
+        return ogc_svc_impl(cfg, service.lower())
 
     # create dummy env if not exists
     try:
@@ -49,11 +54,11 @@ def ogc_impl():
         # parameter.
         # This is a quick hack to fix #64.  Service and operation routing could be
         # handled more elegantly.
-        op = nocase_args.get("request", "").upper()
+        op = nocase_args.get("request", "").upper()  # type: ignore[union-attr]
         if op in WMS_REQUESTS:
-            return ogc_svc_impl("wms")
+            return ogc_svc_impl(cfg, "wms")
         if op in WCS_REQUESTS:
-            return ogc_svc_impl("wcs")
+            return ogc_svc_impl(cfg, "wcs")
         if op:
             # Should we return a WMS or WCS exception if there is no service specified?
             # Defaulting to WMS because that's what we already have.
@@ -61,9 +66,8 @@ def ogc_impl():
                 "Invalid service and/or request",
                 locator="Service and request parameters",
             )
-        cfg = get_config()  # pylint: disable=redefined-outer-name
         url = nocase_args.get("Host", nocase_args["url_root"])
-        base_url = get_service_base_url(cfg.allowed_urls, url)
+        base_url = get_service_base_url(cfg.allowed_urls, url)  # type: ignore[arg-type]
         return (
             render_template(
                 "index.html",
@@ -73,18 +77,18 @@ def ogc_impl():
                 version=__version__,
             ),
             200,
-            resp_headers({"Content-Type": "text/html"}),
+            resp_headers(cfg, {"Content-Type": "text/html"}),
         )
     except OGCException as e:
         _LOG.error("Handled Error: %s", repr(e.errors))
-        return e.exception_response()
+        return e.exception_response(cfg)
     except Exception as e:  # pylint: disable=broad-except
         _LOG.exception(e)
         ogc_e = WMSException(f"Unexpected server error: {e!s}", http_response=500)
-        return ogc_e.exception_response(traceback=traceback.format_exception(e))
+        return ogc_e.exception_response(cfg, traceback=traceback.format_exception(e))
 
 
-def ogc_svc_impl(svc) -> tuple[str, int, dict[str, str]]:
+def ogc_svc_impl(cfg: OWSConfig, svc) -> FlaskResponse:
     svc_support = OWS_SUPPORTED.get(svc)
     nocase_args = capture_headers(request, lower_get_args())
     service = nocase_args.get("service", svc).upper()
@@ -97,12 +101,12 @@ def ogc_svc_impl(svc) -> tuple[str, int, dict[str, str]]:
                 valid_keys=[
                     service.service
                     for service in OWS_SUPPORTED.values()
-                    if service.activated()
+                    if service.activated(cfg)
                 ],
                 code=WMSException.OPERATION_NOT_SUPPORTED,
                 locator="service parameter",
             )
-        if not svc_support.activated():
+        if not svc_support.activated(cfg):
             raise svc_support.default_exception_class(
                 "Invalid service and/or request",
                 locator="Service and request parameters",
@@ -117,77 +121,81 @@ def ogc_svc_impl(svc) -> tuple[str, int, dict[str, str]]:
         version = nocase_args.get("version")
         version_support = svc_support.negotiated_version(version)
     except OGCException as e:
-        return e.exception_response()
+        return e.exception_response(cfg)
 
     try:
-        return version_support.router(nocase_args)
+        # FIXME: fix type of nocase_args in protocol_versions.py.
+        return version_support.router(cfg, nocase_args)  # type: ignore[arg-type]
     except OGCException as e:
-        return e.exception_response()
+        return e.exception_response(cfg)
     except OperationalError as e:
         # Expected types of failures in this branch. Log the error to console and give
         # the user a generic 500 response.
         _LOG.error(e)
         return version_support.exception_class(
             "Internal server error.", http_response=500
-        ).exception_response()
+        ).exception_response(cfg)
     except Exception as e:  # pylint: disable=broad-except
         _LOG.error(f"Arguments for unexpected error: {nocase_args}")
         _LOG.exception(e)
         ogc_e = version_support.exception_class(
             f"Unexpected server error: {e!s}", http_response=500
         )
-        return ogc_e.exception_response(traceback=traceback.format_exception(e))
+        return ogc_e.exception_response(cfg, traceback=traceback.format_exception(e))
 
 
-def ogc_wms_impl():
-    return ogc_svc_impl("wms")
+def ogc_wms_impl(cfg: OWSConfig):
+    return ogc_svc_impl(cfg, "wms")
 
 
-def ogc_wmts_impl():
-    return ogc_svc_impl("wmts")
+def ogc_wmts_impl(cfg: OWSConfig):
+    return ogc_svc_impl(cfg, "wmts")
 
 
-def ogc_wcs_impl():
-    return ogc_svc_impl("wcs")
+def ogc_wcs_impl(cfg: OWSConfig):
+    return ogc_svc_impl(cfg, "wcs")
 
 
-def ping() -> tuple[str, int, dict[str, str]]:
+def ping(cfg: OWSConfig) -> tuple[str, int, dict[str, str]]:
     dbs_ok = {
-        name: ows_index(dc).check_db_access(dc)
-        for name, dc in get_config().all_dcs.items()
+        name: ows_index(dc).check_db_access(dc) for name, dc in cfg.all_dcs.items()
     }
 
     if all(dbs_ok.values()):
         return (
             render_template("ping.html", status="Up", statuses=dbs_ok),
             200,
-            resp_headers({"Content-Type": "text/html"}),
+            resp_headers(cfg, {"Content-Type": "text/html"}),
         )
     if any(dbs_ok.values()):
         return (
             render_template("ping.html", status="Partially Up", statuses=dbs_ok),
             503,
-            resp_headers({"Content-Type": "text/html"}),
+            resp_headers(cfg, {"Content-Type": "text/html"}),
         )
     return (
         render_template("ping.html", status="Down", statuses=dbs_ok),
         503,
-        resp_headers({"Content-Type": "text/html"}),
+        resp_headers(cfg, {"Content-Type": "text/html"}),
     )
 
 
-def legend(layer, style, dates=None) -> tuple[str | bytes, int, dict[str, str]]:
-    # pylint: disable=redefined-outer-name
-    cfg = get_config()
+def legend(
+    cfg: OWSConfig, layer, style, dates=None
+) -> tuple[str | bytes, int, dict[str, str]]:
     product = cfg.layer_index.get(layer)
     if not product:
-        return "Unknown Layer", 404, resp_headers({"Content-Type": "text/plain"})
+        return "Unknown Layer", 404, resp_headers(cfg, {"Content-Type": "text/plain"})
     ndates = int(lower_get_args().get("ndates", 0)) if dates is None else len(dates)  # type: ignore[arg-type]
     try:
-        img = create_legend_for_style(product, style, ndates)
+        img = create_legend_for_style(cfg, product, style, ndates)
     except WMSException as e:
-        return str(e), e.http_response, resp_headers({"Content-Type": "text/plain"})
+        return (
+            str(e),
+            e.http_response,
+            resp_headers(cfg, {"Content-Type": "text/plain"}),
+        )
 
     if not img:
-        return "Unknown Style", 404, resp_headers({"Content-Type": "text/plain"})
+        return "Unknown Style", 404, resp_headers(cfg, {"Content-Type": "text/plain"})
     return img

--- a/datacube_ows/ogc_exceptions.py
+++ b/datacube_ows/ogc_exceptions.py
@@ -3,6 +3,7 @@
 #
 # Copyright (c) 2017-2024 OWS Contributors
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import traceback as tb
 
@@ -12,6 +13,11 @@ from ows.common.v20.encoders import xml_encode_exception_report
 from typing_extensions import override
 
 from datacube_ows.http_utils import resp_headers
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from datacube_ows.ows_configuration import OWSConfig
+    from datacube_ows.protocol_versions import FlaskResponse
 
 
 class OGCException(Exception):
@@ -37,8 +43,8 @@ class OGCException(Exception):
 
     # pylint: disable=dangerous-default-value
     def exception_response(
-        self, traceback: list | None = None
-    ) -> tuple[str, int, dict[str, str]]:
+        self, cfg: OWSConfig, traceback: list | None = None
+    ) -> FlaskResponse:
         return (
             render_template(
                 "ogc_error.xml",
@@ -48,7 +54,7 @@ class OGCException(Exception):
                 schema_url=self.schema_url,
             ),
             self.http_response,
-            resp_headers({"Content-Type": "application/xml"}),
+            resp_headers(cfg, {"Content-Type": "application/xml"}),
         )
 
 
@@ -106,7 +112,9 @@ class WCS2Exception(OGCException):
 
     # pylint: disable=dangerous-default-value
     @override
-    def exception_response(self, traceback: list | None = None) -> tuple:
+    def exception_response(
+        self, cfg: OWSConfig, traceback: list | None = None
+    ) -> FlaskResponse:
         if traceback is None:
             traceback = []
         exceptions = [
@@ -125,5 +133,5 @@ class WCS2Exception(OGCException):
         return (
             result.value,
             self.http_response,
-            resp_headers({"Content-Type": "application/xml"}),
+            resp_headers(cfg, {"Content-Type": "application/xml"}),
         )

--- a/datacube_ows/protocol_versions.py
+++ b/datacube_ows/protocol_versions.py
@@ -8,6 +8,7 @@
 import contextlib
 import re
 from collections.abc import Callable, Mapping, Sequence
+from typing import TypeAlias
 
 from datacube_ows.ogc_exceptions import (
     OGCException,
@@ -16,19 +17,24 @@ from datacube_ows.ogc_exceptions import (
     WMSException,
     WMTSException,
 )
-from datacube_ows.ows_configuration import get_config
+from datacube_ows.ows_configuration import OWSConfig
 from datacube_ows.wcs1 import handle_wcs1
 from datacube_ows.wcs2 import handle_wcs2
 from datacube_ows.wms import handle_wms
 from datacube_ows.wmts import handle_wmts
 
-FlaskResponse = tuple
-FlaskHandler = Callable[[Mapping[str, str]], FlaskResponse]
+FlaskResponse: TypeAlias = tuple[str | bytes, int, dict[str, str]]
+FlaskHandler: TypeAlias = Callable[[Mapping[str, str]], FlaskResponse]
 
 
 class SupportedSvcVersion:
     def __init__(
-        self, service: str, version: str, router, exception_class: type[OGCException]
+        self,
+        service: str,
+        version: str,
+        # FIXME: second argument should be dict[str, str | None].
+        router: Callable[[OWSConfig, dict[str, str]], FlaskResponse],
+        exception_class: type[OGCException],
     ) -> None:
         self.service = service.lower()
         self.service_upper = service.upper()
@@ -87,8 +93,7 @@ class SupportedSvc:
         # The constructor ensures that self.versions is not empty, so this is safe.
         return self.versions[0]
 
-    def activated(self) -> bool:
-        cfg = get_config()
+    def activated(self, cfg: OWSConfig) -> bool:
         return bool(getattr(cfg, self.service))
 
 

--- a/datacube_ows/startup_utils/__init__.py
+++ b/datacube_ows/startup_utils/__init__.py
@@ -20,8 +20,6 @@ __all__ = [
     "create_app",
 ]
 
-from datacube_ows.config_utils import ConfigException
-
 
 def initialise_logger(name: str | None = None) -> Logger:
     handler = logging.StreamHandler()
@@ -170,11 +168,12 @@ def initialise_babel(cfg, app: Flask) -> object | None:
 def create_app() -> Flask:
     log = initialise_logger()
     app = initialise_flask(__name__)
+    from datacube_ows.config_utils import ConfigException
     from datacube_ows.ows_configuration import get_config
 
     try:
         # Cache a parsed config file object (unless deferring to first request).
-        cfg = None if os.environ.get("DEFER_CFG_PARSE") else get_config()
+        cfg = get_config()
     except (ConfigException, OperationalError) as e:
         log.error(str(e))
         sys.exit(1)
@@ -218,29 +217,29 @@ def create_app() -> Flask:
     @app.route("/")
     @ows_ogc_metric
     def main_route():
-        return ogc_impl()
+        return ogc_impl(cfg)
 
     @app.route("/wms")
     @ows_ogc_metric
     def wms_route():
-        return ogc_wms_impl()
+        return ogc_wms_impl(cfg)
 
     @app.route("/wmts")
     @ows_ogc_metric
     def wmts_route():
-        return ogc_wmts_impl()
+        return ogc_wmts_impl(cfg)
 
     @app.route("/wcs")
     @ows_ogc_metric
     def wcs_route():
-        return ogc_wcs_impl()
+        return ogc_wcs_impl(cfg)
 
     @app.route("/ping")
     @metrics.summary(
         "ows_heartbeat_pings", "Ping durations", labels={"status": lambda r: r.status}
     )
     def ping_route():
-        return ping()
+        return ping(cfg)
 
     @app.route("/legend/<string:layer>/<string:style>/legend.png")
     @metrics.histogram(
@@ -253,13 +252,15 @@ def create_app() -> Flask:
         },
     )
     def legend_route(layer, style):
-        return legend(layer, style)
+        return legend(cfg, layer, style)
 
     # Configure Flask Middleware
     @app.before_request
     def start_timer() -> None:
         # pylint: disable=assigning-non-slot
         g.ogc_start_time = monotonic()
+        if not cfg.ready:
+            _ = get_config()
 
     @app.after_request
     def log_time_and_request_response(response):

--- a/datacube_ows/wcs1.py
+++ b/datacube_ows/wcs1.py
@@ -3,6 +3,8 @@
 #
 # Copyright (c) 2017-2024 OWS Contributors
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
 from typing import Any
 
 from flask import render_template
@@ -13,32 +15,36 @@ from datacube_ows.http_utils import (
     json_response,
 )
 from datacube_ows.ogc_exceptions import WCS1Exception
-from datacube_ows.ows_configuration import get_config
+from datacube_ows.ows_configuration import OWSConfig
 from datacube_ows.query_profiler import QueryProfiler
 from datacube_ows.utils import log_call
 from datacube_ows.wcs1_utils import WCS1GetCoverageRequest, get_coverage_data
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from datacube_ows.protocol_versions import FlaskResponse
 
 WCS_REQUESTS = ("DESCRIBECOVERAGE", "GETCOVERAGE")
 
 
 @log_call
-def handle_wcs1(nocase_args) -> tuple:
+def handle_wcs1(cfg: OWSConfig, nocase_args: dict[str, str]) -> FlaskResponse:
     operation = nocase_args.get("request", "").upper()
     if not operation:
         raise WCS1Exception("No operation specified", locator="Request parameter")
     if operation == "GETCAPABILITIES":
-        return get_capabilities(nocase_args)
+        return get_capabilities(cfg, nocase_args)
     if operation == "DESCRIBECOVERAGE":
-        return desc_coverages(nocase_args)
+        return desc_coverages(cfg, nocase_args)
     if operation == "GETCOVERAGE":
-        return get_coverage(nocase_args)
+        return get_coverage(cfg, nocase_args)
     raise WCS1Exception(
         f"Unrecognised operation: {operation}", locator="Request parameter"
     )
 
 
 @log_call
-def get_capabilities(args) -> tuple:
+def get_capabilities(cfg: OWSConfig, args) -> tuple:
     # TODO: Handle updatesequence request parameter for cache consistency.
     section = args.get("section")
     if section:
@@ -64,7 +70,6 @@ def get_capabilities(args) -> tuple:
         )
 
     # Extract layer metadata from Datacube.
-    cfg = get_config()
     url = args.get("Host", args["url_root"])
     base_url = get_service_base_url(cfg.allowed_urls, url)
     headers = cache_control_headers(cfg.wms_cap_cache_age)
@@ -84,10 +89,7 @@ def get_capabilities(args) -> tuple:
 
 
 @log_call
-def desc_coverages(args) -> tuple:
-    # Extract layer metadata from Datacube.
-    cfg = get_config()
-
+def desc_coverages(cfg: OWSConfig, args) -> tuple:
     coverages = args.get("coverage")
     products = []
     if coverages:
@@ -117,20 +119,19 @@ def desc_coverages(args) -> tuple:
 
 
 @log_call
-def get_coverage(args: dict) -> tuple[Any, int, dict]:
-    cfg = get_config()
-    req = WCS1GetCoverageRequest(args)
+def get_coverage(cfg: OWSConfig, args: dict) -> tuple[Any, int, dict]:
+    req = WCS1GetCoverageRequest(cfg, args)
     qprof = QueryProfiler(req.ows_stats)
-    n_datasets, data = get_coverage_data(req, qprof)
+    n_datasets, data = get_coverage_data(cfg, req, qprof)
     if req.ows_stats:
-        return json_response(qprof.profile())
+        return json_response(qprof.profile(), cfg)
     headers = {
         "Content-Type": req.format.mime,
         "content-disposition": f"attachment; filename={req.layer_name}.{req.format.extension}",
     }
     headers.update(req.layer.resource_limits.wcs_cache_rules.cache_headers(n_datasets))  # type: ignore[union-attr]
     return (
-        req.format.renderer(req.version)(req, data),
+        req.format.renderer(req.version)(cfg, req, data),
         200,
         cfg.response_headers(
             {

--- a/datacube_ows/wcs1_utils.py
+++ b/datacube_ows/wcs1_utils.py
@@ -3,6 +3,7 @@
 #
 # Copyright (c) 2017-2024 OWS Contributors
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 from datetime import UTC
 
@@ -19,19 +20,20 @@ from rasterio import MemoryFile
 from datacube_ows.config_utils import ConfigException
 from datacube_ows.loading import DataStacker
 from datacube_ows.ogc_exceptions import WCS1Exception
-from datacube_ows.ows_configuration import get_config
 from datacube_ows.resource_limits import ResourceLimited
 from datacube_ows.wcs_utils import get_bands_from_styles
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from datacube_ows.ows_configuration import OWSConfig
 
 
 class WCS1GetCoverageRequest:
     version = Version(1, 0, 0)
 
     # pylint: disable=too-many-instance-attributes, too-many-branches, too-many-statements, too-many-locals
-    def __init__(self, args) -> None:
+    def __init__(self, cfg: OWSConfig, args) -> None:
         self.args = args
-        cfg = get_config()
-
         # Argument: Coverage (required)  -> product/layer
         if "coverage" not in args:
             raise WCS1Exception(
@@ -368,7 +370,7 @@ class WCS1GetCoverageRequest:
         self.ows_stats = bool(args.get("ows_stats"))
 
 
-def get_coverage_data(req, qprof) -> tuple | tuple[int, tuple]:
+def get_coverage_data(cfg: OWSConfig, req, qprof) -> tuple | tuple[int, tuple]:
     # pylint: disable=too-many-locals, protected-access
     stacker = DataStacker(req.layer, req.geobox, req.times, bands=req.bands)
     qprof.start_event("count-datasets")
@@ -395,7 +397,6 @@ def get_coverage_data(req, qprof) -> tuple | tuple[int, tuple]:
     if n_datasets == 0:
         # Return an empty coverage file with full metadata?
         qprof.start_event("build_empty_dataset")
-        cfg = get_config()
         x_range = (req.minx, req.maxx)
         y_range = (req.miny, req.maxy)
         xname = cfg.published_CRSs[req.response_crsid]["horizontal_coord"]
@@ -462,7 +463,7 @@ def get_coverage_data(req, qprof) -> tuple | tuple[int, tuple]:
     return n_datasets, output
 
 
-def get_tiff(req, data: xr.Dataset) -> bytes:
+def get_tiff(cfg: OWSConfig, req, data: xr.Dataset) -> bytes:
     """Uses rasterio MemoryFiles in order to return a streamable GeoTiff response"""
     # Does not support multi-time dimension data - is this even possible in GeoTiff?
     supported_dtype_map = {
@@ -484,7 +485,6 @@ def get_tiff(req, data: xr.Dataset) -> bytes:
 
     data = data.squeeze(dim="time", drop=True)
     data = data.astype(dtype)
-    cfg = get_config()
     xname = str(cfg.published_CRSs[req.response_crsid]["horizontal_coord"])
     yname = str(cfg.published_CRSs[req.response_crsid]["vertical_coord"])
     nodata = 0
@@ -524,7 +524,7 @@ def get_tiff(req, data: xr.Dataset) -> bytes:
         return memfile.read()
 
 
-def get_netcdf(req, data: xr.Dataset) -> bytes:
+def get_netcdf(cfg: OWSConfig, req, data: xr.Dataset) -> bytes:
     # Cleanup dataset attributes for NetCDF export
     data.attrs["crs"] = req.response_crsid
     for _, v in data.data_vars.items():

--- a/datacube_ows/wcs2.py
+++ b/datacube_ows/wcs2.py
@@ -3,6 +3,7 @@
 #
 # Copyright (c) 2017-2024 OWS Contributors
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import logging
 from typing import Any
@@ -24,10 +25,14 @@ from datacube_ows.http_utils import (
     resp_headers,
 )
 from datacube_ows.ogc_exceptions import WCS2Exception
-from datacube_ows.ows_configuration import OWSConfig, get_config
+from datacube_ows.ows_configuration import OWSConfig
 from datacube_ows.query_profiler import QueryProfiler
 from datacube_ows.utils import log_call
 from datacube_ows.wcs2_utils import get_coverage_data
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from datacube_ows.protocol_versions import FlaskResponse
 
 _LOG: logging.Logger = logging.getLogger(__name__)
 
@@ -35,16 +40,17 @@ WCS_REQUESTS = ("DESCRIBECOVERAGE", "GETCOVERAGE")
 
 
 @log_call
-def handle_wcs2(nocase_args) -> tuple:
+def handle_wcs2(cfg: OWSConfig, nocase_args: dict[str, str]) -> FlaskResponse:
     operation = nocase_args.get("request", "").upper()
     if not operation:
         raise WCS2Exception("No operation specified", locator="Request parameter")
     if operation == "GETCAPABILITIES":
-        return get_capabilities(nocase_args)
+        return get_capabilities(cfg, nocase_args)
     if operation == "DESCRIBECOVERAGE":
-        return desc_coverages(nocase_args)
+        return desc_coverages(cfg, nocase_args)
     if operation == "GETCOVERAGE":
         return get_coverage(
+            cfg,
             request.args.lists(),
             bool(nocase_args.get("ows_stats")),
             nocase_args.get("styles"),
@@ -55,9 +61,7 @@ def handle_wcs2(nocase_args) -> tuple:
 
 
 @log_call
-def get_capabilities(args: dict) -> tuple[Any, int, dict]:
-    # Extract layer metadata from Datacube.
-    cfg = get_config()
+def get_capabilities(cfg: OWSConfig, args: dict) -> tuple[Any, int, dict]:
     url = args.get("Host", args["url_root"])
     base_url = get_service_base_url(cfg.allowed_urls, url)
 
@@ -251,9 +255,7 @@ def create_coverage_description(cfg: OWSConfig, product) -> CoverageDescription:
 
 
 @log_call
-def desc_coverages(args) -> tuple:
-    cfg = get_config()
-
+def desc_coverages(cfg: OWSConfig, args) -> tuple:
     request_obj = kvp_decode_describe_coverage(args)
 
     products = []
@@ -288,16 +290,16 @@ def desc_coverages(args) -> tuple:
     min_cache_age = min(p.resource_limits.wcs_desc_cache_rule for p in products)
     headers = cache_control_headers(min_cache_age)
     headers["Content-Type"] = result.content_type
-    return result.value, 200, resp_headers(headers)
+    return result.value, 200, resp_headers(cfg, headers)
 
 
 @log_call
 def get_coverage(
-    args, ows_stats: bool = False, styles=None
+    cfg: OWSConfig, args, ows_stats: bool = False, styles=None
 ) -> tuple[str | bytes, int, dict[str, str]]:
     request_obj = kvp_decode_get_coverage(args)
     qprof = QueryProfiler(ows_stats)
-    output, headers = get_coverage_data(request_obj, styles, qprof)
+    output, headers = get_coverage_data(cfg, request_obj, styles, qprof)
     if ows_stats:
-        return json_response(qprof.profile())
-    return output, 200, resp_headers(headers)
+        return json_response(qprof.profile(), cfg)
+    return output, 200, resp_headers(cfg, headers)

--- a/datacube_ows/wcs2_utils.py
+++ b/datacube_ows/wcs2_utils.py
@@ -3,6 +3,7 @@
 #
 # Copyright (c) 2017-2024 OWS Contributors
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import collections
 import logging
@@ -17,12 +18,13 @@ from rasterio import MemoryFile
 
 from datacube_ows.loading import DataStacker
 from datacube_ows.ogc_exceptions import WCS2Exception
-from datacube_ows.ows_configuration import OWSConfig, get_config
 from datacube_ows.resource_limits import ResourceLimited
 from datacube_ows.utils import default_to_utc
 from datacube_ows.wcs_scaler import WCSScaler, WCSScalerUnknownDimension
 
-# from datacube_ows.wcs_utils import get_bands_from_styles
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from datacube_ows.ows_configuration import OWSConfig
 
 _LOG: logging.Logger = logging.getLogger(__name__)
 
@@ -47,10 +49,8 @@ def uniform_crs(cfg: OWSConfig, crs: str) -> str:
     return crs
 
 
-def get_coverage_data(request, styles, qprof) -> tuple:
+def get_coverage_data(cfg: OWSConfig, request, styles, qprof) -> tuple:
     # pylint: disable=too-many-locals, protected-access
-
-    cfg = get_config()
     qprof.start_event("setup")
     layer_name = request.coverage_id
     layer = cfg.layer_index.get(layer_name)
@@ -336,11 +336,18 @@ def get_coverage_data(request, styles, qprof) -> tuple:
     #
     if fmt.mime == "image/geotiff":
         output = fmt.renderer(request.version)(
-            request, output, output_crs, layer, scaler.size.x, scaler.size.y, affine
+            cfg,
+            request,
+            output,
+            output_crs,
+            layer,
+            scaler.size.x,
+            scaler.size.y,
+            affine,
         )
 
     else:
-        output = fmt.renderer(request.version)(request, output, output_crs)
+        output = fmt.renderer(request.version)(cfg, request, output, output_crs)
 
     headers = {
         "Content-Type": fmt.mime,
@@ -350,7 +357,7 @@ def get_coverage_data(request, styles, qprof) -> tuple:
     return output, headers
 
 
-def get_tiff(request, data, crs, product, width: int, height, affine):
+def get_tiff(cfg: OWSConfig, request, data, crs, product, width: int, height, affine):
     """Uses rasterio MemoryFiles in order to return a streamable GeoTiff response"""
     # Does not support multi-time dimension data - is this even possible in GeoTiff?
     supported_dtype_map = {
@@ -372,8 +379,6 @@ def get_tiff(request, data, crs, product, width: int, height, affine):
 
     # TODO: convert other parameters as-well
     gtiff = request.geotiff_encoding_parameters
-    cfg = get_config()
-
     if len(data.time) > 1:
         raise WCS2Exception("Multiple time slices not supported by GeoTIFF format")
     data = data.squeeze(dim="time", drop=True)
@@ -434,7 +439,7 @@ def get_tiff(request, data, crs, product, width: int, height, affine):
         return memfile.read()
 
 
-def get_netcdf(request, data: xr.Dataset, crs) -> bytes:
+def get_netcdf(cfg: OWSConfig, request, data: xr.Dataset, crs) -> bytes:
     # Cleanup dataset attributes for NetCDF export
     data.attrs["crs"] = crs
     for v in data.data_vars.values():

--- a/datacube_ows/wms.py
+++ b/datacube_ows/wms.py
@@ -3,6 +3,7 @@
 #
 # Copyright (c) 2017-2024 OWS Contributors
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 from flask import render_template
 
@@ -11,26 +12,30 @@ from datacube_ows.feature_info import feature_info
 from datacube_ows.http_utils import cache_control_headers, get_service_base_url
 from datacube_ows.legend_generator import legend_graphic
 from datacube_ows.ogc_exceptions import WMSException
-from datacube_ows.ows_configuration import get_config
+from datacube_ows.ows_configuration import OWSConfig
 from datacube_ows.utils import log_call
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from datacube_ows.protocol_versions import FlaskResponse
 
 WMS_REQUESTS = ("GETMAP", "GETFEATUREINFO", "GETLEGENDGRAPHIC")
 
 
 @log_call
-def handle_wms(nocase_args: dict[str, str]) -> tuple | None:
+def handle_wms(cfg: OWSConfig, nocase_args: dict[str, str]) -> FlaskResponse:
     operation = nocase_args.get("request", "").upper()
     # WMS operation Map
     if not operation:
         raise WMSException("No operation specified", locator="Request parameter")
     if operation == "GETCAPABILITIES":
-        return get_capabilities(nocase_args)
+        return get_capabilities(cfg, nocase_args)
     if operation == "GETMAP":
-        return get_map(nocase_args)
+        return get_map(cfg, nocase_args)
     if operation == "GETFEATUREINFO":
-        return feature_info(nocase_args)
+        return feature_info(cfg, nocase_args)
     if operation == "GETLEGENDGRAPHIC":
-        return legend_graphic(nocase_args)
+        return legend_graphic(cfg, nocase_args)
     raise WMSException(
         f"Unrecognised operation: {operation}",
         WMSException.OPERATION_NOT_SUPPORTED,
@@ -39,11 +44,10 @@ def handle_wms(nocase_args: dict[str, str]) -> tuple | None:
 
 
 @log_call
-def get_capabilities(args) -> tuple[str, int, dict[str, str]]:
+def get_capabilities(cfg: OWSConfig, args) -> tuple[str, int, dict[str, str]]:
     # TODO: Handle updatesequence request parameter for cache consistency.
     # Note: Only WMS v1.3.0 is fully supported at this stage, so no version negotiation is necessary
     # Extract layer metadata from Datacube.
-    cfg = get_config()
     url = args.get("Host", args["url_root"])
     base_url = get_service_base_url(cfg.allowed_urls, url)
     headers = cache_control_headers(cfg.wms_cap_cache_age)

--- a/datacube_ows/wms_utils.py
+++ b/datacube_ows/wms_utils.py
@@ -22,7 +22,7 @@ from typing_extensions import override
 from datacube_ows.config_utils import ConfigException
 from datacube_ows.ogc_exceptions import WMSException
 from datacube_ows.ogc_utils import create_geobox
-from datacube_ows.ows_configuration import OWSNamedLayer, get_config
+from datacube_ows.ows_configuration import OWSConfig, OWSNamedLayer
 from datacube_ows.resource_limits import RequestScale
 from datacube_ows.styles import StyleDef, StyleDefBase
 from datacube_ows.styles.expression import ExpressionException
@@ -63,9 +63,9 @@ def _bounding_pts(
     return minx, miny, maxx, maxy
 
 
-def _get_geobox_xy(args, crs: CRS) -> tuple[float, float, float, float]:
+def _get_geobox_xy(cfg: OWSConfig, args, crs: CRS) -> tuple[float, float, float, float]:
     try:
-        if get_config().published_CRSs[str(crs)]["vertical_coord_first"]:
+        if cfg.published_CRSs[str(crs)]["vertical_coord_first"]:
             miny, minx, maxy, maxx = map(float, args["bbox"].split(","))
         else:
             minx, miny, maxx, maxy = map(float, args["bbox"].split(","))
@@ -76,10 +76,10 @@ def _get_geobox_xy(args, crs: CRS) -> tuple[float, float, float, float]:
     return minx, miny, maxx, maxy
 
 
-def _get_geobox(args, crs: CRS) -> GeoBox:
+def _get_geobox(cfg: OWSConfig, args, crs: CRS) -> GeoBox:
     width = int(args["width"])
     height = int(args["height"])
-    minx, miny, maxx, maxy = _get_geobox_xy(args, crs)
+    minx, miny, maxx, maxy = _get_geobox_xy(cfg, args, crs)
 
     if minx == maxx or miny == maxy:
         raise WMSException("Bounding box must enclose a non-zero area")
@@ -96,20 +96,20 @@ def _get_geobox(args, crs: CRS) -> GeoBox:
     return create_geobox(crs, minx, miny, maxx, maxy, width, height)
 
 
-def _get_polygon(args, crs: CRS) -> geom.Geometry:
-    minx, miny, maxx, maxy = _get_geobox_xy(args, crs)
+def _get_polygon(cfg: OWSConfig, args, crs: CRS) -> geom.Geometry:
+    minx, miny, maxx, maxy = _get_geobox_xy(cfg, args, crs)
     return geom.polygon(
         [(minx, maxy), (minx, miny), (maxx, miny), (maxx, maxy), (minx, maxy)], crs
     )
 
 
-def zoom_factor(args, crs) -> float:
+def zoom_factor(cfg: OWSConfig, args, crs) -> float:
     # Determine the geographic "zoom factor" for the request.
     # (Larger zoom factor means deeper zoom.  Smaller zoom factor means larger area.)
     # Extract request bbox and crs
     width = int(args["width"])
     height = int(args["height"])
-    minx, miny, maxx, maxy = _get_geobox_xy(args, crs)
+    minx, miny, maxx, maxy = _get_geobox_xy(cfg, args, crs)
 
     # Project to a geographic coordinate system
     # This is why we can't just use the regular geobox.  The scale needs to be
@@ -127,8 +127,7 @@ def zoom_factor(args, crs) -> float:
     return 1.0 / math.sqrt(affine.determinant)
 
 
-def img_coords_to_geopoint(geobox, i, j) -> geom.Geometry:
-    cfg = get_config()
+def img_coords_to_geopoint(cfg: OWSConfig, geobox, i, j) -> geom.Geometry:
     h_coord = cfg.published_CRSs[str(geobox.crs)]["horizontal_coord"]
     v_coord = cfg.published_CRSs[str(geobox.crs)]["vertical_coord"]
     try:
@@ -142,14 +141,13 @@ def img_coords_to_geopoint(geobox, i, j) -> geom.Geometry:
     return geom.point(x, y, geobox.crs)
 
 
-def get_layer_from_arg(args, argname: str = "layers") -> OWSNamedLayer:
+def get_layer_from_arg(cfg: OWSConfig, args, argname: str = "layers") -> OWSNamedLayer:
     layers = args.get(argname, "").split(",")
     if len(layers) != 1:
         raise WMSException("Multi-layer requests not supported")
     lyr = layers[0]
     layer_chunks = lyr.split("__")
     lyr = layer_chunks[0]
-    cfg = get_config()
     layer = cfg.layer_index.get(lyr)
     if not layer:
         raise WMSException(
@@ -333,8 +331,8 @@ def parse_wms_time_strings(parts: list[str], with_tz: bool = False) -> tuple:
 
 
 class GetParameters:
-    def __init__(self, args) -> None:
-        self.cfg = get_config()
+    def __init__(self, cfg: OWSConfig, args) -> None:
+        self.cfg = cfg
         # Version
         self.version = get_arg(
             args, "version", "WMS version", permitted_values=["1.1.1", "1.3.0"]
@@ -350,11 +348,11 @@ class GetParameters:
         )
         self.crs = self.cfg.crs(self.crsid)
         # Layers
-        self.layer = self.get_layer(args)
+        self.layer = self.get_layer(cfg, args)
 
-        self.geometry = _get_polygon(args, self.crs)
+        self.geometry = _get_polygon(cfg, args, self.crs)
         # BBox, height and width parameters
-        self.geobox = _get_geobox(args, self.crs)
+        self.geobox = _get_geobox(self.cfg, args, self.crs)
         # Web-merc antimeridian hack:
         if self.geobox.crs != self.crs:
             self.crs = self.geobox.crs  # type: ignore[assignment]
@@ -363,13 +361,13 @@ class GetParameters:
         # Time parameter
         self.times = get_times(args, self.layer)
 
-        self.method_specific_init(args)
+        self.method_specific_init(cfg, args)
 
-    def method_specific_init(self, args) -> None:
+    def method_specific_init(self, cfg: OWSConfig, args) -> None:
         pass
 
-    def get_layer(self, args) -> OWSNamedLayer:
-        return get_layer_from_arg(args)
+    def get_layer(self, cfg: OWSConfig, args) -> OWSNamedLayer:
+        return get_layer_from_arg(cfg, args)
 
 
 def single_style_from_args(layer: OWSNamedLayer, args, required: bool = True):
@@ -448,8 +446,8 @@ def single_style_from_args(layer: OWSNamedLayer, args, required: bool = True):
 
 
 class GetLegendGraphicParameters:
-    def __init__(self, args) -> None:
-        self.layer = get_layer_from_arg(args, "layer")
+    def __init__(self, cfg: OWSConfig, args) -> None:
+        self.layer = get_layer_from_arg(cfg, args, "layer")
 
         # Validate Format parameter
         self.format = get_arg(
@@ -468,7 +466,7 @@ class GetLegendGraphicParameters:
 
 class GetMapParameters(GetParameters):
     @override
-    def method_specific_init(self, args) -> None:
+    def method_specific_init(self, cfg: OWSConfig, args) -> None:
         # Validate Format parameter
         self.format = get_arg(
             args,
@@ -480,7 +478,6 @@ class GetMapParameters(GetParameters):
         )
 
         self.style = single_style_from_args(self.layer, args)
-        cfg = get_config()
         if self.geobox.width > cfg.wms_max_width:
             raise WMSException(
                 f"Width {self.geobox.width} exceeds supported maximum {self.cfg.wms_max_width}.",
@@ -493,7 +490,7 @@ class GetMapParameters(GetParameters):
             )
 
         # Zoom factor
-        self.zf = zoom_factor(args, self.crs)
+        self.zf = zoom_factor(cfg, args, self.crs)
 
         self.ows_stats = bool(args.get("ows_stats"))
 
@@ -511,11 +508,11 @@ class GetMapParameters(GetParameters):
 
 class GetFeatureInfoParameters(GetParameters):
     @override
-    def get_layer(self, args) -> OWSNamedLayer:
-        return get_layer_from_arg(args, "query_layers")
+    def get_layer(self, cfg: OWSConfig, args) -> OWSNamedLayer:
+        return get_layer_from_arg(cfg, args, "query_layers")
 
     @override
-    def method_specific_init(self, args) -> None:
+    def method_specific_init(self, cfg, args) -> None:
         # Validate Formata parameter
         self.format = get_arg(
             args,

--- a/datacube_ows/wmts.py
+++ b/datacube_ows/wmts.py
@@ -3,6 +3,7 @@
 #
 # Copyright (c) 2017-2024 OWS Contributors
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import logging
 
@@ -12,8 +13,12 @@ from datacube_ows.data import get_map
 from datacube_ows.feature_info import feature_info
 from datacube_ows.http_utils import cache_control_headers, get_service_base_url
 from datacube_ows.ogc_exceptions import WMSException, WMTSException
-from datacube_ows.ows_configuration import get_config
+from datacube_ows.ows_configuration import OWSConfig
 from datacube_ows.utils import log_call
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from datacube_ows.protocol_versions import FlaskResponse
 
 _LOG: logging.Logger = logging.getLogger(__name__)
 
@@ -23,17 +28,17 @@ _LOG: logging.Logger = logging.getLogger(__name__)
 
 
 @log_call
-def handle_wmts(nocase_args) -> tuple:
+def handle_wmts(cfg: OWSConfig, nocase_args: dict[str, str]) -> FlaskResponse:
     operation = nocase_args.get("request", "").upper()
     # WMS operation Map
     if not operation:
         raise WMTSException("No operation specified", locator="Request parameter")
     if operation == "GETCAPABILITIES":
-        return get_capabilities(nocase_args)
+        return get_capabilities(cfg, nocase_args)
     if operation == "GETTILE":
-        return get_tile(nocase_args)
+        return get_tile(cfg, nocase_args)
     if operation == "GETFEATUREINFO":
-        return get_feature_info(nocase_args)
+        return get_feature_info(cfg, nocase_args)
     raise WMTSException(
         f"Unrecognised operation: {operation}",
         WMTSException.OPERATION_NOT_SUPPORTED,
@@ -42,11 +47,9 @@ def handle_wmts(nocase_args) -> tuple:
 
 
 @log_call
-def get_capabilities(args) -> tuple:
+def get_capabilities(cfg: OWSConfig, args) -> FlaskResponse:
     # TODO: Handle updatesequence request parameter for cache consistency.
     # Note: Only WMS v1.0.0 exists at this stage, so no version negotiation is necessary
-    # Extract layer metadata from Datacube.
-    cfg = get_config()
     url = args.get("Host", args["url_root"])
     base_url = get_service_base_url(cfg.allowed_urls, url)
     section = args.get("section")
@@ -174,12 +177,11 @@ def wmts_args_to_wms(args, cfg) -> dict:
 
 
 @log_call
-def get_tile(args) -> tuple:
-    cfg = get_config()
+def get_tile(cfg: OWSConfig, args) -> FlaskResponse:
     wms_args = wmts_args_to_wms(args, cfg)
 
     try:
-        return get_map(wms_args)
+        return get_map(cfg, wms_args)
     except WMSException as wmse:
         first_error = wmse.errors[0]
         e = WMTSException(
@@ -194,13 +196,12 @@ def get_tile(args) -> tuple:
 
 
 @log_call
-def get_feature_info(args) -> tuple:
-    cfg = get_config()
+def get_feature_info(cfg: OWSConfig, args) -> FlaskResponse:
     wms_args = wmts_args_to_wms(args, cfg)
     wms_args["query_layers"] = wms_args["layers"]
 
     try:
-        return feature_info(wms_args)
+        return feature_info(cfg, wms_args)
     except WMSException as wmse:
         first_error = wmse.errors[0]
         e = WMTSException(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,7 +21,6 @@ from tests.utils import coords, dim1_da, dim1_da_time, dummy_da
 
 @pytest.fixture
 def flask_client(monkeypatch) -> Generator[flask.Flask]:
-    monkeypatch.setenv("DEFER_CFG_PARSE", "yes")
     from datacube_ows.startup_utils import create_app
 
     with create_app().test_client() as client:

--- a/tests/test_legend_generator.py
+++ b/tests/test_legend_generator.py
@@ -33,7 +33,7 @@ def prelegend_colorramp_style() -> StyleDefBase:
 def test_create_legend_for_style(dummy_layer) -> None:  # noqa: F811
     from datacube_ows.legend_generator import create_legend_for_style
 
-    assert create_legend_for_style(dummy_layer, "stylish_steve") is None
+    assert create_legend_for_style(None, dummy_layer, "stylish_steve") is None  # type: ignore[arg-type]
 
 
 @pytest.fixture

--- a/tests/test_no_db_routes.py
+++ b/tests/test_no_db_routes.py
@@ -26,6 +26,9 @@ def reset_global_config() -> None:
 def no_db(monkeypatch):
     monkeypatch.setenv("DATACUBE_OWS_CFG", "tests.cfg.minimal_cfg.ows_cfg")
     reset_global_config()
+    from datacube_ows.ows_configuration import get_config
+
+    _ = get_config(make_ready=False)
     yield
     reset_global_config()
 

--- a/tests/test_protocol_versions.py
+++ b/tests/test_protocol_versions.py
@@ -8,7 +8,8 @@ import pytest
 
 import datacube_ows.protocol_versions
 from datacube_ows.ogc_exceptions import OGCException
-from datacube_ows.protocol_versions import SupportedSvc
+from datacube_ows.ows_configuration import OWSConfig
+from datacube_ows.protocol_versions import FlaskResponse, SupportedSvc
 
 
 class DummyException1(OGCException):
@@ -19,8 +20,8 @@ class DummyException2(OGCException):
     pass
 
 
-def fake_router(*args, **kwargs) -> None:
-    return None
+def fake_router(cfg: OWSConfig, d: dict[str, str]) -> FlaskResponse:
+    return "", 500, {}
 
 
 @pytest.fixture

--- a/tests/test_wms_utils.py
+++ b/tests/test_wms_utils.py
@@ -316,11 +316,13 @@ def test_parse_item_2(dummy_product) -> None:
 
 
 def test_get_geobox() -> None:
-    from datacube_ows.ows_configuration import OWSConfig
+    from datacube_ows.ows_configuration import OWSConfig, get_config
 
     mock_cfg = MagicMock()
     OWSConfig._instance = mock_cfg
+    cfg = get_config()
     gbox = datacube_ows.wms_utils._get_geobox(
+        cfg,
         args={
             "width": "256",
             "height": "256",
@@ -333,6 +335,7 @@ def test_get_geobox() -> None:
 
     with pytest.raises(WMSException) as e:
         _ = datacube_ows.wms_utils._get_geobox(
+            cfg,
             args={
                 "width": "256",
                 "height": "256",
@@ -345,12 +348,14 @@ def test_get_geobox() -> None:
 
 
 def test_invalid_bbox() -> None:
-    from datacube_ows.ows_configuration import OWSConfig
+    from datacube_ows.ows_configuration import OWSConfig, get_config
 
     mock_cfg = MagicMock()
     OWSConfig._instance = mock_cfg
+    cfg = get_config()
     with pytest.raises(WMSException):
         _ = datacube_ows.wms_utils._get_geobox(
+            cfg,
             args={
                 "width": "256",
                 "height": "256",
@@ -360,6 +365,7 @@ def test_invalid_bbox() -> None:
         )
     with pytest.raises(WMSException):
         _ = datacube_ows.wms_utils._get_geobox(
+            cfg,
             args={
                 "width": "256",
                 "height": "256",
@@ -369,6 +375,7 @@ def test_invalid_bbox() -> None:
         )
     with pytest.raises(WMSException):
         _ = datacube_ows.wms_utils._get_geobox(
+            cfg,
             args={
                 "width": "256",
                 "height": "256",


### PR DESCRIPTION
Get the config under exclusive
lock in create_app, and then
pass that config down into
the functions that needs it.

This avoids taking the lock
repeatedly during request
processing.

<!-- readthedocs-preview datacube-ows start -->
----
📚 Documentation preview 📚: https://datacube-ows--1526.org.readthedocs.build/en/1526/

<!-- readthedocs-preview datacube-ows end -->