### PR TITLE
wcs1_utils: fix type error

### DIFF
--- a/datacube_ows/wcs1_utils.py
+++ b/datacube_ows/wcs1_utils.py
@@ -164,7 +164,9 @@ class WCS1GetCoverageRequest:
             #      CEOS treats no supplied time argument as all time.
             # I'm really not sure what the right thing to do is, but QGIS wants us to do SOMETHING - use configured
             # default.
-            self.times = [self.layer.default_time]
+            self.times = (
+                [] if self.layer.default_time is None else [self.layer.default_time]
+            )
         else:
             # TODO: the min/max/res format option?
             # It's a bit underspeced. I'm not sure what the "res" would look like.


### PR DESCRIPTION
The default_time can be None,
so make an empty list when
that happens.

<!-- readthedocs-preview datacube-ows start -->
----
📚 Documentation preview 📚: https://datacube-ows--1528.org.readthedocs.build/en/1528/

<!-- readthedocs-preview datacube-ows end -->