### PR TITLE
Cleanup cfg-parser check command.

### DIFF
--- a/datacube_ows/cfg_parser_impl.py
+++ b/datacube_ows/cfg_parser_impl.py
@@ -170,8 +170,7 @@ def extract(path: str, cfg_only: bool, msg_file: str) -> int:
     try:
         raw_cfg = read_config(path)
         cfg = OWSConfig(refresh=True, cfg=raw_cfg, ignore_msgfile=cfg_only)
-        with Datacube() as dc:
-            cfg.make_ready(dc)
+        cfg.make_ready()
     except ConfigException as e:
         click.echo(f"Config exception for path {e!s}")
         return False

--- a/datacube_ows/cfg_parser_impl.py
+++ b/datacube_ows/cfg_parser_impl.py
@@ -13,7 +13,6 @@ from typing import cast
 
 import click
 from babel.messages.pofile import write_po
-from datacube import Datacube
 from deepdiff import DeepDiff
 
 from datacube_ows import __version__

--- a/datacube_ows/cfg_parser_impl.py
+++ b/datacube_ows/cfg_parser_impl.py
@@ -119,8 +119,7 @@ def parse_path(
         raw_cfg = read_config(path)
         cfg = OWSConfig(refresh=True, cfg=raw_cfg)
         if not parse_only:
-            with Datacube(app=cfg.odc_app + "-cfg") as dc:
-                cfg.make_ready(dc)
+            cfg.make_ready()
     except ConfigException as e:
         click.echo(f"Config exception for path {e!s}")
         return False


### PR DESCRIPTION
Cfg-parser was still generating a Datacube object and passing it to make_ready.  The config layer doesn't work like that any more.

<!-- readthedocs-preview datacube-ows start -->
----
📚 Documentation preview 📚: https://datacube-ows--1533.org.readthedocs.build/en/1533/

<!-- readthedocs-preview datacube-ows end -->