### PR TITLE
Move create_app to startup_utils

### DIFF
--- a/datacube_ows/__init__.py
+++ b/datacube_ows/__init__.py
@@ -11,6 +11,4 @@ except ImportError:
     # Will only be used when running datacube-ows direct from source code (not properly installed)
     __version__ = "1.9.8"
 
-from .startup_utils import create_app
-
-__all__ = ["__version__", "create_app"]
+__all__ = ["__version__"]

--- a/datacube_ows/wsgi.py
+++ b/datacube_ows/wsgi.py
@@ -16,7 +16,8 @@ sys.path.append("/src")
 if os.path.isfile("/src/odc/.datacube.conf.local"):
     os.environ.setdefault("ODC_CONFIG_PATH", "/src/odc/.datacube.conf.local")
 
-from datacube_ows import __version__, create_app
+from datacube_ows import __version__
+from datacube_ows.startup_utils import create_app
 
 application = create_app()
 

--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -12,7 +12,7 @@ from click.testing import CliRunner
 from datacube.cfg import ODCConfig
 from pytest_localserver.http import WSGIServer
 
-from datacube_ows import create_app
+from datacube_ows.startup_utils import create_app
 
 TYPE_CHECKING = False
 if TYPE_CHECKING:


### PR DESCRIPTION
Stop importing create_app in
datacube_ows to avoid loading
in the entire application
when starting datacube-ows-update.

Refs #1549

<!-- readthedocs-preview datacube-ows start -->
----
📚 Documentation preview 📚: https://datacube-ows--1561.org.readthedocs.build/en/1561/

<!-- readthedocs-preview datacube-ows end -->