### PR TITLE
Use TYPE_CHECKING block for OWS

### DIFF
--- a/datacube_ows/band_utils.py
+++ b/datacube_ows/band_utils.py
@@ -3,12 +3,18 @@
 #
 # Copyright (c) 2017-2024 OWS Contributors
 # SPDX-License-Identifier: Apache-2.0
-from collections.abc import Callable, Sequence
+from __future__ import annotations
+
 from functools import wraps
 from typing import Literal
 
 import numpy
-import xarray as xr
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Callable, Sequence
+
+    import xarray as xr
 
 # Style index functions
 

--- a/datacube_ows/cfg_parser_impl.py
+++ b/datacube_ows/cfg_parser_impl.py
@@ -4,7 +4,7 @@
 #
 # Copyright (c) 2017-2024 OWS Contributors
 # SPDX-License-Identifier: Apache-2.0
-
+from __future__ import annotations
 
 import json
 import os
@@ -17,13 +17,11 @@ from deepdiff import DeepDiff
 
 from datacube_ows import __version__
 from datacube_ows.config_utils import ConfigException
-from datacube_ows.ows_configuration import (
-    OWSConfig,
-    OWSFolder,
-    OWSLayer,
-    OWSNamedLayer,
-    read_config,
-)
+from datacube_ows.ows_configuration import OWSConfig, OWSFolder, read_config
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from datacube_ows.ows_configuration import OWSLayer, OWSNamedLayer
 
 
 @click.group(invoke_without_command=True)

--- a/datacube_ows/cfg_parser_impl.py
+++ b/datacube_ows/cfg_parser_impl.py
@@ -53,7 +53,7 @@ def main(version: bool) -> int:
     "--folders",
     is_flag=True,
     default=False,
-    help="Print the folder/layer heirarchy(ies) to stdout.",
+    help="Print the folder/layer hierarchy(ies) to stdout.",
 )
 @click.option(
     "-s",

--- a/datacube_ows/cfg_parser_impl.py
+++ b/datacube_ows/cfg_parser_impl.py
@@ -405,7 +405,7 @@ def layers_report(
             "styles_count": len(lyr.styles),
             "styles_list": [styl.name for styl in lyr.styles],
         }
-        cast(list[dict], report["layers"]).append(layer)
+        cast("list[dict]", report["layers"]).append(layer)
     if input_file:
         with open(input_file) as f:
             input_file_data = json.load(f)

--- a/datacube_ows/config_utils.py
+++ b/datacube_ows/config_utils.py
@@ -462,7 +462,7 @@ class OWSMetadataConfig(OWSConfigEntry):
     @classmethod
     def set_msg_src(cls, src: Catalog | None) -> None:
         """
-        Allow all OWSMetadatConfig subclasses to share a common message catalog.
+        Allow all OWSMetadataConfig subclasses to share a common message catalog.
         :param src: A Message Catalog object
         """
         OWSMetadataConfig._msg_src = src

--- a/datacube_ows/config_utils.py
+++ b/datacube_ows/config_utils.py
@@ -62,7 +62,7 @@ def cfg_expand(
         if "include" in cfg_unexpanded:
             if cfg_unexpanded["include"] in inclusions:
                 raise ConfigException(f"Cyclic inclusion: {cfg_unexpanded['include']}")
-            raw_path = cast(str, cfg_unexpanded["include"])
+            raw_path = cast("str", cfg_unexpanded["include"])
             # Required to pass a copy of the list into recursive invocations,
             # test_cfg_inclusion.py will show how it fails otherwise.
             ninclusions: list[str] = inclusions.copy()
@@ -98,7 +98,7 @@ def cfg_expand(
                 f"Unsupported inclusion type: {cfg_unexpanded['type']!s}"
             )
         return {
-            k: cfg_expand(cast(CFG_DICT, v), cwd=cwd, inclusions=inclusions)
+            k: cfg_expand(cast("CFG_DICT", v), cwd=cwd, inclusions=inclusions)
             for k, v in cfg_unexpanded.items()
         }
     if isinstance(cfg_unexpanded, Sequence) and not isinstance(cfg_unexpanded, str):
@@ -156,7 +156,7 @@ def import_python_obj(path: str) -> CFG_DICT:
         obj = getattr(mod, obj_name)
     except (ImportError, ValueError, ModuleNotFoundError, AttributeError):
         raise ConfigException(f"Could not import python object: {path}") from None
-    return cast(CFG_DICT, obj)
+    return cast("CFG_DICT", obj)
 
 
 class ConfigException(Exception):
@@ -356,12 +356,12 @@ class OWSMetadataConfig(OWSConfigEntry):
                 self.register_metadata(
                     self.get_obj_label(),
                     FLD_TITLE,
-                    cast(str, cfg.get(FLD_TITLE, self.default_title)),
+                    cast("str", cfg.get(FLD_TITLE, self.default_title)),
                 )
             else:
                 try:
                     self.register_metadata(
-                        self.get_obj_label(), FLD_TITLE, cast(str, cfg[FLD_TITLE])
+                        self.get_obj_label(), FLD_TITLE, cast("str", cfg[FLD_TITLE])
                     )
                 except KeyError:
                     raise ConfigException(
@@ -384,10 +384,10 @@ class OWSMetadataConfig(OWSConfigEntry):
                 raise ConfigException(f"Entity {self.get_obj_label()} has no abstract")
             else:
                 self.register_metadata(
-                    self.get_obj_label(), "abstract", cast(str, local_abstract)
+                    self.get_obj_label(), "abstract", cast("str", local_abstract)
                 )
         if self.METADATA_KEYWORDS:
-            local_keyword_set = set(cast(list[str], cfg.get("keywords", [])))
+            local_keyword_set = set(cast("list[str]", cfg.get("keywords", [])))
             self.register_metadata(
                 self.get_obj_label(), FLD_KEYWORDS, ",".join(local_keyword_set)
             )
@@ -395,7 +395,7 @@ class OWSMetadataConfig(OWSConfigEntry):
             self._keywords = keyword_set.union(local_keyword_set)
         if self.METADATA_ATTRIBUTION:
             inheriting = False
-            attrib = cast(dict[str, str], cfg.get("attribution"))
+            attrib = cast("dict[str, str]", cfg.get("attribution"))
             if attrib is None and inherit_from is not None:
                 attrib = inherit_from.attribution
                 inheriting = True
@@ -405,18 +405,18 @@ class OWSMetadataConfig(OWSConfigEntry):
                     self.get_obj_label(), FLD_ATTRIBUTION, attrib_title, inheriting
                 )
         if self.METADATA_FEES:
-            fees = cast(str, cfg.get(FLD_FEES))
+            fees = cast("str", cfg.get(FLD_FEES))
             if not fees:
                 fees = "none"
             self.register_metadata(self.get_obj_label(), FLD_FEES, fees)
         if self.METADATA_ACCESS_CONSTRAINTS:
-            acc = cast(str, cfg.get("access_contraints"))
+            acc = cast("str", cfg.get("access_contraints"))
             if not acc:
                 acc = "none"
             self.register_metadata(self.get_obj_label(), FLD_ACCESS_CONSTRAINTS, acc)
         if self.METADATA_CONTACT_INFO:
             cfg_contact_info: dict[str, str] = cast(
-                dict[str, str], cfg.get("contact_info", {})
+                "dict[str, str]", cfg.get("contact_info", {})
             )
             org = cfg_contact_info.get("organisation")
             position = cfg_contact_info.get("position")
@@ -429,7 +429,7 @@ class OWSMetadataConfig(OWSConfigEntry):
                     self.get_obj_label(), FLD_CONTACT_POSITION, position
                 )
         if self.METADATA_DEFAULT_BANDS:
-            band_map = cast(dict[str, list[str]], cfg)
+            band_map = cast("dict[str, list[str]]", cfg)
             for k, v in band_map.items():
                 if len(v):
                     self.register_metadata(self.get_obj_label(), k, v[0])
@@ -442,7 +442,7 @@ class OWSMetadataConfig(OWSConfigEntry):
                     self.get_obj_label(), f"rule_{patch.idx}", patch.label
                 )
         if self.METADATA_LEGEND_UNITS:
-            units = cast(str, cfg.get(FLD_UNITS))
+            units = cast("str", cfg.get(FLD_UNITS))
             if units is not None:
                 self.register_metadata(self.get_obj_label(), FLD_UNITS, units)
         if self.METADATA_TICK_LABELS:
@@ -490,7 +490,7 @@ class OWSMetadataConfig(OWSConfigEntry):
             if not msg:
                 msg_: str | None = self._metadata_registry.get(lookup)
             else:
-                msg_ = cast(str, msg.string)
+                msg_ = cast("str", msg.string)
             return msg_
         return self._metadata_registry.get(lookup)
 
@@ -658,7 +658,7 @@ class OWSExtensibleConfigEntry(OWSIndexedConfigEntry):
         """
         if not expanded:
             cfg = self.expand_inherit(
-                cast(CFG_DICT, cfg),
+                cast("CFG_DICT", cfg),
                 global_cfg,
                 keyval_subs=keyval_subs,
                 keyval_defaults=keyval_defaults,
@@ -687,7 +687,7 @@ class OWSExtensibleConfigEntry(OWSIndexedConfigEntry):
             lookup = True
             # Precludes e.g. defaulting style lookup to current layer.
             lookup_keys: dict[str, str] = {}
-            inherits = cast(dict[str, str], cfg["inherits"])
+            inherits = cast("dict[str, str]", cfg["inherits"])
             for k in cls.INDEX_KEYS:
                 if (
                     k not in inherits
@@ -708,7 +708,7 @@ class OWSExtensibleConfigEntry(OWSIndexedConfigEntry):
                 parent_cfg = parent._raw_cfg
             else:
                 parent_cfg = cfg["inherits"]
-            cfg = deepinherit(cast(dict[str, Any], parent_cfg), cfg)
+            cfg = deepinherit(cast("dict[str, Any]", parent_cfg), cfg)
             cfg["inheritance_expanded"] = True
         return cfg
 
@@ -749,10 +749,10 @@ class OWSFlagBand(OWSConfigEntry):
         :param product_cfg:  The OWSNamedLayer object this flag-band is associated with
         """
         super().__init__(cfg, **kwargs)
-        cfg = cast(CFG_DICT, self._raw_cfg)
+        cfg = cast("CFG_DICT", self._raw_cfg)
         self.layer = product_cfg
         pq_names = self.layer.parse_pq_names(cfg)
-        self.pq_names = cast(list[str], pq_names["pq_names"])
+        self.pq_names = cast("list[str]", pq_names["pq_names"])
         self.pq_low_res_names = pq_names["pq_low_res_names"]
         self.main_products = pq_names["main_products"]
         self.pq_band = str(cfg["band"])
@@ -760,7 +760,7 @@ class OWSFlagBand(OWSConfigEntry):
         if "fuse_func" in cfg:
             if self.layer.global_cfg.load_driver == "legacy":
                 self.pq_fuse_func: FunctionWrapper | str | None = FunctionWrapper(
-                    self.layer, cast(CFG_DICT, cfg["fuse_func"])
+                    self.layer, cast("CFG_DICT", cfg["fuse_func"])
                 )
             elif isinstance(cfg["fuse_func"], str):
                 self.pq_fuse_func = cfg["fuse_func"]
@@ -771,7 +771,7 @@ class OWSFlagBand(OWSConfigEntry):
         else:
             self.pq_fuse_func = None
         self.pq_ignore_time = bool(cfg.get("ignore_time", False))
-        self.ignore_info_flags = cast(list[str], cfg.get("ignore_info_flags", []))
+        self.ignore_info_flags = cast("list[str]", cfg.get("ignore_info_flags", []))
         self.pq_manual_merge = bool(cfg.get("manual_merge", False))
         self.declare_unready("pq_products")
         self.declare_unready("flags_def")
@@ -906,7 +906,7 @@ class FlagProductBands(OWSConfigEntry):
         Second round (db-aware) intialisation.
         """
         for fb in self.flag_bands.values():
-            fb = cast(OWSFlagBand, fb)
+            fb = cast("OWSFlagBand", fb)
             # pyre-ignore [16]
             self.products: list[Product] = fb.pq_products
             # pyre-ignore [16]
@@ -994,16 +994,16 @@ class AbstractMaskRule(OWSConfigEntry):
         self.values: list[list[int]] | list[int] | None = None
         self.invert: bool | list[bool] = bool(cfg.get("invert", False))
         if "flags" in cfg:
-            flags = cast(FlagSpec, cfg["flags"])
+            flags = cast("FlagSpec", cfg["flags"])
             if "or" in flags and "and" in flags:
                 raise ConfigException(
                     f"ValueMap rule in {self.context} combines 'and' and 'or' rules"
                 )
             if "or" in flags:
                 self.or_flags = True
-                flags = cast(FlagSpec, flags["or"])
+                flags = cast("FlagSpec", flags["or"])
             elif "and" in flags:
-                flags = cast(FlagSpec, flags["and"])
+                flags = cast("FlagSpec", flags["and"])
             self.flags = flags
         else:
             self.flags = None
@@ -1018,7 +1018,7 @@ class AbstractMaskRule(OWSConfigEntry):
             if isinstance(val, int):
                 self.values = [val]
             else:
-                self.values = cast(list[int], val)
+                self.values = cast("list[int]", val)
 
         if not self.flags and not self.values:
             raise ConfigException(
@@ -1038,7 +1038,7 @@ class AbstractMaskRule(OWSConfigEntry):
         """
         if self.values:
             mask: DataArray | None = None
-            for v in cast(list[int], self.values):
+            for v in cast("list[int]", self.values):
                 vmask = data == v
                 if mask is None:
                     mask = vmask
@@ -1046,14 +1046,14 @@ class AbstractMaskRule(OWSConfigEntry):
                     mask |= vmask
         elif self.or_flags:
             mask = None
-            for f in cast(CFG_DICT, self.flags).items():
+            for f in cast("CFG_DICT", self.flags).items():
                 d = {f[0]: f[1]}
                 if mask is None:
                     mask = make_mask(data, **d)
                 else:
                     mask |= make_mask(data, **d)
         else:
-            mask = make_mask(data, **cast(CFG_DICT, self.flags))
+            mask = make_mask(data, **cast("CFG_DICT", self.flags))
         if mask is not None and self.invert:
             mask = ~mask  # pylint: disable=invalid-unary-operand-type
         return mask
@@ -1104,9 +1104,9 @@ class FunctionWrapper:
                     "Directly including callable objects in configuration is no longer supported. Please reference callables by fully qualified name."
                 )
             else:
-                self._func = get_function(cast(str, func_cfg["function"]))
-            self._args = cast(list[RAW_CFG], func_cfg.get("args", []))
-            self._kwargs = cast(CFG_DICT, func_cfg.get("kwargs", {})).copy()
+                self._func = get_function(cast("str", func_cfg["function"]))
+            self._args = cast("list[RAW_CFG]", func_cfg.get("args", []))
+            self._kwargs = cast("CFG_DICT", func_cfg.get("kwargs", {})).copy()
             self.pass_layer_cfg = bool(func_cfg.get("pass_layer_cfg", False))
             if "pass_product_cfg" in func_cfg:
                 _LOG.warning(
@@ -1116,16 +1116,15 @@ class FunctionWrapper:
             if func_cfg.get("mapped_bands", func_cfg.get("pass_product_cfg", False)):
                 if hasattr(product_or_style_cfg, "band_idx"):
                     # NamedLayer
-                    from datacube_ows.ows_configuration import OWSNamedLayer
 
-                    named_layer = cast(OWSNamedLayer, product_or_style_cfg)
+                    named_layer = cast("OWSNamedLayer", product_or_style_cfg)
                     b_idx = named_layer.band_idx
                     self.band_mapper = b_idx.band
                 else:
                     # Style
                     from datacube_ows.styles import StyleDef
 
-                    style = cast(StyleDef, product_or_style_cfg)
+                    style = cast("StyleDef", product_or_style_cfg)
                     b_idx = style.product.band_idx
                     delocaliser = style.local_band
                     self.band_mapper = lambda b: b_idx.band(delocaliser(b))

--- a/datacube_ows/config_utils.py
+++ b/datacube_ows/config_utils.py
@@ -3,31 +3,37 @@
 #
 # Copyright (c) 2017-2024 OWS Contributors
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import contextlib
 import json
 import logging
 import os
-from collections.abc import Callable, Iterable, Sequence
+from collections.abc import Callable, Sequence
 from importlib import import_module
 from itertools import chain
-from typing import Any, Optional, TypeAlias, cast
+from typing import Any, TypeAlias, cast
 from urllib.parse import urlparse
 
 import fsspec
-from babel.messages import Catalog, Message
-from datacube.model import Product
 from datacube.utils.masking import make_mask
 from flask_babel import gettext as _
 from typing_extensions import override
-from xarray import DataArray
 
 from datacube_ows.config_toolkit import deepinherit
 
 TYPE_CHECKING = False
 if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    from babel.messages import Catalog, Message
+    from datacube.model import Product
+    from xarray import DataArray
+
     import datacube_ows.ows_configuration
-    import datacube_ows.styles.base
+    from datacube_ows.ows_configuration import AttributionCfg, OWSConfig, OWSNamedLayer
+    from datacube_ows.styles import StyleDef
+    from datacube_ows.styles.base import StyleMask
 
 _LOG: logging.Logger = logging.getLogger(__name__)
 
@@ -316,13 +322,13 @@ class OWSMetadataConfig(OWSConfigEntry):
 
     # Inaccessible attributes to allow type checking
     abstract: str = ""
-    attribution: Optional["datacube_ows.ows_configuration.AttributionCfg"] = None
+    attribution: AttributionCfg | None = None
 
     def get_obj_label(self) -> str:
         """Return the metadata path prefix for this object."""
         return "global"
 
-    def can_inherit_from(self) -> Optional["OWSMetadataConfig"]:
+    def can_inherit_from(self) -> OWSMetadataConfig | None:
         """
         The parent config object this object can inherit metadata from.
 
@@ -541,7 +547,7 @@ class OWSMetadataConfig(OWSConfigEntry):
         """
         return self.read_inheritance(self.get_obj_label(), fld)
 
-    def global_config(self) -> "datacube_ows.ows_configuration.OWSConfig":
+    def global_config(self) -> OWSConfig:
         """
         Return the global config object.
 
@@ -613,11 +619,8 @@ class OWSIndexedConfigEntry(OWSConfigEntry):
 
     @classmethod
     def lookup_impl(
-        cls,
-        cfg: "datacube_ows.ows_configuration.OWSConfig",
-        keyvals: dict[str, str],
-        subs: CFG_DICT | None = None,
-    ) -> "OWSIndexedConfigEntry":
+        cls, cfg: OWSConfig, keyvals: dict[str, str], subs: CFG_DICT | None = None
+    ) -> OWSIndexedConfigEntry:
         """
         Lookup a config entry of this type by identifying label(s)
 
@@ -640,7 +643,7 @@ class OWSExtensibleConfigEntry(OWSIndexedConfigEntry):
         self,
         cfg: RAW_CFG,
         keyvals: dict[str, str],
-        global_cfg: "datacube_ows.ows_configuration.OWSConfig",
+        global_cfg: OWSConfig,
         *args,
         keyval_subs: dict[str, Any] | None = None,
         keyval_defaults: dict[str, str] | None = None,
@@ -670,7 +673,7 @@ class OWSExtensibleConfigEntry(OWSIndexedConfigEntry):
     def expand_inherit(
         cls,
         cfg: CFG_DICT,
-        global_cfg: "datacube_ows.ows_configuration.OWSConfig",
+        global_cfg: OWSConfig,
         keyval_subs: dict[str, Any] | None = None,
         keyval_defaults: dict[str, str] | None = None,
     ) -> RAW_CFG:
@@ -736,12 +739,7 @@ class OWSFlagBand(OWSConfigEntry):
     Represents a flag band, which may come from the main product or a parallel secondary product.
     """
 
-    def __init__(
-        self,
-        cfg: CFG_DICT,
-        product_cfg: "datacube_ows.ows_configuration.OWSNamedLayer",
-        **kwargs,
-    ) -> None:
+    def __init__(self, cfg: CFG_DICT, product_cfg: OWSNamedLayer, **kwargs) -> None:
         """
         Class constructor, first round initialisation
 
@@ -844,9 +842,7 @@ class FlagProductBands(OWSConfigEntry):
     A collection of flag bands for a layer that all come from the same product (or multi-product product collection).
     """
 
-    def __init__(
-        self, flag_band: FlagBand, layer: "datacube_ows.ows_configuration.OWSNamedLayer"
-    ) -> None:
+    def __init__(self, flag_band: FlagBand, layer: OWSNamedLayer) -> None:
         """
         Class constructor, first round initialisation
 
@@ -918,10 +914,8 @@ class FlagProductBands(OWSConfigEntry):
 
     @classmethod
     def build_list_from_masks(
-        cls,
-        masks: Iterable["datacube_ows.styles.base.StyleMask"],
-        layer: "datacube_ows.ows_configuration.OWSNamedLayer",
-    ) -> list["FlagProductBands"]:
+        cls, masks: Iterable[StyleMask], layer: OWSNamedLayer
+    ) -> list[FlagProductBands]:
         """
         Class method to instantiate a list of FlagProductBands from a list of style masks.
 
@@ -945,10 +939,8 @@ class FlagProductBands(OWSConfigEntry):
 
     @classmethod
     def build_list_from_flagbands(
-        cls,
-        flagbands: Iterable[OWSFlagBand],
-        layer: "datacube_ows.ows_configuration.OWSNamedLayer",
-    ) -> list["FlagProductBands"]:
+        cls, flagbands: Iterable[OWSFlagBand], layer: OWSNamedLayer
+    ) -> list[FlagProductBands]:
         """
         Class method to instantiate a list of FlagProductBands from a list of OWS Flag Bands.
 
@@ -1116,14 +1108,11 @@ class FunctionWrapper:
             if func_cfg.get("mapped_bands", func_cfg.get("pass_product_cfg", False)):
                 if hasattr(product_or_style_cfg, "band_idx"):
                     # NamedLayer
-
                     named_layer = cast("OWSNamedLayer", product_or_style_cfg)
                     b_idx = named_layer.band_idx
                     self.band_mapper = b_idx.band
                 else:
                     # Style
-                    from datacube_ows.styles import StyleDef
-
                     style = cast("StyleDef", product_or_style_cfg)
                     b_idx = style.product.band_idx
                     delocaliser = style.local_band

--- a/datacube_ows/data.py
+++ b/datacube_ows/data.py
@@ -12,8 +12,6 @@ from typing import Any
 import numpy
 import numpy.ma
 import xarray
