### PR TITLE
Dockerfile: switch to gthread worker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -130,9 +130,10 @@ ENTRYPOINT ["/usr/local/bin/remap-user.sh"]
 CMD [\
     "gunicorn", \
     "-b", "0.0.0.0:8000", \
-    "--workers=3", \
+    "--workers=2", \
+    "--threads=2", \
     "-k", \
-    "gevent", \
+    "gthread", \
     "--timeout", "121", \
     "--pid", "/home/ubuntu/gunicorn.pid", \
     "--log-level", "info", \


### PR DESCRIPTION
Use gthread instead of gevent
as the gunicorn worker type.
This should reduce the memory
consumption compared to
the previous gevent worker
type.

<!-- readthedocs-preview datacube-ows start -->
----
📚 Documentation preview 📚: https://datacube-ows--1555.org.readthedocs.build/en/1555/

<!-- readthedocs-preview datacube-ows end -->