### PR TITLE
ows_configuration: forbid allowed_uris=[]

### DIFF
--- a/datacube_ows/ows_configuration.py
+++ b/datacube_ows/ows_configuration.py
@@ -1766,6 +1766,10 @@ class OWSConfig(OWSMetadataConfig):
             self.msg_file_name = cast(str | None, cfg.get("message_file"))
         self.parse_metadata(cfg)
         self.allowed_urls = cast(str | list[str], cfg["allowed_urls"])
+        if isinstance(self.allowed_urls, list) and len(self.allowed_urls) == 0:
+            raise ConfigException(
+                'Empty list for allowed_urls. Please use the empty string ("") instead.'
+            )
         self.info_url = cfg["info_url"]
         self.contact_info = ContactInfo.parse(cfg.get("contact_info"), self)
         self.attribution = AttributionCfg.parse(

--- a/tests/cfg/minimal_cfg.py
+++ b/tests/cfg/minimal_cfg.py
@@ -7,7 +7,7 @@
 ows_cfg = {
     "global": {
         "title": "Minimal test config",
-        "allowed_urls": [],
+        "allowed_urls": "",
         "info_url": "http://opendatacube.org",
         "env": "nosuchdb",
         "published_CRSs": {

--- a/tests/test_no_db_routes.py
+++ b/tests/test_no_db_routes.py
@@ -65,6 +65,5 @@ def test_legend_fail(no_db, flask_client) -> None:
 
 def test_index_fail(no_db, flask_client) -> None:
     """Base index endpoint fails"""
-    # Should actually be 200 TODO
     rv = flask_client.get("/")
-    assert rv.status_code == 500
+    assert rv.status_code == 200


### PR DESCRIPTION
This causes an index out of bounds
error, so raise an exception with
a readable error message when
validating the config instead.

<!-- readthedocs-preview datacube-ows start -->
----
📚 Documentation preview 📚: https://datacube-ows--1543.org.readthedocs.build/en/1543/

<!-- readthedocs-preview datacube-ows end -->