-from odc.geo import geom
-from odc.geo.geobox import GeoBox
 from pandas import Timestamp
 from rasterio.features import rasterize
 from rasterio.io import MemoryFile
@@ -22,17 +20,20 @@ from datacube_ows.http_utils import json_response, png_response
 from datacube_ows.loading import DataStacker
 from datacube_ows.ogc_exceptions import WMSException
 from datacube_ows.ogc_utils import xarray_image_as_png
-from datacube_ows.ows_configuration import OWSConfig, OWSNamedLayer
 from datacube_ows.query_profiler import QueryProfiler
 from datacube_ows.resource_limits import ResourceLimited
-from datacube_ows.styles import StyleDef
 from datacube_ows.time_utils import solar_date, tz_for_geometry
 from datacube_ows.utils import default_to_utc, log_call
 from datacube_ows.wms_utils import GetMapParameters
 
 TYPE_CHECKING = False
 if TYPE_CHECKING:
+    from odc.geo import geom
+    from odc.geo.geobox import GeoBox
+
+    from datacube_ows.ows_configuration import OWSConfig, OWSNamedLayer
     from datacube_ows.protocol_versions import FlaskResponse
+    from datacube_ows.styles import StyleDef
 
 
 _LOG: logging.Logger = logging.getLogger(__name__)

--- a/datacube_ows/feature_info.py
+++ b/datacube_ows/feature_info.py
@@ -176,8 +176,8 @@ def feature_info(cfg: OWSConfig, args: dict[str, str]) -> FlaskResponse:
     all_time_datasets = stacker.datasets_all_time(point=geo_point_geobox.extent)
 
     # Taking the data as a single point so our indexes into the data should be 0,0
-    h_coord = cast(str, cfg.published_CRSs[params.crsid]["horizontal_coord"])
-    v_coord = cast(str, cfg.published_CRSs[params.crsid]["vertical_coord"])
+    h_coord = cast("str", cfg.published_CRSs[params.crsid]["horizontal_coord"])
+    v_coord = cast("str", cfg.published_CRSs[params.crsid]["vertical_coord"])
     s3_bucket = cfg.s3_bucket
     s3_url = cfg.s3_url
     isel_kwargs = {h_coord: 0, v_coord: 0}
@@ -218,7 +218,7 @@ def feature_info(cfg: OWSConfig, args: dict[str, str]) -> FlaskResponse:
                 ds: Dataset | None = None
                 for pbq, dss in time_datasets.items():
                     if pbq.main:
-                        ds = cast(Dataset, dss.sel(time=dt).values.tolist()[0])
+                        ds = cast("Dataset", dss.sel(time=dt).values.tolist()[0])
                         break
                 assert ds is not None
                 if params.layer.multi_product:
@@ -245,9 +245,9 @@ def feature_info(cfg: OWSConfig, args: dict[str, str]) -> FlaskResponse:
                         "%Y-%m-%d %H:%M:%S %Z"
                     )
                 # Collect raw band values for pixel and derived bands from styles
-                date_info["bands"] = cast(RAW_CFG, _make_band_dict(params.layer, td))
+                date_info["bands"] = cast("RAW_CFG", _make_band_dict(params.layer, td))
                 derived_band_dict = cast(
-                    RAW_CFG, _make_derived_band_dict(td, params.layer.style_index)
+                    "RAW_CFG", _make_derived_band_dict(td, params.layer.style_index)
                 )
                 if derived_band_dict:
                     date_info["band_derived"] = derived_band_dict
@@ -273,8 +273,8 @@ def feature_info(cfg: OWSConfig, args: dict[str, str]) -> FlaskResponse:
                         # * the ODC Dataset model (i.e. full ODC metadata)
                         date_info[k] = f(td, ds)
 
