### PR TITLE
index/postgres: fix deprecation warning

### DIFF
--- a/datacube_ows/index/postgres/mv_index.py
+++ b/datacube_ows/index/postgres/mv_index.py
@@ -147,7 +147,8 @@ def mv_search(
 
                     TZRange = DateTimeTZRange
                 or_clauses.append(stv.c.temporal_extent.op("&&")(TZRange(*t)))
-        s = s.where(or_(*or_clauses))
+        if or_clauses:
+            s = s.where(or_(*or_clauses))
     orig_crs = None
     if geom is not None:
         orig_crs = geom.crs


### PR DESCRIPTION
Empty or-clauses are deprecated,
so only create the or-clause if
there are some clauses.

<!-- readthedocs-preview datacube-ows start -->
----
📚 Documentation preview 📚: https://datacube-ows--1541.org.readthedocs.build/en/1541/

<!-- readthedocs-preview datacube-ows end -->