### PR TITLE
CI: fix PyPi release upload

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -96,6 +96,8 @@ jobs:
 
       - name: Build Packages
         run: |
+          SETUPTOOLS_SCM_PRETEND_VERSION=$(git describe --abbrev=0 --tags)
+          export SETUPTOOLS_SCM_PRETEND_VERSION
           uv build
           uv tool run twine check --strict dist/*
 


### PR DESCRIPTION
Some files in the repository
are modified by the testing
in CI, so import the fix from
Explorer to set the version
based on the tag.

<!-- readthedocs-preview datacube-ows start -->
----
📚 Documentation preview 📚: https://datacube-ows--1538.org.readthedocs.build/en/1538/

<!-- readthedocs-preview datacube-ows end -->