-                cast(list[RAW_CFG], feature_json["data"]).append(date_info)
-                fi_date_index[dt] = cast(dict[str, list[RAW_CFG]], feature_json)[
+                cast("list[RAW_CFG]", feature_json["data"]).append(date_info)
+                fi_date_index[dt] = cast("dict[str, list[RAW_CFG]]", feature_json)[
                     "data"
                 ][-1]
             # Multidate custom includes reflect all selected times on multidate requests,
@@ -288,12 +288,12 @@ def feature_info(cfg: OWSConfig, args: dict[str, str]) -> FlaskResponse:
                         # Function signature: pass in:
                         # * a multi-date single pixel (1x1xn) multiband xarray Dataset,
                         date_info[k] = f(data)
-                cast(list[RAW_CFG], feature_json["data"]).append(date_info)
+                cast("list[RAW_CFG]", feature_json["data"]).append(date_info)
         feature_json["data_available_for_dates"] = []
         pt_native = None
         for d in all_time_datasets.coords["time"].values:
             dt_datasets = all_time_datasets.sel(time=d)
-            for ds in cast(Iterable[Dataset], dt_datasets.values.item()):
+            for ds in cast("Iterable[Dataset]", dt_datasets.values.item()):
                 assert ds.crs is not None  # For type checker
                 if pt_native is None or pt_native.crs != ds.crs:
                     pt_native = geo_point.to_crs(ds.crs)
@@ -304,16 +304,16 @@ def feature_info(cfg: OWSConfig, args: dict[str, str]) -> FlaskResponse:
                         pass
                     elif params.layer.time_resolution.is_subday():
                         cast(
-                            list[RAW_CFG], feature_json["data_available_for_dates"]
+                            "list[RAW_CFG]", feature_json["data_available_for_dates"]
                         ).append(dt.isoformat())
                     else:
                         cast(
-                            list[RAW_CFG], feature_json["data_available_for_dates"]
+                            "list[RAW_CFG]", feature_json["data_available_for_dates"]
                         ).append(dt.strftime("%Y-%m-%d"))
                     break
         if time_datasets:
             feature_json["data_links"] = cast(
-                RAW_CFG,
+                "RAW_CFG",
                 sorted(
                     get_s3_browser_uris(time_datasets, pt_native, s3_url, s3_bucket)
                 ),

--- a/datacube_ows/feature_info.py
+++ b/datacube_ows/feature_info.py
@@ -7,32 +7,36 @@ from __future__ import annotations
 
 import logging
 import re
-from collections.abc import Iterable
-from datetime import datetime
 from itertools import chain
 from typing import cast
 
 import numpy
-import xarray
-from datacube.model import Dataset
 from datacube.utils.masking import mask_to_dict
 from odc.geo import geom
 from odc.geo.crs import CRS
 from odc.geo.geobox import GeoBox
 from pandas import Timestamp
 
-from datacube_ows.config_utils import CFG_DICT, RAW_CFG, ConfigException
+from datacube_ows.config_utils import ConfigException
 from datacube_ows.http_utils import html_json_response, json_response
-from datacube_ows.loading import DataStacker, ProductBandQuery
-from datacube_ows.ows_configuration import OWSConfig, OWSNamedLayer
-from datacube_ows.styles import StyleDef
+from datacube_ows.loading import DataStacker
 from datacube_ows.time_utils import dataset_center_time
 from datacube_ows.utils import log_call
 from datacube_ows.wms_utils import GetFeatureInfoParameters, img_coords_to_geopoint
 
 TYPE_CHECKING = False
 if TYPE_CHECKING:
+    from collections.abc import Iterable
+    from datetime import datetime
+
+    import xarray
+    from datacube.model import Dataset
+
+    from datacube_ows.config_utils import CFG_DICT, RAW_CFG
+    from datacube_ows.loading import ProductBandQuery
+    from datacube_ows.ows_configuration import OWSConfig, OWSNamedLayer
     from datacube_ows.protocol_versions import FlaskResponse
+    from datacube_ows.styles import StyleDef
 
 
 @log_call

--- a/datacube_ows/http_utils.py
+++ b/datacube_ows/http_utils.py
@@ -6,15 +6,17 @@
 from __future__ import annotations
 
 import json
-from collections.abc import Mapping
 from urllib.parse import urlparse
 
-from flask import Request, render_template, request
-
-from datacube_ows.config_utils import CFG_DICT
+from flask import render_template, request
 
 TYPE_CHECKING = False
 if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+    from flask import Request
+
+    from datacube_ows.config_utils import CFG_DICT
     from datacube_ows.ows_configuration import OWSConfig
     from datacube_ows.protocol_versions import FlaskResponse
 

--- a/datacube_ows/index/api.py
+++ b/datacube_ows/index/api.py
@@ -3,24 +3,29 @@
 #
 # Copyright (c) 2017-2024 OWS Contributors
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import dataclasses
 from abc import ABC, abstractmethod
-from collections.abc import Callable, Iterable
 from datetime import date, datetime
 from functools import wraps
-from typing import Any, Literal, NamedTuple, TypeAlias, Union
-from uuid import UUID
+from typing import Any, Literal, NamedTuple, TypeAlias
 
 from datacube import Datacube
-from datacube.model import Dataset, Product
 from odc.geo.crs import CRS
-from odc.geo.geom import Geometry, polygon
+from odc.geo.geom import polygon
 
-from datacube_ows.config_utils import CFG_DICT, ConfigException
+from datacube_ows.config_utils import ConfigException
 
 TYPE_CHECKING = False
 if TYPE_CHECKING:
+    from collections.abc import Callable, Iterable
+    from uuid import UUID
+
+    from datacube.model import Dataset, Product
+    from odc.geo.geom import Geometry
+
+    from datacube_ows.config_utils import CFG_DICT
     from datacube_ows.ows_configuration import OWSNamedLayer
 
 
@@ -103,18 +108,18 @@ class OWSAbstractIndex(ABC):
     # Range table update method (requires odc "manage" perms)
     @abstractmethod
     def create_range_entry(
-        self, layer: "OWSNamedLayer", cache: dict[LayerSignature, list[str]]
+        self, layer: OWSNamedLayer, cache: dict[LayerSignature, list[str]]
     ) -> None: ...
 
     # Range table read method (requires odc "user" perms)
     @abstractmethod
-    def get_ranges(self, layer: "OWSNamedLayer") -> LayerExtent | None: ...
+    def get_ranges(self, layer: OWSNamedLayer) -> LayerExtent | None: ...
 
     # Spatiotemporal search methods (requires odc "user" perms)
     @abstractmethod
     def ds_search(
         self,
-        layer: "OWSNamedLayer",
+        layer: OWSNamedLayer,
         times: Iterable[TimeSearchTerm] | None = None,
         geom: Geometry | None = None,
         products: Iterable[Product] | None = None,
@@ -122,7 +127,7 @@ class OWSAbstractIndex(ABC):
 
     def dsid_search(
         self,
-        layer: "OWSNamedLayer",
+        layer: OWSNamedLayer,
         times: Iterable[TimeSearchTerm] | None = None,
         geom: Geometry | None = None,
         products: Iterable[Product] | None = None,
@@ -132,7 +137,7 @@ class OWSAbstractIndex(ABC):
 
     def count(
         self,
-        layer: "OWSNamedLayer",
+        layer: OWSNamedLayer,
         times: Iterable[TimeSearchTerm] | None = None,
         geom: Geometry | None = None,
         products: Iterable[Product] | None = None,
@@ -141,7 +146,7 @@ class OWSAbstractIndex(ABC):
 
     def extent(
         self,
-        layer: "OWSNamedLayer",
+        layer: OWSNamedLayer,
         times: Iterable[TimeSearchTerm] | None = None,
         geom: Geometry | None = None,
         products: Iterable[Product] | None = None,
@@ -166,9 +171,7 @@ class OWSAbstractIndex(ABC):
         return ext
 
     @staticmethod
-    def _prep_geom(
-        layer: "OWSNamedLayer", any_geom: Geometry | None
-    ) -> Geometry | None:
+    def _prep_geom(layer: OWSNamedLayer, any_geom: Geometry | None) -> Geometry | None:
         # Prepare a Geometry for geospatial search
         # Perhaps Core can be updated so this is not needed?
         if any_geom is None:
@@ -228,9 +231,7 @@ def check_perms(
 ) -> Callable[[Callable], Callable]:
     def outer(f: Callable) -> Callable:
         @wraps(f)
-        def inner(
-            instance, dcl: Union[Datacube, "OWSNamedLayer"], *args, **kwargs
-        ) -> Any:
+        def inner(instance, dcl: Datacube | OWSNamedLayer, *args, **kwargs) -> Any:
             from datacube_ows.ows_configuration import OWSNamedLayer
 
             if isinstance(dcl, OWSNamedLayer):

--- a/datacube_ows/index/driver.py
+++ b/datacube_ows/index/driver.py
@@ -3,9 +3,9 @@
 #
 # Copyright (c) 2017-2024 OWS Contributors
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 from threading import Lock
-from typing import Optional
 
 from datacube.drivers.driver_cache import load_drivers
 
@@ -20,7 +20,7 @@ class OWSIndexDriverCache:
     _instance = None
     _initialised = False
 
-    def __new__(cls, *args, **kwargs) -> "OWSIndexDriverCache":
+    def __new__(cls, *args, **kwargs) -> OWSIndexDriverCache:
         if cls._instance is None:
             with cache_lock:
                 if cls._instance is None:
@@ -33,7 +33,7 @@ class OWSIndexDriverCache:
                 self._initialised = True
                 self._drivers = load_drivers(group)
 
-    def __call__(self, name: str) -> Optional["OWSAbstractIndexDriver"]:
+    def __call__(self, name: str) -> OWSAbstractIndexDriver | None:
         """
         :returns: None if driver with a given name is not found
 
@@ -51,5 +51,5 @@ def ows_index_drivers() -> list[str]:
     return OWSIndexDriverCache("datacube_ows.plugins.index").drivers()
 
 
-def ows_index_driver_by_name(name: str) -> Optional["OWSAbstractIndexDriver"]:
+def ows_index_driver_by_name(name: str) -> OWSAbstractIndexDriver | None:
     return OWSIndexDriverCache("datacube_ows.plugins.index")(name)

--- a/datacube_ows/index/postgis/api.py
+++ b/datacube_ows/index/postgis/api.py
@@ -3,18 +3,16 @@
 #
 # Copyright (c) 2017-2024 OWS Contributors
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import datetime
-from collections.abc import Iterable
 from threading import Lock
 from typing import Any, Literal
-from uuid import UUID
 
 import click
 from antimeridian import fix_shape
-from datacube import Datacube
 from datacube.drivers.common_psql import as_role
-from datacube.model import Dataset, Product, Range
+from datacube.model import Range
 from odc.geo import CRS, Geometry
 from sqlalchemy import text
 from typing_extensions import override
@@ -22,20 +20,27 @@ from typing_extensions import override
 from datacube_ows.index.api import (
     AbortRun,
     InsufficientDbPrivileges,
-    LayerExtent,
-    LayerSignature,
     OWSAbstractIndex,
     OWSAbstractIndexDriver,
-    TimeSearchTerm,
     check_perms,
 )
 from datacube_ows.index.sql import run_sql
-from datacube_ows.ows_configuration import OWSNamedLayer
 from datacube_ows.utils import get_driver_name, get_sqlconn
 
 from ...utils import default_to_utc
 from .product_ranges import create_range_entry as create_range_entry_impl
 from .product_ranges import get_ranges as get_ranges_impl
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+    from uuid import UUID
+
+    from datacube import Datacube
+    from datacube.model import Dataset, Product
+
+    from datacube_ows.index.api import LayerExtent, LayerSignature, TimeSearchTerm
+    from datacube_ows.ows_configuration import OWSNamedLayer
 
 
 class OWSPostgisIndex(OWSAbstractIndex):

--- a/datacube_ows/index/postgis/product_ranges.py
+++ b/datacube_ows/index/postgis/product_ranges.py
@@ -3,21 +3,28 @@
 #
 # Copyright (c) 2017-2024 OWS Contributors
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import logging
 import math
-from collections.abc import Callable
-from datetime import UTC, date, datetime
+from datetime import UTC, datetime
 
 import click
-import odc.geo
 from datacube.api.query import _convert_to_solar_time
 from odc.geo.crs import CRS
 from sqlalchemy import text
 
 from datacube_ows.index.api import CoordRange, LayerExtent, LayerSignature
-from datacube_ows.ows_configuration import OWSNamedLayer
 from datacube_ows.utils import get_driver_name, get_sqlconn
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from datetime import date
+
+    import odc.geo
+
+    from datacube_ows.ows_configuration import OWSNamedLayer
 
 _LOG: logging.Logger = logging.getLogger(__name__)
 

--- a/datacube_ows/index/postgres/api.py
+++ b/datacube_ows/index/postgres/api.py
@@ -3,36 +3,40 @@
 #
 # Copyright (c) 2017-2024 OWS Contributors
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
-from collections.abc import Iterable
 from threading import Lock
 from typing import Literal, cast
-from uuid import UUID
 
 import click
-from datacube import Datacube
 from datacube.drivers.common_psql import as_role
-from datacube.model import Dataset, Product
-from odc.geo import CRS, Geometry
 from sqlalchemy import text
 from typing_extensions import override
 
 from datacube_ows.index.api import (
     InsufficientDbPrivileges,
-    LayerExtent,
-    LayerSignature,
     OWSAbstractIndex,
     OWSAbstractIndexDriver,
-    TimeSearchTerm,
     check_perms,
 )
 from datacube_ows.index.sql import run_sql
-from datacube_ows.ows_configuration import OWSNamedLayer
 from datacube_ows.utils import get_driver_name, get_sqlconn
 
 from .mv_index import MVSelectOpts, mv_search
 from .product_ranges import create_range_entry as create_range_entry_impl
 from .product_ranges import get_ranges as get_ranges_impl
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+    from uuid import UUID
+
+    from datacube import Datacube
+    from datacube.model import Dataset, Product
+    from odc.geo import CRS, Geometry
+
+    from datacube_ows.index.api import LayerExtent, LayerSignature, TimeSearchTerm
+    from datacube_ows.ows_configuration import OWSNamedLayer
 
 
 class OWSPostgresIndex(OWSAbstractIndex):

--- a/datacube_ows/index/postgres/api.py
+++ b/datacube_ows/index/postgres/api.py
@@ -117,7 +117,7 @@ class OWSPostgresIndex(OWSAbstractIndex):
         products: Iterable[Product] | None = None,
     ) -> Iterable[Dataset]:
         return cast(
-            Iterable[Dataset],
+            "Iterable[Dataset]",
             mv_search(
                 layer.dc,
                 MVSelectOpts.DATASETS,
@@ -136,7 +136,7 @@ class OWSPostgresIndex(OWSAbstractIndex):
         products: Iterable[Product] | None = None,
     ) -> Iterable[UUID]:
         return cast(
-            Iterable[UUID],
+            "Iterable[UUID]",
             mv_search(
                 layer.dc,
                 MVSelectOpts.IDS,
@@ -155,7 +155,7 @@ class OWSPostgresIndex(OWSAbstractIndex):
         products: Iterable[Product] | None = None,
     ) -> int:
         return cast(
-            int,
+            "int",
             mv_search(
                 layer.dc,
                 MVSelectOpts.COUNT,
@@ -175,7 +175,7 @@ class OWSPostgresIndex(OWSAbstractIndex):
         crs: CRS | None = None,
     ) -> Geometry | None:
         extent = cast(
-            Geometry | None,
+            "Geometry | None",
             mv_search(
                 layer.dc,
                 MVSelectOpts.EXTENT,

--- a/datacube_ows/index/postgres/mv_index.py
+++ b/datacube_ows/index/postgres/mv_index.py
@@ -3,27 +3,33 @@
 #
 # Copyright (c) 2017-2024 OWS Contributors
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import datetime
 import json
 from collections.abc import Iterable
 from enum import Enum
-from types import UnionType
 from typing import cast
 from uuid import UUID as UUID_
 
-from datacube import Datacube
-from datacube.model import Dataset, Product
+from datacube.model import Dataset
 from geoalchemy2 import Geometry
 from geoalchemy2.functions import ST_AsGeoJSON, ST_Union
 from odc.geo.geom import Geometry as ODCGeom
 from sqlalchemy import SMALLINT, Column, MetaData, Table, and_, or_, select, text
 from sqlalchemy.dialects.postgresql import TSTZRANGE, UUID
 from sqlalchemy.engine import Row
-from sqlalchemy.sql.elements import ClauseElement
 from sqlalchemy.sql.functions import count, func
 
 from datacube_ows.utils import default_to_utc, get_driver_name, get_sqlconn
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from types import UnionType
+
+    from datacube import Datacube
+    from datacube.model import Product
+    from sqlalchemy.sql.elements import ClauseElement
 
 
 def get_st_view(meta: MetaData) -> Table:

--- a/datacube_ows/index/postgres/mv_index.py
+++ b/datacube_ows/index/postgres/mv_index.py
@@ -67,7 +67,7 @@ class MVSelectOpts(Enum):
         if self == self.IDS or self == self.DATASETS:
             return [stv.c.id]
         if self == self.COUNT:
-            return [cast(ClauseElement, count(stv.c.id))]
+            return [cast("ClauseElement", count(stv.c.id))]
         if self == self.EXTENT:
             return [ST_AsGeoJSON(ST_Union(text("spatial_extent")))]
         raise AssertionError("Invalid selection option")
@@ -167,7 +167,7 @@ def mv_search(
         with get_sqlconn(dc) as conn:
             for r in conn.execute(s):
                 if sel == MVSelectOpts.COUNT:
-                    return cast(int, r[0])
+                    return cast("int", r[0])
                 # MVSelectOpts.EXTENT
                 geojson = r[0]
                 if geojson is None:

--- a/datacube_ows/index/postgres/product_ranges.py
+++ b/datacube_ows/index/postgres/product_ranges.py
@@ -3,23 +3,30 @@
 #
 # Copyright (c) 2017-2024 OWS Contributors
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import logging
 import math
-from collections.abc import Callable
-from datetime import UTC, date, datetime
+from datetime import UTC, datetime
 from typing import cast
 
-import odc.geo
 from datacube.api.query import _convert_to_solar_time
-from odc.geo.crs import CRS
-from odc.geo.geom import Geometry
 from sqlalchemy import text
 
 from datacube_ows.index.api import CoordRange, LayerExtent, LayerSignature
 from datacube_ows.index.postgres.mv_index import MVSelectOpts, mv_search
-from datacube_ows.ows_configuration import OWSNamedLayer
 from datacube_ows.utils import get_driver_name, get_sqlconn
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from datetime import date
+
+    import odc.geo
+    from odc.geo.crs import CRS
+    from odc.geo.geom import Geometry
+
+    from datacube_ows.ows_configuration import OWSNamedLayer
 
 _LOG: logging.Logger = logging.getLogger(__name__)
 

--- a/datacube_ows/index/postgres/product_ranges.py
+++ b/datacube_ows/index/postgres/product_ranges.py
@@ -170,7 +170,7 @@ def create_range_entry(
             # Get extent polygon from materialised views
 
             extent_4386 = cast(
-                Geometry,
+                "Geometry",
                 mv_search(layer.dc, MVSelectOpts.EXTENT, products=layer.products),
             )
 

--- a/datacube_ows/index/sql.py
+++ b/datacube_ows/index/sql.py
@@ -3,18 +3,22 @@
 #
 # Copyright (c) 2017-2024 OWS Contributors
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import importlib.resources
 import re
 
 import click
-import datacube.index
 import sqlalchemy
-from datacube import Datacube
 from sqlalchemy.exc import ProgrammingError
 
 from datacube_ows.index.api import InsufficientDbPrivileges
 from datacube_ows.utils import get_driver_name, get_sqlconn
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    import datacube.index
+    from datacube import Datacube
 
 
 def run_sql(dc: Datacube, path: str, **params: str) -> bool:

--- a/datacube_ows/loading.py
+++ b/datacube_ows/loading.py
@@ -281,7 +281,7 @@ class DataStacker:
             raise WMSException(
                 "Cannot add default flag data as there is no non-flag data available"
             )
-        template = cast(xarray.DataArray, getattr(data, cast(str, var)))
+        template = cast("xarray.DataArray", getattr(data, cast("str", var)))
         data_new_bands = {}
         for band in pbq.bands:
             default_value = pbq.products[0].measurements[band].nodata
@@ -374,7 +374,7 @@ class DataStacker:
             assert data is not None
             qry_result.coords["time"] = data.coords["time"]
             data = cast(
-                xarray.Dataset,
+                "xarray.Dataset",
                 xarray.combine_by_coords([data, qry_result], join="exact"),
             )
 
@@ -405,7 +405,7 @@ class DataStacker:
         for dt in datasets.time.values:
             tds = datasets.sel(time=dt)
             merged = None
-            for ds in cast(Iterable[Dataset], tds.values.item()):
+            for ds in cast("Iterable[Dataset]", tds.values.item()):
                 d = self.read_data_for_single_dataset(
                     ds, measurements, self._geobox, fuse_func=fuse_func
                 )

--- a/datacube_ows/loading.py
+++ b/datacube_ows/loading.py
@@ -3,31 +3,38 @@
 #
 # Copyright (c) 2017-2024 OWS Contributors
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
-import datetime
 import logging
 from collections import OrderedDict
-from collections.abc import Iterable, Mapping
+from collections.abc import Iterable
 from typing import cast
 from uuid import UUID
 
 import datacube
 import numpy
 import xarray
-from datacube.model import Dataset, Measurement, Product
-from odc.geo.crs import CRS
-from odc.geo.geobox import GeoBox
-from odc.geo.geom import Geometry
-from odc.geo.warp import Resampling
-from odc.loader.types import FuserFunc
 from typing_extensions import override
 
 from datacube_ows.ogc_exceptions import WMSException
-from datacube_ows.ows_configuration import OWSNamedLayer
 from datacube_ows.startup_utils.creds import CredentialManager
-from datacube_ows.styles import StyleDef
 from datacube_ows.utils import log_call
 from datacube_ows.wms_utils import solar_correct_data
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    import datetime
+    from collections.abc import Mapping
+
+    from datacube.model import Dataset, Measurement, Product
+    from odc.geo.crs import CRS
+    from odc.geo.geobox import GeoBox
+    from odc.geo.geom import Geometry
+    from odc.geo.warp import Resampling
+    from odc.loader.types import FuserFunc
+
+    from datacube_ows.ows_configuration import OWSNamedLayer
+    from datacube_ows.styles import StyleDef
 
 _LOG: logging.Logger = logging.getLogger(__name__)
 
@@ -61,7 +68,7 @@ class ProductBandQuery:
     @classmethod
     def style_queries(
         cls, style: StyleDef, resource_limited: bool = False
-    ) -> list["ProductBandQuery"]:
+    ) -> list[ProductBandQuery]:
         queries = [
             cls.simple_layer_query(
                 style.product,
@@ -93,7 +100,7 @@ class ProductBandQuery:
     @classmethod
     def full_layer_queries(
         cls, layer: OWSNamedLayer, main_bands: list[str] | None = None
-    ) -> list["ProductBandQuery"]:
+    ) -> list[ProductBandQuery]:
         if main_bands:
             needed_bands: Iterable[str] = main_bands
         else:
@@ -134,7 +141,7 @@ class ProductBandQuery:
         manual_merge: bool = False,
         fuse_func: FuserFunc | str | None = None,
         resource_limited: bool = False,
-    ) -> "ProductBandQuery":
+    ) -> ProductBandQuery:
         main_products = layer.low_res_products if resource_limited else layer.products
         return cls(
             main_products,

--- a/datacube_ows/ogc.py
+++ b/datacube_ows/ogc.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 
 import logging
 import traceback
-from logging import Logger
 
 from flask import render_template, request
 from sqlalchemy.exc import OperationalError
@@ -22,14 +21,16 @@ from datacube_ows.http_utils import (
 from datacube_ows.index.api import ows_index
 from datacube_ows.legend_generator import create_legend_for_style
 from datacube_ows.ogc_exceptions import OGCException, WMSException
-from datacube_ows.protocol_versions import SupportedSvc, supported_versions
+from datacube_ows.protocol_versions import supported_versions
 from datacube_ows.wcs1 import WCS_REQUESTS
 from datacube_ows.wms import WMS_REQUESTS
 
 TYPE_CHECKING = False
 if TYPE_CHECKING:
+    from logging import Logger
+
     from datacube_ows.ows_configuration import OWSConfig
-    from datacube_ows.protocol_versions import FlaskResponse
+    from datacube_ows.protocol_versions import FlaskResponse, SupportedSvc
 
 _LOG: Logger = logging.getLogger(__name__)
 

--- a/datacube_ows/ogc_utils.py
+++ b/datacube_ows/ogc_utils.py
@@ -116,7 +116,7 @@ def mask_by_nan(data: xarray.Dataset, band: str) -> numpy.ndarray:
     """
     Mask by nan, for bands with floating point data
     """
-    return ~numpy.isnan(cast(numpy.generic, data[band]))
+    return ~numpy.isnan(cast("numpy.generic", data[band]))
 
 
 # Example mosaic date function

--- a/datacube_ows/ogc_utils.py
+++ b/datacube_ows/ogc_utils.py
@@ -3,22 +3,25 @@
 #
 # Copyright (c) 2017-2024 OWS Contributors
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
-import datetime
 import logging
 from io import BytesIO
 from typing import Any, cast
 
 import numpy
-import xarray
 from affine import Affine
 from deprecat import deprecat
-from odc.geo.crs import CRS
 from odc.geo.geobox import GeoBox
 from PIL import Image
 
 TYPE_CHECKING = False
 if TYPE_CHECKING:
+    import datetime
+
+    import xarray
+    from odc.geo.crs import CRS
+
     from datacube_ows.config_utils import OWSExtensibleConfigEntry
 
 
@@ -32,7 +35,7 @@ _LOG: logging.Logger = logging.getLogger(__name__)
 )
 def rolling_window_ndays(
     available_dates: list[datetime.datetime],
-    layer_cfg: "OWSExtensibleConfigEntry",
+    layer_cfg: OWSExtensibleConfigEntry,
     ndays: int = 6,
 ) -> tuple[datetime.datetime, datetime.datetime]:
     from datacube_ows.time_utils import rolling_window_ndays

--- a/datacube_ows/ows_configuration.py
+++ b/datacube_ows/ows_configuration.py
@@ -151,7 +151,7 @@ class BandIndex(OWSMetadataConfig):
         if band_cfg is None:
             band_cfg = {}
         super().__init__(band_cfg)
-        self.band_cfg = cast(dict[str, list[str]], band_cfg)
+        self.band_cfg = cast("dict[str, list[str]]", band_cfg)
         self.layer = layer
         self.layer_name = layer.name
         self.parse_metadata(band_cfg)
@@ -206,7 +206,7 @@ class BandIndex(OWSMetadataConfig):
                 self.add_aliases(self.band_cfg)
             try:
                 prod_measurements = cast(
-                    dict[str, Measurement],
+                    "dict[str, Measurement]",
                     product.lookup_measurements(list(self.band_cfg.keys())),
                 )
                 if first_product:
@@ -266,7 +266,7 @@ class BandIndex(OWSMetadataConfig):
         canonical_name = self.band(name_alias)
         if canonical:
             return canonical_name
-        return cast(str, self.read_local_metadata(canonical_name))
+        return cast("str", self.read_local_metadata(canonical_name))
 
     def nodata_val(self, name_alias: str) -> float | int:
         name = self.band(name_alias)
@@ -290,8 +290,8 @@ class AttributionCfg(OWSConfigEntry):
     def __init__(self, cfg: CFG_DICT, owner: Union["OWSConfig", "OWSLayer"]) -> None:
         super().__init__(cfg)
         self.owner = owner
-        self.url = cast(str | None, cfg.get("url"))
-        logo = cast(dict[str, str] | None, cfg.get("logo"))
+        self.url = cast("str | None", cfg.get("url"))
+        logo = cast("dict[str, str] | None", cfg.get("logo"))
         if not self.title and not self.url and not logo:
             raise ConfigException(
                 "At least one of title, url and logo is required in an attribution definition"
@@ -334,7 +334,7 @@ class SuppURL(OWSConfigEntry):
         return [cls(u) for u in cfg]
 
     def __init__(self, cfg: dict[str, str]) -> None:
-        super().__init__(cast(RAW_CFG, cfg))
+        super().__init__(cast("RAW_CFG", cfg))
         self.url = cfg["url"]
         self.format = cfg["format"]
 
@@ -366,10 +366,10 @@ class OWSLayer(OWSMetadataConfig):
         # Inherit or override attribution
         if "attribution" in cfg:
             self.attribution = AttributionCfg.parse(
-                cast(CFG_DICT | None, cfg.get("attribution")), self
+                cast("CFG_DICT | None", cfg.get("attribution")), self
             )
         elif parent_layer:
-            self.attribution = cast(OWSLayer, self.parent_layer).attribution
+            self.attribution = cast("OWSLayer", self.parent_layer).attribution
         else:
             self.attribution = self.global_cfg.attribution
 
@@ -484,7 +484,7 @@ class OWSFolder(OWSLayer):
         if "layers" not in cfg:
             raise ConfigException(f"No layers section in folder layer {self.title}")
         child = 0
-        for lyr_cfg in cast(list[RAW_CFG], cfg["layers"]):
+        for lyr_cfg in cast("list[RAW_CFG]", cfg["layers"]):
             if isinstance(lyr_cfg, dict):
                 try:
                     lyr = parse_ows_layer(
@@ -622,7 +622,7 @@ class OWSNamedLayer(OWSExtensibleConfigEntry, OWSLayer):
         parent_layer: OWSFolder | None = None,
         **kwargs,
     ) -> None:
-        name = cast(str, cfg["name"])
+        name = cast("str", cfg["name"])
         super().__init__(
             cfg,
             object_label=f"layer.{name}",
@@ -632,7 +632,7 @@ class OWSNamedLayer(OWSExtensibleConfigEntry, OWSLayer):
             **kwargs,
         )
         self.name = name
-        cfg = cast(CFG_DICT, self._raw_cfg)
+        cfg = cast("CFG_DICT", self._raw_cfg)
         self.hide = False
         try:
             self.parse_product_names(cfg)
@@ -663,7 +663,7 @@ class OWSNamedLayer(OWSExtensibleConfigEntry, OWSLayer):
             self.user_band_math = bool(cfg.get("user_band_math", False))
         else:
             self.user_band_math = False
-        tr = TimeRes.parse(cast(str | None, cfg.get("time_resolution")))
+        tr = TimeRes.parse(cast("str | None", cfg.get("time_resolution")))
         if not tr:
             raise ConfigException(
                 f"Invalid time resolution value {cfg['time_resolution']} in named layer {self.name}"
@@ -672,13 +672,13 @@ class OWSNamedLayer(OWSExtensibleConfigEntry, OWSLayer):
         self.mosaic_date_func: FunctionWrapper | None = None
         if "mosaic_date_func" in cfg:
             self.mosaic_date_func = FunctionWrapper(
-                self, cast(CFG_DICT, cfg["mosaic_date_func"])
+                self, cast("CFG_DICT", cfg["mosaic_date_func"])
             )
         if self.mosaic_date_func and not self.time_resolution.allow_mosaic():
             raise ConfigException(
                 f"Mosaic date function not supported for {self.time_resolution} time resolution."
             )
-        dtr: str = cast(str, cfg.get("default_time", DEF_TIME_LATEST))
+        dtr: str = cast("str", cfg.get("default_time", DEF_TIME_LATEST))
         if dtr in (DEF_TIME_LATEST, DEF_TIME_EARLIEST):
             self.default_time_rule: str | datetime.datetime | datetime.date = dtr
         else:
@@ -691,7 +691,7 @@ class OWSNamedLayer(OWSExtensibleConfigEntry, OWSLayer):
                 raise ConfigException(
                     f"Invalid default_time value in named layer {self.name} ({dtr})"
                 ) from None
-        self.time_axis = cast(CFG_DICT | None, cfg.get("time_axis"))
+        self.time_axis = cast("CFG_DICT | None", cfg.get("time_axis"))
         if self.time_axis:
             if self.time_resolution.is_subday():
                 raise ConfigException(
@@ -707,8 +707,8 @@ class OWSNamedLayer(OWSExtensibleConfigEntry, OWSLayer):
                 raise ConfigException("time_interval must be an integer")
             if self.time_axis_interval <= 0:
                 raise ConfigException("time_interval must be greater than zero")
-            time_axis_start = cast(str | None, self.time_axis.get("start_date"))
-            time_axis_end = cast(str | None, self.time_axis.get("end_date"))
+            time_axis_start = cast("str | None", self.time_axis.get("start_date"))
+            time_axis_end = cast("str | None", self.time_axis.get("end_date"))
             if time_axis_start is None:
                 self.time_axis_start: datetime.date | None = None
             else:
@@ -746,46 +746,46 @@ class OWSNamedLayer(OWSExtensibleConfigEntry, OWSLayer):
         self._ranges: LayerExtent | None = None
         self.bboxes: CFG_DICT = {}
         self.default_time: datetime.datetime | datetime.date | None = None
-        self.band_idx = BandIndex(self, cast(CFG_DICT, cfg.get("bands")))
+        self.band_idx = BandIndex(self, cast("CFG_DICT", cfg.get("bands")))
         self.cfg_native_resolution = cfg.get("native_resolution")
-        self.cfg_native_crs = cast(str, cfg.get("native_crs"))
+        self.cfg_native_crs = cast("str", cfg.get("native_crs"))
         self.declare_unready("resolution_x")
         self.declare_unready("resolution_y")
         self.resource_limits = OWSResourceManagementRules(
             self.global_cfg,
-            cast(CFG_DICT, cfg.get("resource_limits", {})),
+            cast("CFG_DICT", cfg.get("resource_limits", {})),
             f"Layer {self.name}",
         )
         try:
-            self.parse_flags(cast(CFG_DICT, cfg.get("flags", {})))
+            self.parse_flags(cast("CFG_DICT", cfg.get("flags", {})))
             self.declare_unready("all_flag_band_names")
         except KeyError as e:
             raise ConfigException(
                 f"Missing required config ({e!s}) in flags section for layer {self.name}"
             ) from None
         try:
-            self.parse_image_processing(cast(CFG_DICT, cfg["image_processing"]))
+            self.parse_image_processing(cast("CFG_DICT", cfg["image_processing"]))
         except KeyError as e:
             raise ConfigException(
                 f"Missing required config ({e!s}) in image processing section for layer {self.name}"
             ) from None
-        self.identifiers = cast(dict[str, str], cfg.get("identifiers", {}))
+        self.identifiers = cast("dict[str, str]", cfg.get("identifiers", {}))
         for auth in self.identifiers:
             if auth not in self.global_cfg.authorities:
                 raise ConfigException(
                     f"Identifier with non-declared authority: {auth} in layer {self.name}"
                 )
-        self.parse_urls(cast(CFG_DICT, cfg.get("urls", {})))
-        self.parse_feature_info(cast(CFG_DICT, cfg.get("feature_info", {})))
+        self.parse_urls(cast("CFG_DICT", cfg.get("urls", {})))
+        self.parse_feature_info(cast("CFG_DICT", cfg.get("feature_info", {})))
         self.feature_info_include_utc_dates = cfg.get("feature_info_url_dates", False)
         if "patch_url_function" in cfg:
             self.patch_url: FunctionWrapper | None = FunctionWrapper(
-                self, cast(CFG_DICT, cfg["patch_url_function"])
+                self, cast("CFG_DICT", cfg["patch_url_function"])
             )
         else:
             self.patch_url = None
         try:
-            self.parse_styling(cast(CFG_DICT, cfg["styling"]))
+            self.parse_styling(cast("CFG_DICT", cfg["styling"]))
         except KeyError as e:
             raise ConfigException(
                 f"Missing required config item {e} in styling section for layer {self.name}"
@@ -793,7 +793,7 @@ class OWSNamedLayer(OWSExtensibleConfigEntry, OWSLayer):
 
         if self.global_cfg.wcs:
             try:
-                self.parse_wcs(cast(CFG_DICT | bool, cfg.get("wcs", {})))
+                self.parse_wcs(cast("CFG_DICT | bool", cfg.get("wcs", {})))
             except KeyError as e:
                 raise ConfigException(
                     f"Missing required config item {e} in wcs section for layer {self.name}"
@@ -878,7 +878,7 @@ class OWSNamedLayer(OWSExtensibleConfigEntry, OWSLayer):
         else:
             self.extent_mask_func = [
                 FunctionWrapper(self, emf)
-                for emf in cast(list[CFG_DICT | str], emf_cfg)
+                for emf in cast("list[CFG_DICT | str]", emf_cfg)
             ]
         self.raw_afb = cfg.get("always_fetch_bands", [])
         self.declare_unready("always_fetch_bands")
@@ -898,7 +898,7 @@ class OWSNamedLayer(OWSExtensibleConfigEntry, OWSLayer):
         if cfg.get("fuse_func"):
             if self.global_cfg.load_driver == "legacy":
                 self.fuse_func: FunctionWrapper | str | None = FunctionWrapper(
-                    self, cast(str | CFG_DICT, cfg["fuse_func"])
+                    self, cast("str | CFG_DICT", cfg["fuse_func"])
                 )
             elif isinstance(cfg["fuse_func"], str):
                 self.fuse_func = cfg["fuse_func"]
@@ -912,13 +912,13 @@ class OWSNamedLayer(OWSExtensibleConfigEntry, OWSLayer):
     # pylint: disable=attribute-defined-outside-init
     def ready_image_processing(self) -> None:
         self.always_fetch_bands = [
-            self.band_idx.band(b) for b in cast(list[str], self.raw_afb)
+            self.band_idx.band(b) for b in cast("list[str]", self.raw_afb)
         ]
 
     # pylint: disable=attribute-defined-outside-init
     def parse_feature_info(self, cfg: CFG_DICT) -> None:
         self.feature_info_include_utc_dates = bool(cfg.get("include_utc_dates", False))
-        custom = cast(dict[str, CFG_DICT | str], cfg.get("include_custom", {}))
+        custom = cast("dict[str, CFG_DICT | str]", cfg.get("include_custom", {}))
         self.legacy_feature_info_custom_includes = {
             k: FunctionWrapper(self, v) for k, v in custom.items()
         }
@@ -929,7 +929,7 @@ class OWSNamedLayer(OWSExtensibleConfigEntry, OWSLayer):
                 "to the new 'custom_includes' directive.",
                 self.name,
             )
-        custom = cast(dict[str, CFG_DICT | str | F], cfg.get("custom_includes", {}))
+        custom = cast("dict[str, CFG_DICT | str | F]", cfg.get("custom_includes", {}))
         self.feature_info_custom_includes = {
             k: FunctionWrapper(self, v) for k, v in custom.items()
         }
@@ -969,17 +969,17 @@ class OWSNamedLayer(OWSExtensibleConfigEntry, OWSLayer):
     # pylint: disable=attribute-defined-outside-init
     def parse_urls(self, cfg: CFG_DICT) -> None:
         self.feature_list_urls = SuppURL.parse_list(
-            cast(list[dict[str, str]], cfg.get("features", []))
+            cast("list[dict[str, str]]", cfg.get("features", []))
         )
         self.data_urls = SuppURL.parse_list(
-            cast(list[dict[str, str]], cfg.get("data", []))
+            cast("list[dict[str, str]]", cfg.get("data", []))
         )
 
     # pylint: disable=attribute-defined-outside-init
     def parse_styling(self, cfg: CFG_DICT) -> None:
         self.styles = []
         self.style_index = {}
-        for scfg in cast(list[CFG_DICT], cfg["styles"]):
+        for scfg in cast("list[CFG_DICT]", cfg["styles"]):
             style = StyleDef(self, scfg)
             self.styles.append(style)
             self.style_index[style.name] = style
@@ -988,7 +988,7 @@ class OWSNamedLayer(OWSExtensibleConfigEntry, OWSLayer):
                 raise ConfigException(
                     f"Default style {cfg['default_style']} is not in the 'styles' for layer {self.name}"
                 )
-            self.default_style = self.style_index[cast(str, cfg["default_style"])]
+            self.default_style = self.style_index[cast("str", cfg["default_style"])]
         else:
             self.default_style = self.styles[0]
 
@@ -997,7 +997,7 @@ class OWSNamedLayer(OWSExtensibleConfigEntry, OWSLayer):
         if cfg is False or not self.global_cfg.wcs:
             self.wcs = False
         else:
-            self.wcs = not cast(CFG_DICT, cfg).get("disable", False)
+            self.wcs = not cast("CFG_DICT", cfg).get("disable", False)
         if not self.wcs:
             return
         assert isinstance(cfg, dict)
@@ -1024,7 +1024,7 @@ class OWSNamedLayer(OWSExtensibleConfigEntry, OWSLayer):
                     "main layer section if required",
                     self.name,
                 )
-                self.cfg_native_crs = cast(str, cfg["native_crs"])
+                self.cfg_native_crs = cast("str", cfg["native_crs"])
             else:
                 _LOG.warning(
                     "native_crs in wcs section of layer %s ignored in favour of value in "
@@ -1149,7 +1149,7 @@ class OWSNamedLayer(OWSExtensibleConfigEntry, OWSLayer):
             # Prepare Rectified Grids
             try:
                 native_bounding_box = cast(
-                    dict[str, int | float], self.bboxes[self.native_CRS]
+                    "dict[str, int | float]", self.bboxes[self.native_CRS]
                 )
             except KeyError:
                 if not self.global_cfg.called_from_update_ranges:
@@ -1211,7 +1211,7 @@ class OWSNamedLayer(OWSExtensibleConfigEntry, OWSLayer):
                     }
                 else:
                     try:
-                        bbox = cast(dict[str, int | float], self.bboxes[crs])
+                        bbox = cast("dict[str, int | float]", self.bboxes[crs])
                     except KeyError:
                         continue
                     self.grids[crs] = {
@@ -1296,7 +1296,7 @@ class OWSNamedLayer(OWSExtensibleConfigEntry, OWSLayer):
             return {}
         bboxes = {}
         for crs_id, bbox in cast(
-            dict[str, dict[str, float]], self._ranges.bboxes
+            "dict[str, dict[str, float]]", self._ranges.bboxes
         ).items():
             if crs_id in self.global_cfg.published_CRSs:
                 # Assume we've already handled coordinate swapping for
@@ -1320,7 +1320,7 @@ class OWSNamedLayer(OWSExtensibleConfigEntry, OWSLayer):
         self, t: datetime.datetime | datetime.date, geobox=None
     ) -> datetime.datetime | tuple[datetime.datetime, datetime.datetime]:
         if not geobox:
-            bbox = cast(dict[str, float | int], self.ranges.bboxes[self.native_CRS])
+            bbox = cast("dict[str, float | int]", self.ranges.bboxes[self.native_CRS])
             geobox = create_geobox(
                 CRS(self.native_CRS),
                 bbox["left"],
@@ -1361,10 +1361,10 @@ class OWSProductLayer(OWSNamedLayer):
 
     @override
     def parse_product_names(self, cfg: CFG_DICT) -> None:
-        self.product_name = cast(str, cfg["product_name"])
+        self.product_name = cast("str", cfg["product_name"])
         self.product_names: tuple[str, ...] = (self.product_name,)
 
-        self.low_res_product_name = cast(str, cfg.get("low_res_product_name"))
+        self.low_res_product_name = cast("str", cfg.get("low_res_product_name"))
         if self.low_res_product_name:
             self.low_res_product_names: tuple[str, ...] = (self.low_res_product_name,)
         else:
@@ -1386,13 +1386,15 @@ class OWSProductLayer(OWSNamedLayer):
                 f"The 'dataset' entry in the flags section is no longer supported.  Please refer to the documentation for the correct format (layer {self.name})"
             )
         if "product" in cfg:
-            pq_names: tuple[str, ...] = (cast(str, cfg["product"]),)
+            pq_names: tuple[str, ...] = (cast("str", cfg["product"]),)
         else:
             pq_names = (self.product_name,)
             main_product = pq_names[0] == self.product_name
 
         if "low_res_product" in cfg:
-            pq_low_res_names: tuple[str, ...] = (cast(str, cfg.get("low_res_product")),)
+            pq_low_res_names: tuple[str, ...] = (
+                cast("str", cfg.get("low_res_product")),
+            )
         elif main_product:
             pq_low_res_names = self.low_res_product_names
         else:
@@ -1418,10 +1420,10 @@ class OWSMultiProductLayer(OWSNamedLayer):
 
     @override
     def parse_product_names(self, cfg: CFG_DICT) -> None:
-        self.product_names = tuple(cast(list[str], cfg["product_names"]))
+        self.product_names = tuple(cast("list[str]", cfg["product_names"]))
         self.product_name = self.product_names[0]
         self.low_res_product_names = tuple(
-            cast(list[str], cfg.get("low_res_product_names", []))
+            cast("list[str]", cfg.get("low_res_product_names", []))
         )
         if self.low_res_product_names:
             self.low_res_product_name: str | None = self.low_res_product_names[0]
@@ -1443,14 +1445,14 @@ class OWSMultiProductLayer(OWSNamedLayer):
                 f"The 'datasets' entry in the flags section is no longer supported. Please refer to the documentation for the correct format (layer {self.name})"
             )
         if "products" in cfg:
-            pq_names = tuple(cast(list[str], cfg["products"]))
+            pq_names = tuple(cast("list[str]", cfg["products"]))
             main_products = pq_names == self.product_names
         else:
             main_products = True
             pq_names = self.product_names
 
         if "low_res_products" in cfg:
-            pq_low_res_names = tuple(cast(list[str], cfg["low_res_products"]))
+            pq_low_res_names = tuple(cast("list[str]", cfg["low_res_products"]))
         else:
             pq_low_res_names = self.low_res_product_names
         if "product" in cfg:
@@ -1496,9 +1498,9 @@ class WCSFormat:
                 renderers.append(
                     WCSFormat(
                         name,
-                        cast(str, fmt["mime"]),
-                        cast(str, fmt["extension"]),
-                        cast(dict[int, CFG_DICT], fmt["renderers"]),
+                        cast("str", fmt["mime"]),
+                        cast("str", fmt["extension"]),
+                        cast("dict[int, CFG_DICT]", fmt["renderers"]),
                         bool(fmt.get("multi-time", False)),
                     )
                 )
@@ -1543,7 +1545,7 @@ class ContactInfo(OWSConfigEntry):
 
         class Address(OWSConfigEntry):
             def __init__(self, cfg: dict[str, str]) -> None:
-                super().__init__(cast(CFG_DICT, cfg))
+                super().__init__(cast("CFG_DICT", cfg))
                 self.type = cfg.get("type")
                 self.address = cfg.get("address")
                 self.city = cfg.get("city")
@@ -1557,10 +1559,10 @@ class ContactInfo(OWSConfigEntry):
                     return None
                 return cls(cfg)
 
-        self.address = Address.parse(cast(dict[str, str] | None, cfg.get("address")))
-        self.telephone = cast(str | None, cfg.get("telephone"))
-        self.fax = cast(str | None, cfg.get("fax"))
-        self.email = cast(str | None, cfg.get("email"))
+        self.address = Address.parse(cast("dict[str, str] | None", cfg.get("address")))
+        self.telephone = cast("str | None", cfg.get("telephone"))
+        self.fax = cast("str | None", cfg.get("fax"))
+        self.email = cast("str | None", cfg.get("email"))
 
     @property
     def organisation(self) -> str | None:
@@ -1619,20 +1621,20 @@ class OWSConfig(OWSMetadataConfig):
                 cfg = read_config()
             super().__init__(cfg)
             try:
-                self.parse_global(cast(CFG_DICT, cfg["global"]), ignore_msgfile)
+                self.parse_global(cast("CFG_DICT", cfg["global"]), ignore_msgfile)
             except KeyError as e:
                 raise ConfigException(
                     f"Missing required config entry in 'global' section: {e!s}"
                 ) from None
 
             if self.wms or self.wmts:
-                self.parse_wms(cast(CFG_DICT, cfg.get("wms", {})))
+                self.parse_wms(cast("CFG_DICT", cfg.get("wms", {})))
             else:
                 self.parse_wms({})
 
             if self.wcs:
                 try:
-                    self.parse_wcs(cast(CFG_DICT, cfg.get("wcs")))
+                    self.parse_wcs(cast("CFG_DICT", cfg.get("wcs")))
                 except KeyError as e:
                     raise ConfigException(
                         f"Missing required config entry in 'wcs' section (with WCS enabled): {e!s}"
@@ -1640,7 +1642,7 @@ class OWSConfig(OWSMetadataConfig):
             else:
                 self.parse_wcs(None)
             try:
-                self.parse_layers(cast(list[CFG_DICT], cfg["layers"]))
+                self.parse_layers(cast("list[CFG_DICT]", cfg["layers"]))
             except KeyError:
                 raise ConfigException(
                     "Missing required config entry in 'layers' section"
@@ -1648,7 +1650,7 @@ class OWSConfig(OWSMetadataConfig):
 
             try:
                 if self.wmts:
-                    self.parse_wmts(cast(CFG_DICT, cfg.get("wmts", {})))
+                    self.parse_wmts(cast("CFG_DICT", cfg.get("wmts", {})))
                 else:
                     self.parse_wmts({})
             except KeyError as e:
@@ -1741,31 +1743,31 @@ class OWSConfig(OWSMetadataConfig):
         return self.catalog
 
     def parse_global(self, cfg: CFG_DICT, ignore_msgfile: bool) -> None:
-        default_env = cast(str, cfg.get("env"))
+        default_env = cast("str", cfg.get("env"))
         self.default_env = ODCConfig.get_environment(env=default_env)
-        self.odc_app = cast(str, cfg.get("odc_app", "datacube-ows"))
-        self._response_headers = cast(dict[str, str], cfg.get("response_headers", {}))
-        services = cast(dict[str, bool], cfg.get("services", {}))
+        self.odc_app = cast("str", cfg.get("odc_app", "datacube-ows"))
+        self._response_headers = cast("dict[str, str]", cfg.get("response_headers", {}))
+        services = cast("dict[str, bool]", cfg.get("services", {}))
         self.wms = services.get("wms", True)
         self.wmts = services.get("wmts", True)
         self.wcs = services.get("wcs", False)
         if not self.wms and not self.wmts and not self.wcs:
             raise ConfigException("At least one service must be active.")
-        self.locales = cast(list[str], cfg.get("supported_languages", ["en"]))
+        self.locales = cast("list[str]", cfg.get("supported_languages", ["en"]))
         if len(self.locales) < 1:
             raise ConfigException("You must support at least one language.")
         self.default_locale = self.locales[0]
-        self.message_domain = cast(str, cfg.get("message_domain", "ows_cfg"))
-        self.translations_dir = cast(str | None, cfg.get("translations_directory"))
+        self.message_domain = cast("str", cfg.get("message_domain", "ows_cfg"))
+        self.translations_dir = cast("str | None", cfg.get("translations_directory"))
         self.internationalised = self.translations_dir and len(self.locales) > 1
         if self.internationalised:
             _LOG.info("Internationalisation enabled.")
         if ignore_msgfile:
             self.msg_file_name: str | None = None
         else:
-            self.msg_file_name = cast(str | None, cfg.get("message_file"))
+            self.msg_file_name = cast("str | None", cfg.get("message_file"))
         self.parse_metadata(cfg)
-        self.allowed_urls = cast(str | list[str], cfg["allowed_urls"])
+        self.allowed_urls = cast("str | list[str]", cfg["allowed_urls"])
         if isinstance(self.allowed_urls, list) and len(self.allowed_urls) == 0:
             raise ConfigException(
                 'Empty list for allowed_urls. Please use the empty string ("") instead.'
@@ -1773,9 +1775,9 @@ class OWSConfig(OWSMetadataConfig):
         self.info_url = cfg["info_url"]
         self.contact_info = ContactInfo.parse(cfg.get("contact_info"), self)
         self.attribution = AttributionCfg.parse(
-            cast(CFG_DICT | None, cfg.get("attribution")), self
+            cast("CFG_DICT | None", cfg.get("attribution")), self
         )
-        self.load_driver = cast(str, cfg.get("load_driver", "legacy"))
+        self.load_driver = cast("str", cfg.get("load_driver", "legacy"))
         if self.load_driver not in ["rio", "legacy"]:
             raise ConfigException(
                 f"Invalid load_driver: {self.load_driver} Please use 'rio' or 'legacy'"
@@ -1790,7 +1792,9 @@ class OWSConfig(OWSMetadataConfig):
         self.internal_CRSs: dict[str, CFG_DICT] = {}
         CRS_aliases: dict[str, CFG_DICT] = {}
         geographic_CRSs: list[str] = []
-        for crs_str, crsdef in cast(dict[str, CFG_DICT], cfg["published_CRSs"]).items():
+        for crs_str, crsdef in cast(
+            "dict[str, CFG_DICT]", cfg["published_CRSs"]
+        ).items():
             if "alias" in crsdef:
                 CRS_aliases[crs_str] = crsdef
                 continue
@@ -1840,7 +1844,7 @@ class OWSConfig(OWSMetadataConfig):
             }
 
         for alias, alias_def in CRS_aliases.items():
-            target_crs = cast(str, alias_def["alias"])
+            target_crs = cast("str", alias_def["alias"])
             if target_crs not in self.published_CRSs:
                 _LOG.warning(
                     "CRS %s defined as alias for %s, which is not a published CRS - skipping",
@@ -1856,12 +1860,12 @@ class OWSConfig(OWSMetadataConfig):
     def parse_wms(self, cfg: CFG_DICT) -> None:
         if not self.wms and not self.wmts:
             cfg = {}
-        self.s3_bucket = cast(str, cfg.get("s3_bucket", ""))
-        self.s3_url = cast(str, cfg.get("s3_url", ""))
-        self.s3_aws_zone = cast(str, cfg.get("s3_aws_zone", ""))
+        self.s3_bucket = cast("str", cfg.get("s3_bucket", ""))
+        self.s3_url = cast("str", cfg.get("s3_url", ""))
+        self.s3_aws_zone = cast("str", cfg.get("s3_aws_zone", ""))
         try:
-            self.wms_max_width = int(cast(str | int, cfg.get("max_width", 256)))
-            self.wms_max_height = int(cast(str | int, cfg.get("max_height", 256)))
+            self.wms_max_width = int(cast("str | int", cfg.get("max_width", 256)))
+            self.wms_max_height = int(cast("str | int", cfg.get("max_height", 256)))
         except ValueError:
             raise ConfigException(
                 f"max_width and max_height in wms section must be integers: {cfg.get('max_width', 256)},{cfg.get('max_height', 256)}"
@@ -1870,7 +1874,7 @@ class OWSConfig(OWSMetadataConfig):
             raise ConfigException(
                 f"max_width and max_height in wms section must be positive integers: {cfg.get('max_width', 256)},{cfg.get('max_height', 256)}"
             )
-        self.authorities = cast(dict[str, str], cfg.get("authorities", {}))
+        self.authorities = cast("dict[str, str]", cfg.get("authorities", {}))
         self.user_band_math_extension = cfg.get("user_band_math_extension", False)
         self.wms_cap_cache_age = parse_cache_age(cfg, "caps_cache_maxage", "wms")
         if "attribution" in cfg:
@@ -1883,7 +1887,7 @@ class OWSConfig(OWSMetadataConfig):
             if not isinstance(cfg, Mapping):
                 raise ConfigException("WCS section missing (and WCS is enabled)")
             self.wcs_formats = WCSFormat.from_cfg(
-                cast(dict[str, CFG_DICT], cfg["formats"])
+                cast("dict[str, CFG_DICT]", cfg["formats"])
             )
             self.wcs_formats_by_name = {fmt.name: fmt for fmt in self.wcs_formats}
             self.wcs_formats_by_mime = {fmt.mime: fmt for fmt in self.wcs_formats}
@@ -1912,10 +1916,10 @@ class OWSConfig(OWSMetadataConfig):
             self.wcs_default_descov_age = 0
 
     def parse_wmts(self, cfg: CFG_DICT) -> None:
-        tms_cfgs = cast(dict[str, CFG_DICT], TileMatrixSet.default_tm_sets.copy())
+        tms_cfgs = cast("dict[str, CFG_DICT]", TileMatrixSet.default_tm_sets.copy())
         if "tile_matrix_sets" in cfg:
             for identifier, tms in cast(
-                dict[str, CFG_DICT], cfg["tile_matrix_sets"]
+                "dict[str, CFG_DICT]", cfg["tile_matrix_sets"]
             ).items():
                 tms_cfgs[identifier] = tms
         self.tile_matrix_sets: dict[str, TileMatrixSet] = {}
@@ -1934,7 +1938,7 @@ class OWSConfig(OWSMetadataConfig):
         self.declare_unready("native_product_index")
         self.root_layer_folder = OWSFolder(
             cast(
-                CFG_DICT,
+                "CFG_DICT",
                 {
                     "title": self.title,
                     "abstract": self.abstract,
@@ -1957,7 +1961,7 @@ class OWSConfig(OWSMetadataConfig):
     def alias_bboxes(self, bboxes: CFG_DICT) -> CFG_DICT:
         out: CFG_DICT = {}
         for crsid, crsdef in self.published_CRSs.items():
-            a_crsid = cast(str, crsdef["alias_of"])
+            a_crsid = cast("str", crsdef["alias_of"])
             if a_crsid:
                 if a_crsid in bboxes:
                     out[crsid] = bboxes[a_crsid]

--- a/datacube_ows/ows_configuration.py
+++ b/datacube_ows/ows_configuration.py
@@ -11,6 +11,8 @@
 #
 #  Refer to the documentation for information on how to configure datacube_ows.
 #
+from __future__ import annotations
+
 import contextlib
 import datetime
 import enum
@@ -18,30 +20,24 @@ import json
 import logging
 import math
 import os
-from collections.abc import Iterable, Mapping
+from collections.abc import Mapping
 from enum import Enum
 from threading import Lock
-from typing import Any, Optional, Union, cast
+from typing import Any, cast
 
 import numpy
 from babel.messages.catalog import Catalog
 from babel.messages.pofile import read_po
 from datacube import Datacube
-from datacube.api.query import GroupBy
-from datacube.cfg import ODCConfig, ODCEnvironment
-from datacube.model import Measurement, Product
+from datacube.cfg import ODCConfig
 from odc.geo import CRS, CRSError
-from odc.geo.geobox import GeoBox
 from ows import Version
 from slugify import slugify
 from sqlalchemy.exc import OperationalError
 from typing_extensions import override
 
 from datacube_ows.config_utils import (
-    CFG_DICT,
-    RAW_CFG,
     ConfigException,
-    F,
     FlagProductBands,
     FunctionWrapper,
     ODCInitException,
@@ -55,7 +51,7 @@ from datacube_ows.config_utils import (
     import_python_obj,
     load_json_obj,
 )
-from datacube_ows.index.api import OWSAbstractIndex, ows_index
+from datacube_ows.index.api import ows_index
 from datacube_ows.ogc_utils import create_geobox
 from datacube_ows.resource_limits import OWSResourceManagementRules, parse_cache_age
 from datacube_ows.styles import StyleDef
@@ -65,7 +61,15 @@ from datacube_ows.utils import group_by_begin_datetime, group_by_mosaic, group_b
 
 TYPE_CHECKING = False
 if TYPE_CHECKING:
-    from datacube_ows.index.api import LayerExtent
+    from collections.abc import Iterable
+
+    from datacube.api.query import GroupBy
+    from datacube.cfg import ODCEnvironment
+    from datacube.model import Measurement, Product
+    from odc.geo.geobox import GeoBox
+
+    from datacube_ows.config_utils import CFG_DICT, RAW_CFG, F
+    from datacube_ows.index.api import LayerExtent, OWSAbstractIndex
 
 _LOG: logging.Logger = logging.getLogger(__name__)
 
@@ -147,7 +151,7 @@ class BandIndex(OWSMetadataConfig):
     METADATA_TITLE = False
     METADATA_ABSTRACT = False
 
-    def __init__(self, layer: "OWSNamedLayer", band_cfg: CFG_DICT | None) -> None:
+    def __init__(self, layer: OWSNamedLayer, band_cfg: CFG_DICT | None) -> None:
         if band_cfg is None:
             band_cfg = {}
         super().__init__(band_cfg)
@@ -162,7 +166,7 @@ class BandIndex(OWSMetadataConfig):
         self.declare_unready("_dtypes")
 
     @override
-    def global_config(self) -> "OWSConfig":
+    def global_config(self) -> OWSConfig:
         return self.layer.global_config()
 
     @override
@@ -287,7 +291,7 @@ class BandIndex(OWSMetadataConfig):
 
 
 class AttributionCfg(OWSConfigEntry):
-    def __init__(self, cfg: CFG_DICT, owner: Union["OWSConfig", "OWSLayer"]) -> None:
+    def __init__(self, cfg: CFG_DICT, owner: OWSConfig | OWSLayer) -> None:
         super().__init__(cfg)
         self.owner = owner
         self.url = cast("str | None", cfg.get("url"))
@@ -319,8 +323,8 @@ class AttributionCfg(OWSConfigEntry):
 
     @classmethod
     def parse(
-        cls, cfg: CFG_DICT | None, owner: Union["OWSConfig", "OWSLayer"]
-    ) -> Optional["AttributionCfg"]:
+        cls, cfg: CFG_DICT | None, owner: OWSConfig | OWSLayer
+    ) -> AttributionCfg | None:
         if not cfg:
             return None
         return cls(cfg, owner)
@@ -328,7 +332,7 @@ class AttributionCfg(OWSConfigEntry):
 
 class SuppURL(OWSConfigEntry):
     @classmethod
-    def parse_list(cls, cfg: list[dict[str, str]] | None) -> list["SuppURL"]:
+    def parse_list(cls, cfg: list[dict[str, str]] | None) -> list[SuppURL]:
         if not cfg:
             return []
         return [cls(u) for u in cfg]
@@ -349,7 +353,7 @@ class OWSLayer(OWSMetadataConfig):
         self,
         cfg: CFG_DICT,
         object_label: str,
-        parent_layer: Optional["OWSLayer"] = None,
+        parent_layer: OWSLayer | None = None,
         **kwargs,
     ) -> None:
         super().__init__(cfg, **kwargs)
@@ -430,11 +434,11 @@ class OWSLayer(OWSMetadataConfig):
         return ows_index(self.dc)
 
     @override
-    def global_config(self) -> "OWSConfig":
+    def global_config(self) -> OWSConfig:
         return self.global_cfg
 
     @override
-    def can_inherit_from(self) -> Union["OWSConfig", "OWSLayer"]:
+    def can_inherit_from(self) -> OWSConfig | OWSLayer:
         if self.parent_layer:
             return self.parent_layer
         return self.global_cfg
@@ -458,8 +462,8 @@ class OWSFolder(OWSLayer):
     def __init__(
         self,
         cfg: CFG_DICT,
-        global_cfg: "OWSConfig",
-        parent_layer: Optional["OWSFolder"] = None,
+        global_cfg: OWSConfig,
+        parent_layer: OWSFolder | None = None,
         sibling: int = 0,
         **kwargs,
     ) -> None:
@@ -549,7 +553,7 @@ class TimeRes(Enum):
         return not self.is_subday()
 
     @classmethod
-    def parse(cls, cfg: str | None) -> Optional["TimeRes"]:
+    def parse(cls, cfg: str | None) -> TimeRes | None:
         if cfg is None:
             cfg = "solar"
         elif cfg == "raw":
@@ -618,7 +622,7 @@ class OWSNamedLayer(OWSExtensibleConfigEntry, OWSLayer):
     def __init__(
         self,
         cfg: CFG_DICT,
-        global_cfg: "OWSConfig",
+        global_cfg: OWSConfig,
         parent_layer: OWSFolder | None = None,
         **kwargs,
     ) -> None:
@@ -1265,7 +1269,7 @@ class OWSNamedLayer(OWSExtensibleConfigEntry, OWSLayer):
         return True
 
     def time_range(
-        self, ranges: Optional["LayerExtent"] = None
+        self, ranges: LayerExtent | None = None
     ) -> tuple[datetime.datetime | datetime.date, datetime.datetime | datetime.date]:
         if ranges is None:
             ranges = self.ranges
@@ -1282,7 +1286,7 @@ class OWSNamedLayer(OWSExtensibleConfigEntry, OWSLayer):
         return start, end
 
     @property
-    def ranges(self) -> "LayerExtent":
+    def ranges(self) -> LayerExtent:
         if self.dynamic:
             ranges_ok = self.force_range_update()
             if not ranges_ok:
@@ -1344,8 +1348,8 @@ class OWSNamedLayer(OWSExtensibleConfigEntry, OWSLayer):
     @classmethod
     @override
     def lookup_impl(
-        cls, cfg: "OWSConfig", keyvals: dict[str, str], subs: CFG_DICT | None = None
-    ) -> "OWSNamedLayer":
+        cls, cfg: OWSConfig, keyvals: dict[str, str], subs: CFG_DICT | None = None
+    ) -> OWSNamedLayer:
         try:
             return cfg.layer_index[keyvals["layer"]]
         except KeyError:
@@ -1478,7 +1482,7 @@ class OWSMultiProductLayer(OWSNamedLayer):
 
 def parse_ows_layer(
     cfg: CFG_DICT,
-    global_cfg: "OWSConfig",
+    global_cfg: OWSConfig,
     parent_layer: OWSFolder | None = None,
     sibling: int = 0,
 ) -> OWSLayer:
@@ -1491,7 +1495,7 @@ def parse_ows_layer(
 
 class WCSFormat:
     @staticmethod
-    def from_cfg(cfg: dict[str, CFG_DICT]) -> list["WCSFormat"]:
+    def from_cfg(cfg: dict[str, CFG_DICT]) -> list[WCSFormat]:
         renderers: list[WCSFormat] = []
         for name, fmt in cfg.items():
             if "renderers" in fmt:
@@ -1538,7 +1542,7 @@ class WCSFormat:
 
 
 class ContactInfo(OWSConfigEntry):
-    def __init__(self, cfg: CFG_DICT, global_cfg: "OWSConfig") -> None:
+    def __init__(self, cfg: CFG_DICT, global_cfg: OWSConfig) -> None:
         super().__init__(cfg)
         self.global_cfg = global_cfg
         self.person = cfg.get("person")
@@ -1554,7 +1558,7 @@ class ContactInfo(OWSConfigEntry):
                 self.country = cfg.get("country")
 
             @classmethod
-            def parse(cls, cfg: dict[str, str] | None) -> Optional["Address"]:
+            def parse(cls, cfg: dict[str, str] | None) -> Address | None:
                 if not cfg:
                     return None
                 return cls(cfg)
@@ -1573,17 +1577,17 @@ class ContactInfo(OWSConfigEntry):
         return self.global_cfg.contact_position
 
     @classmethod
-    def parse(cls, cfg, global_cfg) -> Optional["ContactInfo"]:
+    def parse(cls, cfg, global_cfg) -> ContactInfo | None:
         if cfg:
             return cls(cfg, global_cfg)
         return None
 
 
 class OWSConfig(OWSMetadataConfig):
-    _instance: Optional["OWSConfig"] = None
+    _instance: OWSConfig | None = None
     initialised = False
 
-    def __new__(cls, *args, **kwargs) -> "OWSConfig":
+    def __new__(cls, *args, **kwargs) -> OWSConfig:
         if not cls._instance or kwargs.get("refresh"):
             cls._instance = super().__new__(cls)
         return cls._instance

--- a/datacube_ows/protocol_versions.py
+++ b/datacube_ows/protocol_versions.py
@@ -3,25 +3,30 @@
 #
 # Copyright (c) 2017-2024 OWS Contributors
 # SPDX-License-Identifier: Apache-2.0
-
+from __future__ import annotations
 
 import contextlib
 import re
-from collections.abc import Callable, Mapping, Sequence
+from collections.abc import Callable, Mapping
 from typing import TypeAlias
 
 from datacube_ows.ogc_exceptions import (
-    OGCException,
     WCS1Exception,
     WCS2Exception,
     WMSException,
     WMTSException,
 )
-from datacube_ows.ows_configuration import OWSConfig
 from datacube_ows.wcs1 import handle_wcs1
 from datacube_ows.wcs2 import handle_wcs2
 from datacube_ows.wms import handle_wms
 from datacube_ows.wmts import handle_wmts
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from datacube_ows.ogc_exceptions import OGCException
+    from datacube_ows.ows_configuration import OWSConfig
 
 FlaskResponse: TypeAlias = tuple[str | bytes, int, dict[str, str]]
 FlaskHandler: TypeAlias = Callable[[Mapping[str, str]], FlaskResponse]

--- a/datacube_ows/resource_limits.py
+++ b/datacube_ows/resource_limits.py
@@ -3,9 +3,9 @@
 #
 # Copyright (c) 2017-2024 OWS Contributors
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import math
-from collections.abc import Iterable, Mapping
 from typing import Any, cast
 
 import affine
@@ -14,13 +14,16 @@ from odc.geo.crs import CRS
 from odc.geo.geobox import GeoBox
 from odc.geo.geom import polygon
 
-from datacube_ows.config_utils import CFG_DICT, RAW_CFG, ConfigException, OWSConfigEntry
+from datacube_ows.config_utils import ConfigException, OWSConfigEntry
 from datacube_ows.http_utils import cache_control_headers
 from datacube_ows.ogc_utils import create_geobox
 
 TYPE_CHECKING = False
 if TYPE_CHECKING:
-    import datacube_ows.ows_configuration
+    from collections.abc import Iterable, Mapping
+
+    from datacube_ows.config_utils import CFG_DICT, RAW_CFG
+    from datacube_ows.ows_configuration import OWSConfig
 
 
 def parse_cache_age(cfg: dict, entry, section, default: int = 0) -> int:
@@ -39,7 +42,7 @@ def parse_cache_age(cfg: dict, entry, section, default: int = 0) -> int:
 
 # pyre-ignore[13]
 class RequestScale:
-    standard_scale: "RequestScale"
+    standard_scale: RequestScale
 
     def __init__(
         self,
@@ -119,7 +122,7 @@ class RequestScale:
     def res_xy(self) -> int | float:
         return self.resolution[0] * self.resolution[1]
 
-    def __truediv__(self, other: "RequestScale") -> float:
+    def __truediv__(self, other: RequestScale) -> float:
         ratio = 1.0
         ratio = ratio * self.n_dates / other.n_dates
         for i in range(2):
@@ -241,12 +244,7 @@ class ResourceLimited(Exception):
 
 class OWSResourceManagementRules(OWSConfigEntry):
     # pylint: disable=attribute-defined-outside-init
-    def __init__(
-        self,
-        global_cfg: "datacube_ows.ows_configuration.OWSConfig",
-        cfg: CFG_DICT,
-        context: str,
-    ) -> None:
+    def __init__(self, global_cfg: OWSConfig, cfg: CFG_DICT, context: str) -> None:
         """
         Class constructor.
 

--- a/datacube_ows/resource_limits.py
+++ b/datacube_ows/resource_limits.py
@@ -62,7 +62,7 @@ class RequestScale:
         else:
             self.total_band_size = sum(
                 np.dtype(band["dtype"]).itemsize
-                for band in cast(Iterable[Mapping[str, Any]], request_bands)
+                for band in cast("Iterable[Mapping[str, Any]]", request_bands)
             )
 
     def _standardise_geobox(self, geobox: GeoBox) -> GeoBox:
@@ -85,7 +85,7 @@ class RequestScale:
     ) -> tuple[float, float]:
         # Convert native resolution to metres for ready comparison.
         if crs.units == ("metre", "metre"):
-            return cast(tuple[float, float], tuple(abs(r) for r in resolution))
+            return cast("tuple[float, float]", tuple(abs(r) for r in resolution))
         resolution_rectangle = polygon(
             [(0, 0), (0, resolution[1]), resolution, (0, resolution[0]), (0, 0)],
             crs=crs,
@@ -155,7 +155,7 @@ class CacheControlRules(OWSConfigEntry):
         :param max_datasets: Over-arching maximum dataset limit in context.
         """
         super().__init__(cfg)
-        self.rules = cast(list[CFG_DICT] | None, self._raw_cfg)
+        self.rules = cast("list[CFG_DICT] | None", self._raw_cfg)
         self.use_caching: bool = self.rules is not None
         self.max_datasets = max_datasets
         if not self.use_caching:
@@ -164,7 +164,7 @@ class CacheControlRules(OWSConfigEntry):
         # Validate rules
         min_so_far: int = 0
         max_max_age_so_far: int = 0
-        for rule in cast(list[CFG_DICT], self.rules):
+        for rule in cast("list[CFG_DICT]", self.rules):
             if "min_datasets" not in rule:
                 raise ConfigException(
                     f"Dataset cache rule does not contain a 'min_datasets' element in {context}"
@@ -223,12 +223,12 @@ class CacheControlRules(OWSConfigEntry):
         ):
             return cache_control_headers(0)
         rule = None
-        for r in cast(list[CFG_DICT], self.rules):
-            if n_datasets < cast(int, r["min_datasets"]):
+        for r in cast("list[CFG_DICT]", self.rules):
+            if n_datasets < cast("int", r["min_datasets"]):
                 break
             rule = r
         if rule:
-            return cache_control_headers(cast(int, rule["max_age"]))
+            return cache_control_headers(cast("int", rule["max_age"]))
         return cache_control_headers(0)
 
 
@@ -254,11 +254,11 @@ class OWSResourceManagementRules(OWSConfigEntry):
         :param context: The context (e.g. layer name) for reporting validation errors.
         """
         super().__init__(cfg)
-        cfg = cast(CFG_DICT, self._raw_cfg)
-        wms_cfg = cast(CFG_DICT, cfg.get("wms", {}))
-        wcs_cfg = cast(CFG_DICT, cfg.get("wcs", {}))
+        cfg = cast("CFG_DICT", self._raw_cfg)
+        wms_cfg = cast("CFG_DICT", cfg.get("wms", {}))
+        wcs_cfg = cast("CFG_DICT", cfg.get("wcs", {}))
         self.zoom_fill = cast(
-            list[int], wms_cfg.get("zoomed_out_fill_colour", [150, 180, 200, 160])
+            "list[int]", wms_cfg.get("zoomed_out_fill_colour", [150, 180, 200, 160])
         )
         if len(self.zoom_fill) == 3:
             self.zoom_fill += [255]
@@ -266,11 +266,11 @@ class OWSResourceManagementRules(OWSConfigEntry):
             raise ConfigException(
                 f"zoomed_out_fill_colour must have 3 or 4 elements in {context}"
             )
-        self.min_zoom = cast(float | None, wms_cfg.get("min_zoom_factor"))
-        self.min_zoom_lvl = cast(int | float | None, wms_cfg.get("min_zoom_level"))
-        self.max_datasets_wms = cast(int, wms_cfg.get("max_datasets", 0))
-        self.max_datasets_wcs = cast(int, wcs_cfg.get("max_datasets", 0))
-        self.max_image_size_wcs = cast(int, wcs_cfg.get("max_image_size", 0))
+        self.min_zoom = cast("float | None", wms_cfg.get("min_zoom_factor"))
+        self.min_zoom_lvl = cast("int | float | None", wms_cfg.get("min_zoom_level"))
+        self.max_datasets_wms = cast("int", wms_cfg.get("max_datasets", 0))
+        self.max_datasets_wcs = cast("int", wcs_cfg.get("max_datasets", 0))
+        self.max_image_size_wcs = cast("int", wcs_cfg.get("max_image_size", 0))
         self.wms_cache_rules = CacheControlRules(
             wms_cfg.get("dataset_cache_rules"), context, self.max_datasets_wms
         )

--- a/datacube_ows/startup_utils/__init__.py
+++ b/datacube_ows/startup_utils/__init__.py
@@ -3,18 +3,22 @@
 #
 # Copyright (c) 2017-2024 OWS Contributors
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import logging
 import os
 import sys
 import warnings
-from collections.abc import Callable
-from logging import Logger
 from time import monotonic
 from typing import Any, TypeVar
 
 from flask import Flask, g, request
 from sqlalchemy.exc import OperationalError
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from logging import Logger
 
 __all__ = [
     "create_app",

--- a/datacube_ows/startup_utils/creds.py
+++ b/datacube_ows/startup_utils/creds.py
@@ -1,8 +1,13 @@
+from __future__ import annotations
+
 import os
-from logging import Logger
 from threading import Lock
 
 from datacube.utils.aws import configure_s3_access
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from logging import Logger
 
 credential_lock = Lock()
 
@@ -10,7 +15,7 @@ credential_lock = Lock()
 class CredentialManager:
     _instance = None
 
-    def __new__(cls, log: Logger | None = None) -> "CredentialManager":
+    def __new__(cls, log: Logger | None = None) -> CredentialManager:
         # new/init assumed to be called with credential_lock held
         if not cls._instance:
             cls._instance = super().__new__(cls)

--- a/datacube_ows/styles/api/base.py
+++ b/datacube_ows/styles/api/base.py
@@ -3,13 +3,18 @@
 #
 # Copyright (c) 2017-2024 OWS Contributors
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import xarray
-from PIL import Image
 
-from datacube_ows.config_utils import CFG_DICT
 from datacube_ows.startup_utils import initialise_ignorable_warnings
 from datacube_ows.styles.base import StandaloneProductProxy, StyleDefBase
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from PIL import Image
+
+    from datacube_ows.config_utils import CFG_DICT
 
 initialise_ignorable_warnings()
 

--- a/datacube_ows/styles/base.py
+++ b/datacube_ows/styles/base.py
@@ -57,14 +57,14 @@ class LegendBase(OWSConfigEntry):
         cfg: CFG_DICT,
     ) -> None:
         super().__init__(cfg)
-        raw_cfg = cast(CFG_DICT, self._raw_cfg)
+        raw_cfg = cast("CFG_DICT", self._raw_cfg)
         self.style_or_mdh = style_or_mdh
         if isinstance(self.style_or_mdh, StyleDefBase):
             self.style: StyleDefBase = self.style_or_mdh
         else:
             self.style = self.style_or_mdh.style
         self.show_legend = cast(
-            bool, raw_cfg.get("show_legend", self.style_or_mdh.auto_legend)
+            "bool", raw_cfg.get("show_legend", self.style_or_mdh.auto_legend)
         )
         self.legend_urls: MutableMapping[str, str] = self.parse_urls(raw_cfg.get("url"))
 
@@ -81,7 +81,7 @@ class LegendBase(OWSConfigEntry):
         if isinstance(cfg, str):
             cfg_d: CFG_DICT = {def_loc: cfg}
         else:
-            cfg_d = cast(CFG_DICT, cfg)
+            cfg_d = cast("CFG_DICT", cfg)
         if def_loc not in cfg_d:
             raise ConfigException(
                 f"No legend url for {self.get_obj_label()} supplied for default language {def_loc}"
@@ -95,9 +95,9 @@ class LegendBase(OWSConfigEntry):
         return urls
 
     def parse_common_auto_elements(self, cfg: CFG_DICT) -> None:
-        self.width = cast(float, cfg.get("width", 4.0))
-        self.height = cast(float, cfg.get("height", 1.25))
-        self.mpl_rcparams = cast(MutableMapping[str, str], cfg.get("rcParams", {}))
+        self.width = cast("float", cfg.get("width", 4.0))
+        self.height = cast("float", cfg.get("height", 1.25))
+        self.mpl_rcparams = cast("MutableMapping[str, str]", cfg.get("rcParams", {}))
 
     def render(self, bytesio: io.BytesIO) -> None:
         raise NotImplementedError()
@@ -112,7 +112,7 @@ class LegendBase(OWSConfigEntry):
         if self.style == self.style_or_mdh:
             min_count: int = 1
         else:
-            min_count = cast(int, self.style_or_mdh.min_count)
+            min_count = cast("int", self.style_or_mdh.min_count)
         return f"{style_label}.legend.{min_count}"
 
 
@@ -158,7 +158,7 @@ class StyleDefBase(OWSExtensibleConfigEntry, OWSMetadataConfig):
         """
         if product and style_cfg:
             expanded_cfg = cast(
-                CFG_DICT,
+                "CFG_DICT",
                 cls.expand_inherit(
                     style_cfg,
                     global_cfg=product.global_cfg,
@@ -202,25 +202,25 @@ class StyleDefBase(OWSExtensibleConfigEntry, OWSMetadataConfig):
             keyval_subs={"layer": {product.name: product}},
             keyval_defaults={"layer": product.name},
         )
-        raw_cfg = cast(CFG_DICT, self._raw_cfg)
+        raw_cfg = cast("CFG_DICT", self._raw_cfg)
         self.stand_alone: bool = stand_alone
         if self.stand_alone:
             self._metadata_registry: dict[str, str] = {}
         self.user_defined: bool = user_defined
         self.local_band_map = cast(
-            MutableMapping[str, str], raw_cfg.get("band_map", {})
+            "MutableMapping[str, str]", raw_cfg.get("band_map", {})
         )
         if self.local_band_map:
             pass
         self.product: datacube_ows.ows_configuration.OWSNamedLayer = product
         if self.stand_alone:
-            self.name = cast(str, raw_cfg.get("name", "stand_alone"))
+            self.name = cast("str", raw_cfg.get("name", "stand_alone"))
         else:
-            self.name = cast(str, raw_cfg["name"])
+            self.name = cast("str", raw_cfg["name"])
         self.parse_metadata(raw_cfg)
         self.masks: list[StyleMask] = [
             StyleMask(mask_cfg, self)
-            for mask_cfg in cast(list[CFG_DICT], raw_cfg.get("pq_masks", []))
+            for mask_cfg in cast("list[CFG_DICT]", raw_cfg.get("pq_masks", []))
         ]
         if self.stand_alone:
             self.flag_products: list[FlagProductBands] = []
@@ -235,12 +235,12 @@ class StyleDefBase(OWSExtensibleConfigEntry, OWSMetadataConfig):
         self.declare_unready("flag_bands")
 
         custom_includes = cast(
-            dict[str, CFG_DICT | str | F], style_cfg.get("custom_includes", {})
+            "dict[str, CFG_DICT | str | F]", style_cfg.get("custom_includes", {})
         )
         self.feature_info_includes = {
             k: FunctionWrapper(self, v) for k, v in custom_includes.items()
         }
-        self.legend_cfg = self.Legend(self, cast(CFG_DICT, raw_cfg.get("legend", {})))
+        self.legend_cfg = self.Legend(self, cast("CFG_DICT", raw_cfg.get("legend", {})))
         if not defer_multi_date:
             self.parse_multi_date(raw_cfg)
 
@@ -328,7 +328,7 @@ class StyleDefBase(OWSExtensibleConfigEntry, OWSMetadataConfig):
     def parse_multi_date(self, cfg: CFG_DICT) -> None:
         """Used by __init__()"""
         self.multi_date_handlers: list[StyleDefBase.MultiDateHandler] = []
-        for mb_cfg in cast(list[CFG_DICT], cfg.get("multi_date", [])):
+        for mb_cfg in cast("list[CFG_DICT]", cfg.get("multi_date", [])):
             self.multi_date_handlers.append(self.MultiDateHandler(self, mb_cfg))
 
     def to_mask(
@@ -398,7 +398,7 @@ class StyleDefBase(OWSExtensibleConfigEntry, OWSMetadataConfig):
                         flat_mask = mask_slice
                     else:
                         flat_mask &= mask_slice
-                mask = cast(xr.DataArray, flat_mask)
+                mask = cast("xr.DataArray", flat_mask)
             alpha = alpha.where(mask, other=0)
         return img_data.assign({"alpha": alpha})
 
@@ -566,35 +566,37 @@ class StyleDefBase(OWSExtensibleConfigEntry, OWSMetadataConfig):
             :param cfg: The multidate handler configuration
             """
             super().__init__(cfg)
-            raw_cfg = cast(CFG_DICT, self._raw_cfg)
+            raw_cfg = cast("CFG_DICT", self._raw_cfg)
             self.style = style
             if "allowed_count_range" not in raw_cfg:
                 raise ConfigException(
                     "multi_date handler must have an allowed_count_range"
                 )
-            if len(cast(list[int], cfg["allowed_count_range"])) > 2:
+            if len(cast("list[int]", cfg["allowed_count_range"])) > 2:
                 raise ConfigException(
                     "multi_date handler allowed_count_range must have 2 and only 2 members"
                 )
-            self.min_count, self.max_count = cast(list[int], cfg["allowed_count_range"])
+            self.min_count, self.max_count = cast(
+                "list[int]", cfg["allowed_count_range"]
+            )
             if self.max_count < self.min_count:
                 raise ConfigException(
                     "multi_date handler allowed_count_range: minimum must be less than equal to maximum"
                 )
 
-            self.animate = cast(bool, cfg.get("animate", False))
+            self.animate = cast("bool", cfg.get("animate", False))
             self.frame_duration: int = 1000
             if "aggregator_function" in cfg:
                 self.aggregator: FunctionWrapper | None = FunctionWrapper(
                     style.product,
-                    cast(CFG_DICT, cfg["aggregator_function"]),
+                    cast("CFG_DICT", cfg["aggregator_function"]),
                     stand_alone=self.style.stand_alone,
                 )
             elif self.animate:
                 self.aggregator = FunctionWrapper(
                     style.product, lambda x: x, stand_alone=True
                 )
-                self.frame_duration = cast(int, cfg.get("frame_duration", 1000))
+                self.frame_duration = cast("int", cfg.get("frame_duration", 1000))
             else:
                 self.aggregator = None
                 if self.non_animate_requires_aggregator:
@@ -602,13 +604,13 @@ class StyleDefBase(OWSExtensibleConfigEntry, OWSMetadataConfig):
                         "Aggregator function is required for non-animated multi-date handlers."
                     )
             self.legend_cfg = self.Legend(
-                self, cast(CFG_DICT, raw_cfg.get("legend", {}))
+                self, cast("CFG_DICT", raw_cfg.get("legend", {}))
             )
             self.preserve_user_date_order = cast(
-                bool, cfg.get("preserve_user_date_order", False)
+                "bool", cfg.get("preserve_user_date_order", False)
             )
             custom_includes = cast(
-                dict[str, CFG_DICT | str | F], cfg.get("custom_includes", {})
+                "dict[str, CFG_DICT | str | F]", cfg.get("custom_includes", {})
             )
             self.feature_info_includes = {
                 k: FunctionWrapper(self.style, v) for k, v in custom_includes.items()
@@ -691,7 +693,7 @@ class StyleMask(AbstractMaskRule):
     VALUES_LABEL = "enum"
 
     def __init__(self, cfg: CFG_DICT, style: StyleDefBase) -> None:
-        band = cast(str, cfg["band"])
+        band = cast("str", cfg["band"])
         super().__init__(band, cfg)
         self.stand_alone = style.stand_alone
         self.style = style
@@ -709,7 +711,7 @@ class StyleMask(AbstractMaskRule):
         if self.stand_alone:
             self.flag_band: FlagBand = OWSFlagBandStandalone(self.band)
         else:
-            self.flag_band = cast(FlagBand, self.style.product.flag_bands[self.band])
+            self.flag_band = cast("FlagBand", self.style.product.flag_bands[self.band])
 
     @override
     def create_mask(self, data: xr.DataArray) -> xr.DataArray | None:

--- a/datacube_ows/styles/base.py
+++ b/datacube_ows/styles/base.py
@@ -3,39 +3,47 @@
 #
 # Copyright (c) 2017-2024 OWS Contributors
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import io
 import logging
-from collections.abc import Iterable, Mapping, MutableMapping, Sized
 from threading import Lock
-from typing import Any, Optional, Union, cast
+from typing import Any, cast
 
-import datacube.model
 import numpy as np
 import xarray as xr
 from flask_babel import get_locale
 from PIL import Image
 from typing_extensions import override
 
-import datacube_ows.band_utils
 from datacube_ows.config_utils import (
-    CFG_DICT,
-    RAW_CFG,
     AbstractMaskRule,
     ConfigException,
-    F,
-    FlagBand,
     FlagProductBands,
     FunctionWrapper,
     OWSConfigEntry,
     OWSEntryNotFound,
     OWSExtensibleConfigEntry,
     OWSFlagBandStandalone,
-    OWSIndexedConfigEntry,
     OWSMetadataConfig,
 )
 from datacube_ows.legend_utils import get_image_from_url
 from datacube_ows.ogc_exceptions import WMSException
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Mapping, MutableMapping, Sized
+
+    import datacube.model
+
+    from datacube_ows.config_utils import (
+        CFG_DICT,
+        RAW_CFG,
+        F,
+        FlagBand,
+        OWSIndexedConfigEntry,
+    )
+    from datacube_ows.ows_configuration import OWSConfig, OWSNamedLayer
 
 _LOG: logging.Logger = logging.getLogger(__name__)
 
@@ -51,9 +59,9 @@ class LegendBase(OWSConfigEntry):
 
     def __init__(
         self,
-        style_or_mdh: Union[
-            "StyleDefBase", "StyleDefBase.Legend", "StyleDefBase.MultiDateHandler"
-        ],
+        style_or_mdh: StyleDefBase
+        | StyleDefBase.Legend
+        | StyleDefBase.MultiDateHandler,
         cfg: CFG_DICT,
     ) -> None:
         super().__init__(cfg)
@@ -103,7 +111,7 @@ class LegendBase(OWSConfigEntry):
         raise NotImplementedError()
 
     # For MetadataConfig (for subclasses that extend it)
-    def global_config(self) -> "datacube_ows.ows_configuration.OWSConfig":
+    def global_config(self) -> OWSConfig:
         return self.style.global_config()
 
     def get_obj_label(self) -> str:
@@ -147,12 +155,12 @@ class StyleDefBase(OWSExtensibleConfigEntry, OWSMetadataConfig):
 
     def __new__(
         cls,
-        product: Optional["datacube_ows.ows_configuration.OWSNamedLayer"] = None,
+        product: OWSNamedLayer | None = None,
         style_cfg: CFG_DICT | None = None,
         stand_alone: bool = False,
         defer_multi_date: bool = False,
         user_defined: bool = False,
-    ) -> "StyleDefBase":
+    ) -> StyleDefBase:
         """
         Determine appropriate subclass to instantiate and initialise.
         """
@@ -177,7 +185,7 @@ class StyleDefBase(OWSExtensibleConfigEntry, OWSMetadataConfig):
     # FIXME: product type should also include StandaloneProductProxy.
     def __init__(
         self,
-        product: "datacube_ows.ows_configuration.OWSNamedLayer",
+        product: OWSNamedLayer,
         style_cfg: CFG_DICT,
         stand_alone: bool = False,
         defer_multi_date: bool = False,
@@ -212,7 +220,7 @@ class StyleDefBase(OWSExtensibleConfigEntry, OWSMetadataConfig):
         )
         if self.local_band_map:
             pass
-        self.product: datacube_ows.ows_configuration.OWSNamedLayer = product
+        self.product = product
         if self.stand_alone:
             self.name = cast("str", raw_cfg.get("name", "stand_alone"))
         else:
@@ -248,7 +256,7 @@ class StyleDefBase(OWSExtensibleConfigEntry, OWSMetadataConfig):
         self.max_count: int = 1
 
     @override
-    def global_config(self) -> "datacube_ows.ows_configuration.OWSConfig":
+    def global_config(self) -> OWSConfig:
         """Global config object"""
         return self.product.global_cfg
 
@@ -486,7 +494,7 @@ class StyleDefBase(OWSExtensibleConfigEntry, OWSMetadataConfig):
 
     def get_multi_date_handler(
         self, count_or_sized_or_ds: int | Sized | xr.Dataset
-    ) -> Optional["StyleDefBase.MultiDateHandler"]:
+    ) -> StyleDefBase.MultiDateHandler | None:
         """
         Get the appropriate multidate handler.
 
@@ -506,7 +514,7 @@ class StyleDefBase(OWSExtensibleConfigEntry, OWSMetadataConfig):
     @classmethod
     def register_subclass(
         cls,
-        subclass: type["StyleDefBase"],
+        subclass: type[StyleDefBase],
         triggers: Iterable[str],
         priority: bool = False,
     ) -> None:
@@ -525,7 +533,7 @@ class StyleDefBase(OWSExtensibleConfigEntry, OWSMetadataConfig):
             style_class_reg.append((subclass, triggers))
 
     @classmethod
-    def determine_subclass(cls, cfg: CFG_DICT) -> type["StyleDefBase"] | None:
+    def determine_subclass(cls, cfg: CFG_DICT) -> type[StyleDefBase] | None:
         """
         Determine the subclass to use from a raw configuration
         :param cfg: The configuration for some StyleDef subclass
@@ -558,7 +566,7 @@ class StyleDefBase(OWSExtensibleConfigEntry, OWSMetadataConfig):
 
         non_animate_requires_aggregator = True
 
-        def __init__(self, style: "StyleDefBase", cfg: CFG_DICT) -> None:
+        def __init__(self, style: StyleDefBase, cfg: CFG_DICT) -> None:
             """
             First stage initialisation
 
@@ -652,7 +660,7 @@ class StyleDefBase(OWSExtensibleConfigEntry, OWSMetadataConfig):
     @override
     def lookup_impl(
         cls,
-        cfg: "datacube_ows.ows_configuration.OWSConfig",
+        cfg: OWSConfig,
         keyvals: Mapping[str, Any],
         subs: Mapping[str, Any] | None = None,
     ) -> OWSIndexedConfigEntry:

--- a/datacube_ows/styles/colormap.py
+++ b/datacube_ows/styles/colormap.py
@@ -57,10 +57,10 @@ class AbstractValueMapRule(AbstractMaskRule):
         """
         self.style = style_def
         super().__init__(band, cfg, mapper=style_def.local_band)
-        cfg = cast(CFG_DICT, self._raw_cfg)
+        cfg = cast("CFG_DICT", self._raw_cfg)
 
-        self.title = cast(str, cfg["title"])
-        self.abstract = cast(str, cfg.get("abstract"))
+        self.title = cast("str", cfg["title"])
+        self.abstract = cast("str", cfg.get("abstract"))
         if self.title and self.abstract:
             self.label: str | None = f"{self.title} - {self.abstract}"
         elif self.title:
@@ -79,11 +79,11 @@ class AbstractValueMapRule(AbstractMaskRule):
         )
 
     def parse_color(self, cfg: CFG_DICT) -> None:
-        self.color_str = cast(str, cfg["color"])
+        self.color_str = cast("str", cfg["color"])
         if cfg.get("mask"):
             alpha: float | None = 0.0
         elif "alpha" in cfg:
-            alpha = float(cast(float | int | str, cfg["alpha"]))
+            alpha = float(cast("float | int | str", cfg["alpha"]))
         else:
             alpha = None
         self.rgba = to_rgba(self.color_str, alpha=alpha)
@@ -107,7 +107,7 @@ class AbstractValueMapRule(AbstractMaskRule):
         else:
             mdh = style_or_mdh
             if mdh.aggregator:
-                style_or_mdh = cast(ColorMapStyleDef, mdh.style)
+                style_or_mdh = cast("ColorMapStyleDef", mdh.style)
                 typ = ValueMapRule
             else:
                 if mdh.min_count != mdh.max_count:
@@ -119,7 +119,7 @@ class AbstractValueMapRule(AbstractMaskRule):
         for band_name, rules in cfg.items():
             band_rules = [
                 typ(style_or_mdh, band_name, rule)
-                for rule in cast(list[CFG_DICT], rules)
+                for rule in cast("list[CFG_DICT]", rules)
             ]
             vmap[band_name] = band_rules
         return vmap
@@ -166,7 +166,7 @@ class MultiDateValueMapRule(AbstractValueMapRule):
         self.or_flags: list[bool] = []
         self.values: list[list[int]] = []
         super().__init__(
-            style_def=cast(ColorMapStyleDef.MultiDateHandler, mdh.style),
+            style_def=cast("ColorMapStyleDef.MultiDateHandler", mdh.style),
             band=band,
             cfg=cfg,
         )
@@ -174,7 +174,7 @@ class MultiDateValueMapRule(AbstractValueMapRule):
     @override
     def parse_rule_spec(self, cfg: CFG_DICT) -> None:
         if "invert" in cfg:
-            self.invert = [bool(b) for b in cast(list, cfg["invert"])]
+            self.invert = [bool(b) for b in cast("list", cfg["invert"])]
         else:
             self.invert = [False] * self.mdh.max_count
         if len(self.invert) != self.mdh.max_count:
@@ -182,7 +182,7 @@ class MultiDateValueMapRule(AbstractValueMapRule):
                 "Invert entry has wrong number of rule sets for date count"
             )
         if "flags" in cfg:
-            date_flags = cast(list[CFG_DICT], cfg["flags"])
+            date_flags = cast("list[CFG_DICT]", cfg["flags"])
             if len(date_flags) != self.mdh.max_count:
                 raise ConfigException(
                     "Flags entry has wrong number of rule sets for date count"
@@ -195,11 +195,11 @@ class MultiDateValueMapRule(AbstractValueMapRule):
                     )
                 if "or" in flags:
                     or_flag = True
-                    sflags = cast(FlagSpec, flags["or"])
+                    sflags = cast("FlagSpec", flags["or"])
                 elif "and" in flags:
-                    sflags = cast(FlagSpec, flags["and"])
+                    sflags = cast("FlagSpec", flags["and"])
                 else:
-                    sflags = cast(FlagSpec, flags)
+                    sflags = cast("FlagSpec", flags)
                 self.flags.append(sflags)
                 self.or_flags.append(or_flag)
         else:
@@ -207,7 +207,7 @@ class MultiDateValueMapRule(AbstractValueMapRule):
             self.or_flags = []
 
         if "values" in cfg:
-            self.values = list(cast(list[list[int]], cfg["values"]))
+            self.values = list(cast("list[list[int]]", cfg["values"]))
         else:
             self.values = []
         if not self.flags and not self.values:
@@ -257,13 +257,13 @@ class MultiDateValueMapRule(AbstractValueMapRule):
                 if not flags:
                     d_mask = d_slice == d_slice
                 elif or_flags:
-                    for f in ({k: v} for k, v in cast(CFG_DICT, flags).items()):
+                    for f in ({k: v} for k, v in cast("CFG_DICT", flags).items()):
                         if d_mask is None:
                             d_mask = make_mask(d_slice, **f)
                         else:
                             d_mask |= make_mask(d_slice, **f)
                 else:
-                    d_mask = make_mask(d_slice, **cast(CFG_DICT, flags))
+                    d_mask = make_mask(d_slice, **cast("CFG_DICT", flags))
                 if invert and d_mask is not None:
                     d_mask = ~d_mask  # pylint: disable=invalid-unary-operand-type
                 if mask is None:
@@ -319,8 +319,8 @@ class ColorMapLegendBase(StyleDefBase.Legend, OWSMetadataConfig):
         self, style_or_mdh: Union["StyleDefBase", "StyleDefBase.Legend"], cfg: CFG_DICT
     ) -> None:
         super().__init__(style_or_mdh, cfg)
-        raw_cfg = cast(CFG_DICT, self._raw_cfg)
-        self.ncols = cast(int, raw_cfg.get("ncols", 1))
+        raw_cfg = cast("CFG_DICT", self._raw_cfg)
+        self.ncols = cast("int", raw_cfg.get("ncols", 1))
         if self.ncols < 1:
             raise ConfigException("ncols must be a positive integer")
         self.patches: list[PatchTemplate] = []
@@ -333,7 +333,7 @@ class ColorMapLegendBase(StyleDefBase.Legend, OWSMetadataConfig):
                 # only include values that are not transparent (and that have a non-blank title or abstract)
                 if rule.rgba[-1] > 0.001 and rule.label:
                     self.patches.append(PatchTemplate(idx, rule))
-        self.parse_metadata(cast(CFG_DICT, self._raw_cfg))
+        self.parse_metadata(cast("CFG_DICT", self._raw_cfg))
 
     @override
     def render(self, bytesio: io.BytesIO) -> None:
@@ -388,9 +388,9 @@ class ColorMapStyleDef(StyleDefBase):
         super().__init__(
             product, style_cfg, stand_alone=stand_alone, user_defined=user_defined
         )
-        style_cfg = cast(CFG_DICT, self._raw_cfg)
+        style_cfg = cast("CFG_DICT", self._raw_cfg)
         self.value_map = AbstractValueMapRule.value_map_from_config(
-            self, cast(CFG_DICT, style_cfg["value_map"])
+            self, cast("CFG_DICT", style_cfg["value_map"])
         )
         self.legend_cfg.register_value_map(self.value_map)
         for mdh in self.multi_date_handlers:
@@ -461,7 +461,7 @@ class ColorMapStyleDef(StyleDefBase):
             """
             super().__init__(style, cfg)
             self._value_map: dict[str, list[AbstractValueMapRule]] | None = None
-            tcfg = cast(CFG_DICT, self._raw_cfg)
+            tcfg = cast("CFG_DICT", self._raw_cfg)
             if self.animate:
                 if "value_map" in tcfg:
                     raise ConfigException(
@@ -469,7 +469,7 @@ class ColorMapStyleDef(StyleDefBase):
                     )
             else:
                 self._value_map = AbstractValueMapRule.value_map_from_config(
-                    self, cast(CFG_DICT, tcfg["value_map"])
+                    self, cast("CFG_DICT", tcfg["value_map"])
                 )
 
         @property

--- a/datacube_ows/styles/colormap.py
+++ b/datacube_ows/styles/colormap.py
@@ -3,12 +3,11 @@
 #
 # Copyright (c) 2017-2024 OWS Contributors
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
-import io
 import logging
-from collections.abc import Callable, MutableMapping
 from datetime import datetime
-from typing import Union, cast
+from typing import cast
 
 import numpy
 import xarray
@@ -20,16 +19,18 @@ from typing_extensions import override
 from xarray import DataArray, Dataset
 
 from datacube_ows.config_utils import (
-    CFG_DICT,
     AbstractMaskRule,
     ConfigException,
-    FlagSpec,
     OWSMetadataConfig,
 )
 from datacube_ows.styles.base import StyleDefBase
 
 TYPE_CHECKING = False
 if TYPE_CHECKING:
+    import io
+    from collections.abc import Callable, MutableMapping
+
+    from datacube_ows.config_utils import CFG_DICT, FlagSpec
     from datacube_ows.ows_configuration import OWSNamedLayer
 
 _LOG: logging.Logger = logging.getLogger(__name__)
@@ -44,7 +45,7 @@ class AbstractValueMapRule(AbstractMaskRule):
 
     def __init__(
         self,
-        style_def: Union["ColorMapStyleDef", "ColorMapStyleDef.MultiDateHandler"],
+        style_def: ColorMapStyleDef | ColorMapStyleDef.MultiDateHandler,
         band: str,
         cfg: CFG_DICT,
     ) -> None:
@@ -91,9 +92,9 @@ class AbstractValueMapRule(AbstractMaskRule):
     @classmethod
     def value_map_from_config(
         cls,
-        style_or_mdh: Union["ColorMapStyleDef", "ColorMapStyleDef.MultiDateHandler"],
+        style_or_mdh: ColorMapStyleDef | ColorMapStyleDef.MultiDateHandler,
         cfg: CFG_DICT,
-    ) -> dict[str, list["AbstractValueMapRule"]]:
+    ) -> dict[str, list[AbstractValueMapRule]]:
         """
         Create a multi-date value map rule set from a config specification
 
@@ -132,7 +133,7 @@ class ValueMapRule(AbstractValueMapRule):
     Construct a ValueMap rule-set with ValueMapRule.value_map_from_config
     """
 
-    def __init__(self, style_cfg: "ColorMapStyleDef", band: str, cfg: CFG_DICT) -> None:
+    def __init__(self, style_cfg: ColorMapStyleDef, band: str, cfg: CFG_DICT) -> None:
         """
         Construct a Multi-date Value Map Rule
 
@@ -151,7 +152,7 @@ class MultiDateValueMapRule(AbstractValueMapRule):
     """
 
     def __init__(
-        self, mdh: "ColorMapStyleDef.MultiDateHandler", band: str, cfg: CFG_DICT
+        self, mdh: ColorMapStyleDef.MultiDateHandler, band: str, cfg: CFG_DICT
     ) -> None:
         """
         Construct a Multi-date Value Map Rule
@@ -316,7 +317,7 @@ class ColorMapLegendBase(StyleDefBase.Legend, OWSMetadataConfig):
     METADATA_VALUE_RULES: bool = True
 
     def __init__(
-        self, style_or_mdh: Union["StyleDefBase", "StyleDefBase.Legend"], cfg: CFG_DICT
+        self, style_or_mdh: StyleDefBase | StyleDefBase.Legend, cfg: CFG_DICT
     ) -> None:
         super().__init__(style_or_mdh, cfg)
         raw_cfg = cast("CFG_DICT", self._raw_cfg)
@@ -326,7 +327,7 @@ class ColorMapLegendBase(StyleDefBase.Legend, OWSMetadataConfig):
         self.patches: list[PatchTemplate] = []
 
     def register_value_map(
-        self, value_map: MutableMapping[str, list["AbstractValueMapRule"]]
+        self, value_map: MutableMapping[str, list[AbstractValueMapRule]]
     ) -> None:
         for band in value_map:
             for idx, rule in reversed(list(enumerate(value_map[band]))):
@@ -377,7 +378,7 @@ class ColorMapStyleDef(StyleDefBase):
 
     def __init__(
         self,
-        product: "OWSNamedLayer",
+        product: OWSNamedLayer,
         style_cfg: CFG_DICT,
         stand_alone: bool = False,
         user_defined: bool = False,
@@ -452,7 +453,7 @@ class ColorMapStyleDef(StyleDefBase):
         auto_legend = True
         non_animate_requires_aggregator = False
 
-        def __init__(self, style: "ColorMapStyleDef", cfg: CFG_DICT) -> None:
+        def __init__(self, style: ColorMapStyleDef, cfg: CFG_DICT) -> None:
             """
             First stage initialisation
 
@@ -473,13 +474,13 @@ class ColorMapStyleDef(StyleDefBase):
                 )
 
         @property
-        def value_map(self) -> dict[str, list["AbstractValueMapRule"]]:
+        def value_map(self) -> dict[str, list[AbstractValueMapRule]]:
             if self._value_map is None:
                 self._value_map = self.style.value_map
             return self._value_map
 
         @override
-        def transform_data(self, data: "xarray.Dataset") -> "xarray.Dataset":
+        def transform_data(self, data: xarray.Dataset) -> xarray.Dataset:
             """
             Apply image transformation
 

--- a/datacube_ows/styles/component.py
+++ b/datacube_ows/styles/component.py
@@ -3,19 +3,22 @@
 #
 # Copyright (c) 2017-2024 OWS Contributors
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
-from collections.abc import Callable, Hashable
 from typing import Any, TypeAlias, cast
 
 import numpy as np
 from typing_extensions import override
 from xarray import DataArray, Dataset
 
-from datacube_ows.config_utils import CFG_DICT, ConfigException, FunctionWrapper
+from datacube_ows.config_utils import ConfigException, FunctionWrapper
 from datacube_ows.styles.base import StyleDefBase
 
 TYPE_CHECKING = False
 if TYPE_CHECKING:
+    from collections.abc import Callable, Hashable
+
+    from datacube_ows.config_utils import CFG_DICT
     from datacube_ows.ows_configuration import OWSNamedLayer
 
 # pylint: disable=abstract-method
@@ -31,7 +34,7 @@ class ComponentStyleDef(StyleDefBase):
 
     def __init__(
         self,
-        product: "OWSNamedLayer",
+        product: OWSNamedLayer,
         style_cfg: CFG_DICT,
         stand_alone: bool = False,
         defer_multi_date: bool = False,

--- a/datacube_ows/styles/component.py
+++ b/datacube_ows/styles/component.py
@@ -47,14 +47,14 @@ class ComponentStyleDef(StyleDefBase):
             defer_multi_date=defer_multi_date,
             user_defined=user_defined,
         )
-        style_cfg: CFG_DICT = cast(CFG_DICT, self._raw_cfg)
+        style_cfg: CFG_DICT = cast("CFG_DICT", self._raw_cfg)
         self.raw_rgb_components: dict[str, Callable | LINEAR_COMP_DICT] = {}
         raw_components = cast(
-            dict[str, Callable | LINEAR_COMP_DICT], style_cfg["components"]
+            "dict[str, Callable | LINEAR_COMP_DICT]", style_cfg["components"]
         )
         for imgband in ["red", "green", "blue", "alpha"]:
             components = cast(
-                Callable | LINEAR_COMP_DICT | CFG_DICT | None,
+                "Callable | LINEAR_COMP_DICT | CFG_DICT | None",
                 raw_components.get(imgband),
             )
             if components is None:
@@ -66,7 +66,7 @@ class ComponentStyleDef(StyleDefBase):
             if callable(components) or "function" in components:
                 self.raw_rgb_components[imgband] = FunctionWrapper(
                     self.product,
-                    cast(CFG_DICT | Callable, components),
+                    cast("CFG_DICT | Callable", components),
                     stand_alone=self.stand_alone,
                 )
                 if not self.stand_alone:
@@ -74,20 +74,20 @@ class ComponentStyleDef(StyleDefBase):
                         raise ConfigException(
                             "Style with a function component must declare additional_bands."
                         )
-                    for b in cast(list[str], style_cfg.get("additional_bands", [])):
+                    for b in cast("list[str]", style_cfg.get("additional_bands", [])):
                         self.raw_needed_bands.add(b)
             else:
-                components = cast(LINEAR_COMP_DICT, components)
+                components = cast("LINEAR_COMP_DICT", components)
                 self.raw_rgb_components[imgband] = components
                 for k in components:
                     if k != "scale_range":
                         self.raw_needed_bands.add(k)
-        self.rgb_components = cast(dict[str, None | Callable | LINEAR_COMP_DICT], {})
+        self.rgb_components = cast("dict[str, None | Callable | LINEAR_COMP_DICT]", {})
 
-        self.scale_factor = cast(float, style_cfg.get("scale_factor"))
+        self.scale_factor = cast("float", style_cfg.get("scale_factor"))
         if "scale_range" in style_cfg:
             self.scale_min, self.scale_max = cast(
-                list[float | None], style_cfg["scale_range"]
+                "list[float | None]", style_cfg["scale_range"]
             )
         elif self.scale_factor:
             self.scale_min = 0.0
@@ -99,15 +99,15 @@ class ComponentStyleDef(StyleDefBase):
         self.component_scale_ranges: dict[str, dict[str, float]] = {}
         for cn, cd in raw_components.items():
             if not callable(cd) and "scale_range" in cd:
-                scale_range = cast(list[float], cd["scale_range"])
+                scale_range = cast("list[float]", cd["scale_range"])
                 self.component_scale_ranges[cn] = {
                     "min": scale_range[0],
                     "max": scale_range[1],
                 }
             else:
                 self.component_scale_ranges[cn] = {
-                    "min": cast(float, self.scale_min),
-                    "max": cast(float, self.scale_max),
+                    "min": cast("float", self.scale_min),
+                    "max": cast("float", self.scale_max),
                 }
 
     # pylint: disable=attribute-defined-outside-init
@@ -118,7 +118,7 @@ class ComponentStyleDef(StyleDefBase):
 
         Mostly sorting out bands, esp flag bands.
         """
-        self.rgb_components = cast(dict[str, None | Callable | LINEAR_COMP_DICT], {})
+        self.rgb_components = cast("dict[str, None | Callable | LINEAR_COMP_DICT]", {})
         for band, component in self.raw_rgb_components.items():
             if not component or callable(component):
                 self.rgb_components[band] = component
@@ -168,9 +168,9 @@ class ComponentStyleDef(StyleDefBase):
         :param data: Raw data, all bands.
         :return: RGBA uint8 xarray
         """
-        imgdata = cast(dict[Hashable, Any], {})
+        imgdata = cast("dict[Hashable, Any]", {})
         for imgband, components in cast(
-            dict[str, Callable | LINEAR_COMP_DICT], self.rgb_components
+            "dict[str, Callable | LINEAR_COMP_DICT]", self.rgb_components
         ).items():
             if callable(components):
                 imgband_data = components(data)

--- a/datacube_ows/styles/expression.py
+++ b/datacube_ows/styles/expression.py
@@ -148,7 +148,7 @@ class Expression:
                 return data[self.ows_style.local_band(key.value)]
 
         # pyre-ignore[19]
-        return cast(ExpressionEvaluator, ExpressionDataEvaluator(self.style))
+        return cast("ExpressionEvaluator", ExpressionDataEvaluator(self.style))
 
     def __call__(self, data: Dataset) -> Any:
         evaluator: ExpressionEvaluator = self.eval_cls(data)

--- a/datacube_ows/styles/expression.py
+++ b/datacube_ows/styles/expression.py
@@ -3,20 +3,23 @@
 #
 # Copyright (c) 2017-2024 OWS Contributors
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import operator
-from collections.abc import Callable
 from typing import Any, cast
 
 import lark
 from datacube.virtual.expr import formula_parser
-from xarray import Dataset
 
 from datacube_ows.config_utils import ConfigException
 
 TYPE_CHECKING = False
 if TYPE_CHECKING:
-    import datacube_ows.styles
+    from collections.abc import Callable
+
+    from xarray import Dataset
+
+    from datacube_ows.styles import StyleDef
 
 # Lark stuff.
 
@@ -107,7 +110,7 @@ class Expression:
     Expression wrapper for configurable expression elements
     """
 
-    def __init__(self, style: "datacube_ows.styles.StyleDef", expr_str: str) -> None:
+    def __init__(self, style: StyleDef, expr_str: str) -> None:
         """
         Class constructor
 

--- a/datacube_ows/styles/hybrid.py
+++ b/datacube_ows/styles/hybrid.py
@@ -3,20 +3,23 @@
 #
 # Copyright (c) 2017-2024 OWS Contributors
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 from typing import cast
 
 from typing_extensions import override
 from xarray import DataArray, Dataset
 
-from datacube_ows.config_utils import CFG_DICT, ConfigException
+from datacube_ows.config_utils import ConfigException
 from datacube_ows.styles.base import StyleDefBase
-from datacube_ows.styles.component import LINEAR_COMP_DICT, ComponentStyleDef
+from datacube_ows.styles.component import ComponentStyleDef
 from datacube_ows.styles.ramp import ColorRampDef
 
 TYPE_CHECKING = False
 if TYPE_CHECKING:
+    from datacube_ows.config_utils import CFG_DICT
     from datacube_ows.ows_configuration import OWSNamedLayer
+    from datacube_ows.styles.component import LINEAR_COMP_DICT
 
 
 class HybridStyleDef(ColorRampDef, ComponentStyleDef):
@@ -30,7 +33,7 @@ class HybridStyleDef(ColorRampDef, ComponentStyleDef):
 
     def __init__(
         self,
-        product: "OWSNamedLayer",
+        product: OWSNamedLayer,
         style_cfg: CFG_DICT,
         defer_multi_date: bool = False,
         stand_alone: bool = False,

--- a/datacube_ows/styles/hybrid.py
+++ b/datacube_ows/styles/hybrid.py
@@ -46,8 +46,8 @@ class HybridStyleDef(ColorRampDef, ComponentStyleDef):
             stand_alone=stand_alone,
             user_defined=user_defined,
         )
-        style_cfg = cast(CFG_DICT, self._raw_cfg)
-        self.component_ratio = float(cast(float | str, style_cfg["component_ratio"]))
+        style_cfg = cast("CFG_DICT", self._raw_cfg)
+        self.component_ratio = float(cast("float | str", style_cfg["component_ratio"]))
         if self.component_ratio < 0.0 or self.component_ratio > 1.0:
             raise ConfigException(
                 "Component ratio must be a floating point number between 0 and 1"
@@ -75,14 +75,16 @@ class HybridStyleDef(ColorRampDef, ComponentStyleDef):
             )
             component_band_data: DataArray | None = None
             for c_band, c_intensity in cast(
-                LINEAR_COMP_DICT, self.rgb_components[band]
+                "LINEAR_COMP_DICT", self.rgb_components[band]
             ).items():
                 if callable(c_intensity):
                     imgband_component_data = cast(
-                        DataArray, c_intensity(data[c_band], c_band, band)
+                        "DataArray", c_intensity(data[c_band], c_band, band)
                     )
                 else:
-                    imgband_component_data = data[c_band] * cast(DataArray, c_intensity)
+                    imgband_component_data = data[c_band] * cast(
+                        "DataArray", c_intensity
+                    )
                 if component_band_data is not None:
                     component_band_data += imgband_component_data
                 else:
@@ -91,7 +93,7 @@ class HybridStyleDef(ColorRampDef, ComponentStyleDef):
                     component_band_data = self.compress_band(band, component_band_data)
             img_band_data = rampdata * 255.0 * (
                 1.0 - self.component_ratio
-            ) + self.component_ratio * cast(DataArray, component_band_data)
+            ) + self.component_ratio * cast("DataArray", component_band_data)
             imgdata[band] = (d.dims, img_band_data.astype("uint8").data)
 
         return imgdata

--- a/datacube_ows/styles/ramp.py
+++ b/datacube_ows/styles/ramp.py
@@ -74,11 +74,11 @@ def make_ramp_representation(ramp_spec: RAMP_SPEC, style_name: str) -> RampRepr:
             )
         rep.append(
             RampNode(
-                float(cast(float | str | int, node["value"])),
-                cast(str, node["color"]),
+                float(cast("float | str | int", node["value"])),
+                cast("str", node["color"]),
                 alpha=None
                 if node.get("alpha") is None
-                else float(cast(str | int | float, node["alpha"])),
+                else float(cast("str | int | float", node["alpha"])),
             )
         )
     return rep
@@ -128,11 +128,11 @@ def crack_ramp(
     :param ramp: input (scaled) colour-ramp definition
     :return: A tuple of four lists of floats: representing values, red, green, blue, alpha.
     """
-    values = cast(list[float], [])
-    red = cast(list[float], [])
-    green = cast(list[float], [])
-    blue = cast(list[float], [])
-    alpha = cast(list[float], [])
+    values = cast("list[float]", [])
+    red = cast("list[float]", [])
+    green = cast("list[float]", [])
+    blue = cast("list[float]", [])
+    alpha = cast("list[float]", [])
     for r in ramp:
         values.append(float(r.value))
         cr, cg, cb, ca = r.rgba
@@ -160,7 +160,7 @@ def read_mpl_ramp(mpl_ramp: str) -> RampRepr:
     rgba_hex = to_hex(cmap(0.0))
     unscaled_cmap.append(RampNode(0.0, rgba_hex))
     for val in val_range:
-        rgba_hex = to_hex(cast(tuple[float, float, float, float], cmap(val)))
+        rgba_hex = to_hex(cast("tuple[float, float, float, float]", cmap(val)))
         unscaled_cmap.append(RampNode(float(val), rgba_hex))
     return unscaled_cmap
 
@@ -180,18 +180,18 @@ class ColorRamp:
         self.style = style
         if "color_ramp" in ramp_cfg:
             raw_scaled_ramp = make_ramp_representation(
-                cast(RAMP_SPEC, ramp_cfg["color_ramp"]), self.style.name
+                cast("RAMP_SPEC", ramp_cfg["color_ramp"]), self.style.name
             )
         else:
-            rmin, rmax = cast(list[float], ramp_cfg["range"])
+            rmin, rmax = cast("list[float]", ramp_cfg["range"])
             unscaled_ramp = UNSCALED_DEFAULT_RAMP
             if "mpl_ramp" in ramp_cfg:
-                unscaled_ramp = read_mpl_ramp(cast(str, ramp_cfg["mpl_ramp"]))
+                unscaled_ramp = read_mpl_ramp(cast("str", ramp_cfg["mpl_ramp"]))
             raw_scaled_ramp = scale_unscaled_ramp(rmin, rmax, unscaled_ramp)
         self.ramp = raw_scaled_ramp
 
-        self.values = cast(list[float], [])
-        self.components = cast(MutableMapping[str, list[float]], {})
+        self.values = cast("list[float]", [])
+        self.components = cast("MutableMapping[str, list[float]]", {})
         self.crack_ramp()
 
         # Handle the mutual interdepencies between the ramp and the legend
@@ -245,13 +245,13 @@ class ColorRamp:
         return numpy.interp(data, self.values, self.components[band])
 
     def get_8bit_value(self, data: DataArray, band: str) -> numpy.ndarray:
-        val = cast(numpy.ndarray, self.get_value(data, band))
+        val = cast("numpy.ndarray", self.get_value(data, band))
         val = val * 255
         # Is there a way to stop this raising a runtime warning?
         return val.astype(ubyte)
 
     def apply(self, data: DataArray) -> Dataset:
-        imgdata = cast(MutableMapping[Hashable, Any], {})
+        imgdata = cast("MutableMapping[Hashable, Any]", {})
         for band in self.components:
             imgdata[band] = (data.dims, self.get_8bit_value(data, band))
         return Dataset(imgdata, coords=data.coords)
@@ -274,16 +274,16 @@ class RampLegendBase(StyleDefBase.Legend, OWSMetadataConfig):
         self, style_or_mdh: Union["StyleDefBase", "StyleDefBase.Legend"], cfg: CFG_DICT
     ) -> None:
         super().__init__(style_or_mdh, cfg)
-        raw_cfg = cast(CFG_DICT, self._raw_cfg)
+        raw_cfg = cast("CFG_DICT", self._raw_cfg)
         # Range - defaults deferred until we have parsed the associated ramp
         if "begin" not in raw_cfg:
             self.begin = Decimal("nan")
         else:
-            self.begin = Decimal(cast(str | float | int, raw_cfg["begin"]))
+            self.begin = Decimal(cast("str | float | int", raw_cfg["begin"]))
         if "end" not in raw_cfg:
             self.end = Decimal("nan")
         else:
-            self.end = Decimal(cast(str | float | int, raw_cfg["end"]))
+            self.end = Decimal(cast("str | float | int", raw_cfg["end"]))
 
         # decimal_places, rounder
         def rounder_str(prec: int) -> str:
@@ -296,7 +296,7 @@ class RampLegendBase(StyleDefBase.Legend, OWSMetadataConfig):
             rstr += "1"
             return rstr
 
-        self.decimal_places = cast(int, raw_cfg.get("decimal_places", 1))
+        self.decimal_places = cast("int", raw_cfg.get("decimal_places", 1))
         if self.decimal_places < 0:
             raise ConfigException("decimal_places cannot be negative")
         self.rounder = Decimal(rounder_str(self.decimal_places))
@@ -315,7 +315,9 @@ class RampLegendBase(StyleDefBase.Legend, OWSMetadataConfig):
                 raise ConfigException(
                     "Cannot use ticks and ticks_every in the same legend"
                 )
-            self.ticks_every = Decimal(cast(int | float | str, raw_cfg["ticks_every"]))
+            self.ticks_every = Decimal(
+                cast("int | float | str", raw_cfg["ticks_every"])
+            )
             if self.ticks_every.is_zero() or self.ticks_every.is_signed():
                 raise ConfigException("ticks_every must be greater than zero")
             ticks_handled = True
@@ -325,16 +327,16 @@ class RampLegendBase(StyleDefBase.Legend, OWSMetadataConfig):
                     "Cannot use tick count and ticks in the same legend"
                 )
             self.ticks = [
-                Decimal(t) for t in cast(list[str | int | float], raw_cfg["ticks"])
+                Decimal(t) for t in cast("list[str | int | float]", raw_cfg["ticks"])
             ]
             ticks_handled = True
         if not ticks_handled:
-            self.tick_count = int(cast(str | int, raw_cfg.get("tick_count", 1)))
+            self.tick_count = int(cast("str | int", raw_cfg.get("tick_count", 1)))
             if self.tick_count < 0:
                 raise ConfigException("tick_count cannot be negative")
         # prepare for tick labels
         self.cfg_labels = cast(
-            MutableMapping[str, MutableMapping[str, str]],
+            "MutableMapping[str, MutableMapping[str, str]]",
             raw_cfg.get("tick_labels", {}),
         )
         defaults = self.cfg_labels.get("default", {})
@@ -343,10 +345,10 @@ class RampLegendBase(StyleDefBase.Legend, OWSMetadataConfig):
         self.tick_labels: list[str] = []
         # handle matplotlib args
         self.strip_location = cast(
-            tuple[float, float, float, float],
+            "tuple[float, float, float, float]",
             tuple(
                 cast(
-                    Iterable[float],
+                    "Iterable[float]",
                     raw_cfg.get("strip_location", [0.05, 0.5, 0.9, 0.15]),
                 )
             ),
@@ -356,7 +358,7 @@ class RampLegendBase(StyleDefBase.Legend, OWSMetadataConfig):
 
     def fail_legacy(self) -> None:
         if any(
-            legent in cast(CFG_DICT, self._raw_cfg)
+            legent in cast("CFG_DICT", self._raw_cfg)
             for legent in ["major_ticks", "offset", "scale_by", "radix_point"]
         ):
             raise ConfigException(
@@ -414,7 +416,7 @@ class RampLegendBase(StyleDefBase.Legend, OWSMetadataConfig):
                 self.tick_labels.append(
                     self.lbl_default_prefix + str(tick) + self.lbl_default_suffix
                 )
-        self.parse_metadata(cast(CFG_DICT, self._raw_cfg))
+        self.parse_metadata(cast("CFG_DICT", self._raw_cfg))
 
     def tick_label(self, tick: Decimal) -> str | None:
         try:
@@ -434,9 +436,9 @@ class RampLegendBase(StyleDefBase.Legend, OWSMetadataConfig):
         MutableMapping[float, str],
     ]:
         normalize_factor = float(self.end) - float(self.begin)
-        cdict = cast(MutableMapping[str, list[tuple[float, float, float]]], {})
+        cdict = cast("MutableMapping[str, list[tuple[float, float, float]]]", {})
         bands = cast(
-            MutableMapping[str, list[tuple[float, float, float]]], defaultdict(list)
+            "MutableMapping[str, list[tuple[float, float, float]]]", defaultdict(list)
         )
         started = False
         finished = False
@@ -461,11 +463,11 @@ class RampLegendBase(StyleDefBase.Legend, OWSMetadataConfig):
         for band, blist in bands.items():
             cdict[band] = blist
 
-        ticks = cast(MutableMapping[float, str], {})
+        ticks = cast("MutableMapping[float, str]", {})
         for tick in self.ticks:
             value = float(tick)
             normalized = (value - float(self.begin)) / float(normalize_factor)
-            ticks[normalized] = cast(str, self.tick_label(tick))
+            ticks[normalized] = cast("str", self.tick_label(tick))
 
         return cdict, ticks
 
@@ -526,9 +528,9 @@ class ColorRampDef(StyleDefBase):
             defer_multi_date=True,
             user_defined=user_defined,
         )
-        style_cfg = cast(CFG_DICT, self._raw_cfg)
+        style_cfg = cast("CFG_DICT", self._raw_cfg)
         self.color_ramp = ColorRamp(
-            self, style_cfg, cast(ColorRampDef.Legend, self.legend_cfg)
+            self, style_cfg, cast("ColorRampDef.Legend", self.legend_cfg)
         )
         self.include_in_feature_info = bool(
             style_cfg.get("include_in_feature_info", True)
@@ -537,15 +539,15 @@ class ColorRampDef(StyleDefBase):
         if "index_function" in style_cfg:
             self.index_function: FunctionWrapper | Expression = FunctionWrapper(
                 self,
-                cast(CFG_DICT, style_cfg["index_function"]),
+                cast("CFG_DICT", style_cfg["index_function"]),
                 stand_alone=self.stand_alone,
             )
             if not self.stand_alone:
-                for band in cast(list[str], style_cfg["needed_bands"]):
+                for band in cast("list[str]", style_cfg["needed_bands"]):
                     self.raw_needed_bands.add(band)
         elif "index_expression" in style_cfg:
             self.index_function = Expression(
-                self, cast(str, style_cfg["index_expression"])
+                self, cast("str", style_cfg["index_expression"])
             )
             for band in self.index_function.needed_bands:
                 self.raw_needed_bands.add(band)
@@ -604,10 +606,10 @@ class ColorRampDef(StyleDefBase):
                 self.pass_raw_data = False
             else:
                 self.feature_info_label = cast(
-                    str | None, cfg.get("feature_info_label", None)
+                    "str | None", cfg.get("feature_info_label", None)
                 )
                 self.color_ramp = ColorRamp(
-                    style, cfg, cast(ColorRampDef.Legend, self.legend_cfg)
+                    style, cfg, cast("ColorRampDef.Legend", self.legend_cfg)
                 )
                 self.pass_raw_data = bool(cfg.get("pass_raw_data", False))
 
@@ -624,7 +626,7 @@ class ColorRampDef(StyleDefBase):
                 agg = self.aggregator(data)
             else:
                 xformed_data = cast("ColorRampDef", self.style).apply_index(data)
-                agg = cast(FunctionWrapper, self.aggregator)(xformed_data)
+                agg = cast("FunctionWrapper", self.aggregator)(xformed_data)
             return self.color_ramp.apply(agg)
 
         class Legend(RampLegendBase):

--- a/datacube_ows/styles/ramp.py
+++ b/datacube_ows/styles/ramp.py
@@ -3,15 +3,14 @@
 #
 # Copyright (c) 2017-2024 OWS Contributors
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
-import io
 import logging
 from collections import defaultdict
-from collections.abc import Hashable, Iterable, MutableMapping
 from dataclasses import dataclass
 from decimal import ROUND_HALF_UP, Decimal
 from math import isclose
-from typing import Any, Union, cast
+from typing import Any, cast
 
 import matplotlib
 import matplotlib.colorbar
@@ -20,7 +19,7 @@ from matplotlib import pyplot as plt
 from matplotlib.colors import LinearSegmentedColormap, to_hex, to_rgba
 from numpy import ubyte
 from typing_extensions import override
-from xarray import DataArray, Dataset
+from xarray import Dataset
 
 from datacube_ows.config_utils import (
     CFG_DICT,
@@ -33,6 +32,11 @@ from datacube_ows.styles.expression import Expression
 
 TYPE_CHECKING = False
 if TYPE_CHECKING:
+    import io
+    from collections.abc import Hashable, Iterable, MutableMapping
+
+    from xarray import DataArray
+
     from datacube_ows.ows_configuration import OWSNamedLayer
 
 _LOG: logging.Logger = logging.getLogger(__name__)
@@ -48,7 +52,7 @@ class RampNode:
     def rgba(self) -> tuple[float, float, float, float]:
         return to_rgba(self.color, self.alpha)
 
-    def with_value(self, value: int | float) -> "RampNode":
+    def with_value(self, value: int | float) -> RampNode:
         return RampNode(value, self.color, self.alpha)
 
 
@@ -171,7 +175,7 @@ class ColorRamp:
     """
 
     def __init__(
-        self, style: StyleDefBase, ramp_cfg: CFG_DICT, legend: "RampLegendBase"
+        self, style: StyleDefBase, ramp_cfg: CFG_DICT, legend: RampLegendBase
     ) -> None:
         """
         :param style: The style owning the ramp
@@ -271,7 +275,7 @@ class RampLegendBase(StyleDefBase.Legend, OWSMetadataConfig):
     METADATA_TICK_LABELS: bool = True
 
     def __init__(
-        self, style_or_mdh: Union["StyleDefBase", "StyleDefBase.Legend"], cfg: CFG_DICT
+        self, style_or_mdh: StyleDefBase | StyleDefBase.Legend, cfg: CFG_DICT
     ) -> None:
         super().__init__(style_or_mdh, cfg)
         raw_cfg = cast("CFG_DICT", self._raw_cfg)
@@ -512,7 +516,7 @@ class ColorRampDef(StyleDefBase):
 
     def __init__(
         self,
-        product: "OWSNamedLayer",
+        product: OWSNamedLayer,
         style_cfg: CFG_DICT,
         stand_alone: bool = False,
         defer_multi_date: bool = False,
@@ -592,7 +596,7 @@ class ColorRampDef(StyleDefBase):
     class MultiDateHandler(StyleDefBase.MultiDateHandler):
         auto_legend = True
 
-        def __init__(self, style: "ColorRampDef", cfg: CFG_DICT) -> None:
+        def __init__(self, style: ColorRampDef, cfg: CFG_DICT) -> None:
             """
             First stage initialisation
 

--- a/datacube_ows/tile_matrix_sets.py
+++ b/datacube_ows/tile_matrix_sets.py
@@ -63,7 +63,7 @@ class TileMatrixSet(OWSConfigEntry):
             "crs": "EPSG:3857",
             "matrix_origin": [-20037508.3427892, 20037508.3427892],
             "tile_size": [256, 256],
-            "scale_set": cast(RAW_CFG, webmerc_scale_set),
+            "scale_set": cast("RAW_CFG", webmerc_scale_set),
             "wkss": "urn:ogc:def:wkss:OGC:1.0:GoogleMapsCompatible",
         }
     }
