### PR TITLE
postgis: fix diagnostic printout

### DIFF
--- a/datacube_ows/sql/postgis/ows_schema/grants/002_grant_range_read.sql
+++ b/datacube_ows/sql/postgis/ows_schema/grants/002_grant_range_read.sql
@@ -1,3 +1,3 @@
--- Granting select on layer ranges table to {role}
+-- Granting select on layer ranges table to odc_user
 
 GRANT SELECT ON ows.layer_ranges TO odc_user;


### PR DESCRIPTION
This prints ".. to {role}" to
the console, so replace it
with the real user instead.

<!-- readthedocs-preview datacube-ows start -->
----
📚 Documentation preview 📚: https://datacube-ows--1535.org.readthedocs.build/en/1535/

<!-- readthedocs-preview datacube-ows end -->