@@ -73,41 +73,41 @@ class TileMatrixSet(OWSConfigEntry):
         self.global_cfg = global_cfg
         self.identifier = identifier
 
-        self.crs_name = cast(str, cfg["crs"])
+        self.crs_name = cast("str", cfg["crs"])
         if self.crs_name not in self.global_cfg.published_CRSs:
             raise ConfigException(
                 f"Tile matrix set {identifier} has unpublished CRS: {self.crs_name}"
             )
-        matrix_origin = cast(list, cfg["matrix_origin"])
+        matrix_origin = cast("list", cfg["matrix_origin"])
         validate_2d_array(matrix_origin, identifier, "Matrix origin", float)
-        self.matrix_origin = cast(list[float], matrix_origin)
+        self.matrix_origin = cast("list[float]", matrix_origin)
         if len(self.matrix_origin) != 2:
             raise ConfigException(
                 f"The origin coordinates of tile matrix set {identifier} must have 2 dimensions"
             )
-        tile_size = cast(list, cfg["tile_size"])
+        tile_size = cast("list", cfg["tile_size"])
         validate_2d_array(tile_size, identifier, "Tile size", int)
         if len(tile_size) != 2:
             raise ConfigException(
                 f"The tile size of tile matrix set {identifier} must have 2 dimensions"
             )
-        self.tile_size = cast(list[int], tile_size)
-        scale_set = cast(list, cfg["scale_set"])
+        self.tile_size = cast("list[int]", tile_size)
+        scale_set = cast("list", cfg["scale_set"])
         try:
             validate_array_typ(scale_set, identifier, "Scale set", float)
         except TypeError:
             raise ConfigException(
                 f"In tile matrix set {identifier}, scale_set is not a list"
             ) from None
-        self.scale_set = cast(list[float], scale_set)
+        self.scale_set = cast("list[float]", scale_set)
         if len(self.scale_set) < 1:
             raise ConfigException(
                 f"Tile matrix set {identifier} has no scale denominators in scale_set"
             )
         self.force_raw_crs_name = bool(cfg.get("force_raw_crs_name", False))
-        self.wkss = cast(str | None, cfg.get("wkss"))
+        self.wkss = cast("str | None", cfg.get("wkss"))
         initial_matrix_exponents = cast(
-            list, cfg.get("matrix_exponent_initial_offsets", [0, 0])
+            "list", cfg.get("matrix_exponent_initial_offsets", [0, 0])
         )
         validate_2d_array(
             initial_matrix_exponents, identifier, "Initial matrix exponents", int
@@ -116,14 +116,14 @@ class TileMatrixSet(OWSConfigEntry):
             raise ConfigException(
                 f"The initial matrix exponents of tile matrix set {identifier} must have 2 dimensions"
             )
-        self.initial_matrix_exponents = cast(list[int], initial_matrix_exponents)
-        unit_coefficients = cast(list, cfg.get("unit_coefficients", [1.0, -1.0]))
+        self.initial_matrix_exponents = cast("list[int]", initial_matrix_exponents)
+        unit_coefficients = cast("list", cfg.get("unit_coefficients", [1.0, -1.0]))
         validate_2d_array(unit_coefficients, identifier, "Unit coefficients", float)
         if len(unit_coefficients) != 2:
             raise ConfigException(
                 f"The unit coefficients of tile matrix set {identifier} must have 2 dimensions"
             )
-        self.unit_coefficients = cast(list[float], unit_coefficients)
+        self.unit_coefficients = cast("list[float]", unit_coefficients)
 
     @property
     def crs_cfg(self) -> CFG_DICT:

--- a/datacube_ows/tile_matrix_sets.py
+++ b/datacube_ows/tile_matrix_sets.py
@@ -3,13 +3,15 @@
 #
 # Copyright (c) 2017-2024 OWS Contributors
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 from typing import cast
 
-from datacube_ows.config_utils import CFG_DICT, RAW_CFG, ConfigException, OWSConfigEntry
+from datacube_ows.config_utils import ConfigException, OWSConfigEntry
 
 TYPE_CHECKING = False
 if TYPE_CHECKING:
+    from datacube_ows.config_utils import CFG_DICT, RAW_CFG
     from datacube_ows.ows_configuration import OWSConfig
 
 # Scale denominators for WebMercator QuadTree Scale Set, starting from zoom level 0.
@@ -68,7 +70,7 @@ class TileMatrixSet(OWSConfigEntry):
         }
     }
 
-    def __init__(self, identifier: str, cfg: CFG_DICT, global_cfg: "OWSConfig") -> None:
+    def __init__(self, identifier: str, cfg: CFG_DICT, global_cfg: OWSConfig) -> None:
         super().__init__(cfg)
         self.global_cfg = global_cfg
         self.identifier = identifier

--- a/datacube_ows/time_utils.py
+++ b/datacube_ows/time_utils.py
@@ -3,18 +3,23 @@
 #
 # Copyright (c) 2017-2024 OWS Contributors
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import datetime
 import logging
 from zoneinfo import ZoneInfo
 
-from datacube.model import Dataset
 from dateutil.parser import parse
-from odc.geo import CRS, Geometry
-from odc.geo.geobox import GeoBox
+from odc.geo import CRS
 from timezonefinder import TimezoneFinder
 
-from datacube_ows.config_utils import OWSExtensibleConfigEntry
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from datacube.model import Dataset
+    from odc.geo import Geometry
+    from odc.geo.geobox import GeoBox
+
+    from datacube_ows.config_utils import OWSExtensibleConfigEntry
 
 _LOG: logging.Logger = logging.getLogger(__name__)
 tf = TimezoneFinder(in_memory=True)

--- a/datacube_ows/update_ranges.py
+++ b/datacube_ows/update_ranges.py
@@ -4,22 +4,28 @@
 #
 # Copyright (c) 2017-2024 OWS Contributors
 # SPDX-License-Identifier: Apache-2.0
-
+from __future__ import annotations
 
 import sys
 
 import click
 from datacube import Datacube
-from datacube.cfg import ODCEnvironment
 from datacube.index import IndexSetupError
 from sqlalchemy.exc import OperationalError, ProgrammingError
 
 from datacube_ows import __version__
 from datacube_ows.config_utils import ConfigException, OWSConfigNotReady
-from datacube_ows.index import AbortRun, LayerSignature, ows_index
+from datacube_ows.index import AbortRun, ows_index
 from datacube_ows.index.api import InsufficientDbPrivileges
-from datacube_ows.ows_configuration import OWSConfig, get_config
+from datacube_ows.ows_configuration import get_config
 from datacube_ows.startup_utils import initialise_debugging
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from datacube.cfg import ODCEnvironment
+
+    from datacube_ows.index import LayerSignature
+    from datacube_ows.ows_configuration import OWSConfig
 
 
 @click.command()

--- a/datacube_ows/utils.py
+++ b/datacube_ows/utils.py
@@ -37,7 +37,7 @@ def log_call(func: F) -> F:
         _LOG.debug("%s args: %s kwargs: %s", func.__name__, args, kwargs)
         return func(*args, **kwargs)
 
-    return cast(F, log_wrapper)
+    return cast("F", log_wrapper)
 
 
 def time_call(func: F) -> F:
@@ -59,7 +59,7 @@ def time_call(func: F) -> F:
         _LOG.debug("%s took: %d ms", func.__name__, int((stop - start) * 1000))
         return result
 
-    return cast(F, timing_wrapper)
+    return cast("F", timing_wrapper)
 
 
 def group_by_begin_datetime(

--- a/datacube_ows/utils.py
+++ b/datacube_ows/utils.py
@@ -3,22 +3,28 @@
 #
 # Copyright (c) 2017-2024 OWS Contributors
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import datetime
 import logging
-from collections.abc import Callable, Generator
+from collections.abc import Callable
 from contextlib import contextmanager
 from functools import wraps
 from time import monotonic
 from typing import Any, TypeVar, cast
 
-from datacube import Datacube
 from datacube.api.query import GroupBy, solar_day
-from datacube.index import Index
-from datacube.model import Dataset
 from numpy import datetime64 as npdt64
-from numpy import timedelta64 as npdelt64
-from sqlalchemy.engine.base import Connection
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+    from datacube import Datacube
+    from datacube.index import Index
+    from datacube.model import Dataset
+    from numpy import timedelta64 as npdelt64
+    from sqlalchemy.engine.base import Connection
 
 F = TypeVar("F", bound=Callable[..., Any])
 

--- a/datacube_ows/wcs1.py
+++ b/datacube_ows/wcs1.py
@@ -15,13 +15,13 @@ from datacube_ows.http_utils import (
     json_response,
 )
 from datacube_ows.ogc_exceptions import WCS1Exception
-from datacube_ows.ows_configuration import OWSConfig
 from datacube_ows.query_profiler import QueryProfiler
 from datacube_ows.utils import log_call
 from datacube_ows.wcs1_utils import WCS1GetCoverageRequest, get_coverage_data
 
 TYPE_CHECKING = False
 if TYPE_CHECKING:
+    from datacube_ows.ows_configuration import OWSConfig
     from datacube_ows.protocol_versions import FlaskResponse
 
 WCS_REQUESTS = ("DESCRIBECOVERAGE", "GETCOVERAGE")

--- a/datacube_ows/wcs1_utils.py
+++ b/datacube_ows/wcs1_utils.py
@@ -9,7 +9,6 @@ from datetime import UTC
 
 import numpy
 import xarray
-import xarray as xr
 from affine import Affine
 from dateutil.parser import parse
 from odc.geo import geom
@@ -25,6 +24,8 @@ from datacube_ows.wcs_utils import get_bands_from_styles
 
 TYPE_CHECKING = False
 if TYPE_CHECKING:
+    import xarray as xr
+
     from datacube_ows.ows_configuration import OWSConfig
 
 

--- a/datacube_ows/wcs2.py
+++ b/datacube_ows/wcs2.py
@@ -25,13 +25,13 @@ from datacube_ows.http_utils import (
     resp_headers,
 )
 from datacube_ows.ogc_exceptions import WCS2Exception
-from datacube_ows.ows_configuration import OWSConfig
 from datacube_ows.query_profiler import QueryProfiler
 from datacube_ows.utils import log_call
 from datacube_ows.wcs2_utils import get_coverage_data
 
 TYPE_CHECKING = False
 if TYPE_CHECKING:
+    from datacube_ows.ows_configuration import OWSConfig
     from datacube_ows.protocol_versions import FlaskResponse
 
 _LOG: logging.Logger = logging.getLogger(__name__)

--- a/datacube_ows/wcs2_utils.py
+++ b/datacube_ows/wcs2_utils.py
@@ -7,10 +7,8 @@ from __future__ import annotations
 
 import collections
 import logging
-from datetime import date, datetime
 
 import numpy
-import xarray as xr
 from dateutil.parser import parse
 from odc.geo.geobox import GeoBox
 from ows.wcs.v20 import ScaleAxis, ScaleExtent, ScaleSize, Slice, Trim
@@ -24,6 +22,10 @@ from datacube_ows.wcs_scaler import WCSScaler, WCSScalerUnknownDimension
 
 TYPE_CHECKING = False
 if TYPE_CHECKING:
+    from datetime import date, datetime
+
+    import xarray as xr
+
     from datacube_ows.ows_configuration import OWSConfig
 
 _LOG: logging.Logger = logging.getLogger(__name__)

--- a/datacube_ows/wms.py
+++ b/datacube_ows/wms.py
@@ -12,11 +12,11 @@ from datacube_ows.feature_info import feature_info
 from datacube_ows.http_utils import cache_control_headers, get_service_base_url
 from datacube_ows.legend_generator import legend_graphic
 from datacube_ows.ogc_exceptions import WMSException
-from datacube_ows.ows_configuration import OWSConfig
 from datacube_ows.utils import log_call
 
 TYPE_CHECKING = False
 if TYPE_CHECKING:
+    from datacube_ows.ows_configuration import OWSConfig
     from datacube_ows.protocol_versions import FlaskResponse
 
 WMS_REQUESTS = ("GETMAP", "GETFEATUREINFO", "GETLEGENDGRAPHIC")

--- a/datacube_ows/wms_utils.py
+++ b/datacube_ows/wms_utils.py
@@ -3,9 +3,10 @@
 #
 # Copyright (c) 2017-2024 OWS Contributors
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import math
-from datetime import UTC, date, datetime
+from datetime import UTC, datetime
 
 import numpy
 import regex as re
@@ -15,18 +16,25 @@ from dateutil.relativedelta import relativedelta
 from matplotlib import pyplot as plt
 from odc.geo import geom
 from odc.geo.crs import CRS
-from odc.geo.geobox import GeoBox
 from rasterio.warp import Resampling
 from typing_extensions import override
 
 from datacube_ows.config_utils import ConfigException
 from datacube_ows.ogc_exceptions import WMSException
 from datacube_ows.ogc_utils import create_geobox
-from datacube_ows.ows_configuration import OWSConfig, OWSNamedLayer
 from datacube_ows.resource_limits import RequestScale
-from datacube_ows.styles import StyleDef, StyleDefBase
+from datacube_ows.styles import StyleDef
 from datacube_ows.styles.expression import ExpressionException
 from datacube_ows.utils import default_to_utc, find_matching_date
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from datetime import date
+
+    from odc.geo.geobox import GeoBox
+
+    from datacube_ows.ows_configuration import OWSConfig, OWSNamedLayer
+    from datacube_ows.styles import StyleDefBase
 
 RESAMPLING_METHODS = {
     "nearest": Resampling.nearest,

--- a/datacube_ows/wmts.py
+++ b/datacube_ows/wmts.py
@@ -13,11 +13,11 @@ from datacube_ows.data import get_map
 from datacube_ows.feature_info import feature_info
 from datacube_ows.http_utils import cache_control_headers, get_service_base_url
 from datacube_ows.ogc_exceptions import WMSException, WMTSException
-from datacube_ows.ows_configuration import OWSConfig
 from datacube_ows.utils import log_call
 
 TYPE_CHECKING = False
 if TYPE_CHECKING:
+    from datacube_ows.ows_configuration import OWSConfig
     from datacube_ows.protocol_versions import FlaskResponse
 
 _LOG: logging.Logger = logging.getLogger(__name__)

--- a/integration_tests/cfg/utils.py
+++ b/integration_tests/cfg/utils.py
@@ -3,9 +3,13 @@
 #
 # Copyright (c) 2017-2024 OWS Contributors
 # SPDX-License-Identifier: Apache-2.0
-from collections.abc import Callable
+from __future__ import annotations
 
-import xarray as xr
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    import xarray as xr
 
 
 def trivial_identity(x):

--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -3,18 +3,22 @@
 #
 # Copyright (c) 2017-2024 OWS Contributors
 # SPDX-License-Identifier: Apache-2.0
-
+from __future__ import annotations
 
 import os
-from collections.abc import Generator
 
 import pytest
 from click.testing import CliRunner
 from datacube.cfg import ODCConfig
-from flask import Flask
 from pytest_localserver.http import WSGIServer
 
 from datacube_ows import create_app
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+    from flask import Flask
 
 
 @pytest.fixture(scope="session")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,6 +118,7 @@ extend-exclude = [
 ]
 
 [tool.ruff.lint]
+future-annotations = true
 select = [
     "A",  # Don't shadow built-ins
     "B",  # flake8-bugbear
@@ -134,6 +135,7 @@ select = [
     "W",  # pycodestyle warnings
     "F",  # pyflakes
     "T10", # flake8-debugger
+    "TC",  # Import types in TYPE_CHECKING block
 ]
 ignore = [
     "B026",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,20 +3,26 @@
 #
 # Copyright (c) 2017-2024 OWS Contributors
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import datetime
-from collections.abc import Generator
 from typing import Any
 from unittest.mock import MagicMock
 
-import flask
 import numpy as np
 import pytest
 import xarray as xr
 from datacube.cfg import ODCConfig
 
-from datacube_ows.config_utils import CFG_DICT
 from tests.utils import coords, dim1_da, dim1_da_time, dummy_da
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+    import flask
+
+    from datacube_ows.config_utils import CFG_DICT
 
 
 @pytest.fixture

--- a/tests/test_band_utils.py
+++ b/tests/test_band_utils.py
@@ -6,7 +6,8 @@
 
 """Test band math utilities"""
 
-from collections.abc import Callable, Sequence
+from __future__ import annotations
+
 from typing import Literal
 
 import numpy as np
@@ -33,6 +34,10 @@ from datacube_ows.band_utils import (
     sum_bands,
 )
 from datacube_ows.ows_configuration import BandIndex, OWSProductLayer
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Callable, Sequence
 
 
 class MockArray(xr.DataArray):

--- a/tests/test_cfg_tile_matrix_set.py
+++ b/tests/test_cfg_tile_matrix_set.py
@@ -3,13 +3,18 @@
 #
 # Copyright (c) 2017-2024 OWS Contributors
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 from unittest.mock import MagicMock
 
 import pytest
 
-from datacube_ows.config_utils import CFG_DICT, ConfigException
+from datacube_ows.config_utils import ConfigException
 from datacube_ows.tile_matrix_sets import TileMatrixSet
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from datacube_ows.config_utils import CFG_DICT
 
 
 @pytest.fixture

--- a/tests/test_multidate_handler.py
+++ b/tests/test_multidate_handler.py
@@ -3,12 +3,15 @@
 #
 # Copyright (c) 2017-2024 OWS Contributors
 # SPDX-License-Identifier: Apache-2.0
-
 import numpy as np
 import pytest
 
-from datacube_ows.config_utils import CFG_DICT, ConfigException
+from datacube_ows.config_utils import ConfigException
 from datacube_ows.styles.base import StyleDefBase
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from datacube_ows.config_utils import CFG_DICT
 
 
 def test_multidate_handler() -> None:

--- a/tests/test_protocol_versions.py
+++ b/tests/test_protocol_versions.py
@@ -3,13 +3,17 @@
 #
 # Copyright (c) 2017-2024 OWS Contributors
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import pytest
 
 import datacube_ows.protocol_versions
 from datacube_ows.ogc_exceptions import OGCException
-from datacube_ows.ows_configuration import OWSConfig
-from datacube_ows.protocol_versions import FlaskResponse, SupportedSvc
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from datacube_ows.ows_configuration import OWSConfig
+    from datacube_ows.protocol_versions import FlaskResponse, SupportedSvc
 
 
 class DummyException1(OGCException):

--- a/tests/test_style_api.py
+++ b/tests/test_style_api.py
@@ -3,13 +3,13 @@
 #
 # Copyright (c) 2017-2024 OWS Contributors
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 from decimal import Decimal
 
 import pytest
-import xarray as xr
 
-from datacube_ows.config_utils import CFG_DICT, ConfigException
+from datacube_ows.config_utils import ConfigException
 from datacube_ows.styles.api import (
     StandaloneStyle,
     apply_ows_style,
@@ -22,6 +22,12 @@ from datacube_ows.styles.api import (
     plot_image_with_style_cfg,
     xarray_image_as_png,
 )
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    import xarray as xr
+
+    from datacube_ows.config_utils import CFG_DICT
 
 
 def test_indirect_imports() -> None:

--- a/tests/test_styles.py
+++ b/tests/test_styles.py
@@ -3,6 +3,7 @@
 #
 # Copyright (c) 2017-2024 OWS Contributors
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import datetime
 from unittest.mock import MagicMock, patch
@@ -13,8 +14,12 @@ from typing_extensions import override
 from xarray import DataArray, Dataset, concat
 
 import datacube_ows.styles
-from datacube_ows.config_utils import CFG_DICT, ConfigException, OWSEntryNotFound
+from datacube_ows.config_utils import ConfigException, OWSEntryNotFound
 from datacube_ows.ows_configuration import BandIndex, OWSProductLayer
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from datacube_ows.config_utils import CFG_DICT
 
 
 @pytest.fixture


### PR DESCRIPTION
Reduce the dependencies required
for running datacube-ows-update
by importing type signature symbols
in the TYPE_CHECKING block.

Refs #1549

<!-- readthedocs-preview datacube-ows start -->
----
📚 Documentation preview 📚: https://datacube-ows--1552.org.readthedocs.build/en/1552/

<!-- readthedocs-preview datacube-ows end -->