### PR TITLE
Reduce transitive imports in update_ranges

### DIFF
--- a/cfg_parser.py
+++ b/cfg_parser.py
@@ -5,7 +5,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from datacube_ows.cfg_parser_impl import main
-from datacube_ows.startup_utils import initialise_debugging
+from datacube_ows.debug import initialise_debugging
 
 if __name__ == "__main__":
     initialise_debugging()

--- a/datacube_ows/config_utils.py
+++ b/datacube_ows/config_utils.py
@@ -17,7 +17,6 @@ from urllib.parse import urlparse
 
 import fsspec
 from datacube.utils.masking import make_mask
-from flask_babel import gettext as _
 from typing_extensions import override
 
 from datacube_ows.config_toolkit import deepinherit
@@ -488,6 +487,8 @@ class OWSMetadataConfig(OWSConfigEntry):
         """
         lookup = f"{lbl}.{fld}"
         if self.global_config().internationalised:
+            from flask_babel import gettext as _
+
             trans = _(lookup)
             if trans != lookup:
                 return trans

--- a/datacube_ows/data.py
+++ b/datacube_ows/data.py
@@ -7,19 +7,20 @@ from __future__ import annotations
 
 import logging
 from datetime import date, datetime, timedelta
+from io import BytesIO
 from typing import Any
 
 import numpy
 import numpy.ma
 import xarray
 from pandas import Timestamp
+from PIL import Image
 from rasterio.features import rasterize
 from rasterio.io import MemoryFile
 
 from datacube_ows.http_utils import json_response, png_response
 from datacube_ows.loading import DataStacker
 from datacube_ows.ogc_exceptions import WMSException
-from datacube_ows.ogc_utils import xarray_image_as_png
 from datacube_ows.query_profiler import QueryProfiler
 from datacube_ows.resource_limits import ResourceLimited
 from datacube_ows.time_utils import solar_date, tz_for_geometry
@@ -315,3 +316,110 @@ def _write_polygon(
             for idx, fill in enumerate(zoom_fill, start=1):
                 thing.write_band(idx, data * fill)
         return memfile.read()
+
+
+def xarray_image_as_png(
+    img_data: xarray.Dataset,
+    loop_over=None,
+    animate: bool = False,
+    frame_duration: int = 1000,
+):
+    """
+    Render an Xarray image as a PNG.
+
+    :param img_data: An xarray dataset, containing 3 or 4 uint8 variables: red, green,
+                blue, and optionally alpha.
+    :param loop_over: Optional name of a dimension on img_data.  If set,
+                xarray_image_as_png is called in a loop over all coordinate values for
+                the named dimension.
+    :param animate: Optional generate animated PNG
+    :return: A list of bytes representing a PNG image file. (Or a list of lists of
+                bytes, if loop_over was set.)
+    """
+    if loop_over and not animate:
+        return [
+            xarray_image_as_png(img_data.sel(**{loop_over: coord}))
+            for coord in img_data.coords[loop_over].values
+        ]
+    xcoord = None
+    ycoord = None
+    for cc in ("x", "longitude", "Longitude", "long", "lon"):
+        if cc in img_data.coords:
+            xcoord = cc
+            break
+    for cc in ("y", "latitude", "Latitude", "lat"):
+        if cc in img_data.coords:
+            ycoord = cc
+            break
+    if not xcoord or not ycoord:
+        raise Exception("Could not identify spatial coordinates")
+    width = len(img_data.coords[xcoord])
+    height = len(img_data.coords[ycoord])
+    img_io = BytesIO()
+    # Render XArray to APNG via Pillow
+    # https://pillow.readthedocs.io/en/stable/handbook/image-file-formats.html#apng-sequences
+    if loop_over and animate:
+        time_slices_array = [
+            xarray_image_as_png(img_data.sel(**{loop_over: coord}), animate=True)
+            for coord in img_data.coords[loop_over].values
+        ]
+        images = []
+
+        for t_slice in time_slices_array:
+            im = Image.fromarray(t_slice)
+            images.append(im)
+        images[0].save(
+            img_io,
+            "PNG",
+            save_all=True,
+            default_image=True,
+            loop=0,
+            duration=frame_duration,
+            append_images=images,
+        )
+        img_io.seek(0)
+        return img_io.read()
+
+    if "time" in img_data.dims:
+        img_data = img_data.squeeze(dim="time", drop=True)
+
+    pillow_data = render_frame(img_data.transpose(xcoord, ycoord), width, height)
+    if not loop_over and animate:
+        return pillow_data
+
+    # Change PNG rendering to Pillow
+    im_final = Image.fromarray(pillow_data)
+    im_final.save(img_io, "PNG")
+    img_io.seek(0)
+    return img_io.read()
+
+
+def render_frame(img_data: xarray.Dataset, width: int, height: int) -> numpy.ndarray:
+    """Render to a 3D numpy array an Xarray RGB(A) Dataset input
+
+    Args:
+        img_data ([type]): Input 3D XArray
+        width ([type]): Width of the frame to render
+        height ([type]): Height of the frame to render
+
+    Returns:
+        numpy.ndarray: 3D Rendered Xarray as numpy array
+    """
+    masked = False
+    last_band = None
+    buffer = numpy.zeros((4, width, height), numpy.uint8)
+    band_index = {"red": 0, "green": 1, "blue": 2, "alpha": 3}
+    for band_var in img_data.data_vars:
+        band = str(band_var)
+        index = band_index[band]
+        band_data = img_data[band].values
+        if band == "alpha":
+            masked = True
+        buffer[index, :, :] = band_data
+        last_band = band_data
+    if not masked:
+        assert last_band is not None  # For typechecker.
+        alpha_mask = numpy.empty(last_band.shape).astype("uint8")
+        alpha_mask.fill(255)
+        buffer[3, :, :] = alpha_mask
+    return buffer.transpose()

--- a/datacube_ows/debug.py
+++ b/datacube_ows/debug.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import os
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from logging import Logger
+
+
+def initialise_debugging(log: Logger | None = None) -> None:
+    # PYCHARM Debugging
+    dbg = os.environ.get("PYDEV_DEBUG")
+    if dbg and dbg.lower() not in ("no", "false", "f", "n"):
+        import pydevd_pycharm
+
+        pydevd_pycharm.settrace(
+            "172.17.0.1", port=12321, stdout_to_server=True, stderr_to_server=True
+        )
+        if log:
+            log.info("PyCharm Debugging enabled")

--- a/datacube_ows/feature_info.py
+++ b/datacube_ows/feature_info.py
@@ -12,13 +12,14 @@ from typing import cast
 
 import numpy
 from datacube.utils.masking import mask_to_dict
+from flask import render_template
 from odc.geo import geom
 from odc.geo.crs import CRS
 from odc.geo.geobox import GeoBox
 from pandas import Timestamp
 
 from datacube_ows.config_utils import ConfigException
-from datacube_ows.http_utils import html_json_response, json_response
+from datacube_ows.http_utils import json_response
 from datacube_ows.loading import DataStacker
 from datacube_ows.time_utils import dataset_center_time
 from datacube_ows.utils import log_call
@@ -355,5 +356,6 @@ def feature_info(cfg: OWSConfig, args: dict[str, str]) -> FlaskResponse:
         ],
     }
     if params.format == "text/html":
-        return html_json_response(result, cfg)
+        html_content = render_template("html_feature_info.html", result=result)
+        return html_content, 200, cfg.response_headers({"Content-Type": "text/html"})
     return json_response(result, cfg)

--- a/datacube_ows/http_utils.py
+++ b/datacube_ows/http_utils.py
@@ -8,8 +8,6 @@ from __future__ import annotations
 import json
 from urllib.parse import urlparse
 
-from flask import request
-
 TYPE_CHECKING = False
 if TYPE_CHECKING:
     from collections.abc import Mapping
@@ -86,22 +84,6 @@ def cache_control_headers(max_age: int) -> dict[str, str]:
     if max_age <= 0:
         return {"cache-control": "no-cache"}
     return {"cache-control": f"max-age={max_age}"}
-
-
-def lower_get_args() -> dict[str, str | None]:
-    """
-    Return Flask request arguments, with argument names converted to lower case.
-
-    Get parameters in WMS are case-insensitive, and intended to be single use.
-    Spec does not specify which instance should be used if a parameter is provided more than once.
-    This function uses the LAST instance.
-    """
-    d: dict[str, str | None] = {}
-    for k in request.args:
-        kl = k.lower()
-        for v in request.args.getlist(k):
-            d[kl] = v
-    return d
 
 
 def json_response(result: CFG_DICT, cfg: OWSConfig) -> FlaskResponse:

--- a/datacube_ows/http_utils.py
+++ b/datacube_ows/http_utils.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import json
 from urllib.parse import urlparse
 
-from flask import render_template, request
+from flask import request
 
 TYPE_CHECKING = False
 if TYPE_CHECKING:
@@ -110,11 +110,6 @@ def json_response(result: CFG_DICT, cfg: OWSConfig) -> FlaskResponse:
         200,
         cfg.response_headers({"Content-Type": "application/json"}),
     )
-
-
-def html_json_response(result: CFG_DICT, cfg: OWSConfig) -> FlaskResponse:
-    html_content = render_template("html_feature_info.html", result=result)
-    return html_content, 200, cfg.response_headers({"Content-Type": "text/html"})
 
 
 def png_response(

--- a/datacube_ows/ogc.py
+++ b/datacube_ows/ogc.py
@@ -12,12 +12,7 @@ from flask import render_template, request
 from sqlalchemy.exc import OperationalError
 
 from datacube_ows import __version__
-from datacube_ows.http_utils import (
-    capture_headers,
-    get_service_base_url,
-    lower_get_args,
-    resp_headers,
-)
+from datacube_ows.http_utils import capture_headers, get_service_base_url, resp_headers
 from datacube_ows.index.api import ows_index
 from datacube_ows.legend_generator import create_legend_for_style
 from datacube_ows.ogc_exceptions import OGCException, WMSException
@@ -200,3 +195,19 @@ def legend(
     if not img:
         return "Unknown Style", 404, resp_headers(cfg, {"Content-Type": "text/plain"})
     return img
+
+
+def lower_get_args() -> dict[str, str | None]:
+    """
+    Return Flask request arguments, with argument names converted to lower case.
+
+    Get parameters in WMS are case-insensitive, and intended to be single use.
+    Spec does not specify which instance should be used if a parameter is provided more than once.
+    This function uses the LAST instance.
+    """
+    d: dict[str, str | None] = {}
+    for k in request.args:
+        kl = k.lower()
+        for v in request.args.getlist(k):
+            d[kl] = v
+    return d

--- a/datacube_ows/ogc_exceptions.py
+++ b/datacube_ows/ogc_exceptions.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 
 import traceback as tb
 
-from flask import render_template
 from ows.common.types import OWSException, Version
 from ows.common.v20.encoders import xml_encode_exception_report
 from typing_extensions import override
@@ -45,6 +44,8 @@ class OGCException(Exception):
     def exception_response(
         self, cfg: OWSConfig, traceback: list | None = None
     ) -> FlaskResponse:
+        from flask import render_template
+
         return (
             render_template(
                 "ogc_error.xml",

--- a/datacube_ows/ogc_utils.py
+++ b/datacube_ows/ogc_utils.py
@@ -6,14 +6,12 @@
 from __future__ import annotations
 
 import logging
-from io import BytesIO
 from typing import Any, cast
 
 import numpy
 from affine import Affine
 from deprecat import deprecat
 from odc.geo.geobox import GeoBox
-from PIL import Image
 
 TYPE_CHECKING = False
 if TYPE_CHECKING:
@@ -170,107 +168,3 @@ def create_geobox(
         height = round((float(miny) - float(maxy)) / scale_y)
     affine = Affine.translation(minx, maxy) * Affine.scale(scale_x, scale_y)
     return GeoBox((height, width), affine, crs)
-
-
-def xarray_image_as_png(
-    img_data: xarray.Dataset,
-    loop_over=None,
-    animate: bool = False,
-    frame_duration: int = 1000,
-):
-    """
-    Render an Xarray image as a PNG.
-
-    :param img_data: An xarray dataset, containing 3 or 4 uint8 variables: red, greed, blue, and optionally alpha.
-    :param loop_over: Optional name of a dimension on img_data.  If set, xarray_image_as_png is called in a loop
-                over all coordinate values for the named dimension.
-    :param animate: Optional generate animated PNG
-    :return: A list of bytes representing a PNG image file. (Or a list of lists of bytes, if loop_over was set.)
-    """
-    if loop_over and not animate:
-        return [
-            xarray_image_as_png(img_data.sel(**{loop_over: coord}))
-            for coord in img_data.coords[loop_over].values
-        ]
-    xcoord = None
-    ycoord = None
-    for cc in ("x", "longitude", "Longitude", "long", "lon"):
-        if cc in img_data.coords:
-            xcoord = cc
-            break
-    for cc in ("y", "latitude", "Latitude", "lat"):
-        if cc in img_data.coords:
-            ycoord = cc
-            break
-    if not xcoord or not ycoord:
-        raise Exception("Could not identify spatial coordinates")
-    width = len(img_data.coords[xcoord])
-    height = len(img_data.coords[ycoord])
-    img_io = BytesIO()
-    # Render XArray to APNG via Pillow
-    # https://pillow.readthedocs.io/en/stable/handbook/image-file-formats.html#apng-sequences
-    if loop_over and animate:
-        time_slices_array = [
-            xarray_image_as_png(img_data.sel(**{loop_over: coord}), animate=True)
-            for coord in img_data.coords[loop_over].values
-        ]
-        images = []
-
-        for t_slice in time_slices_array:
-            im = Image.fromarray(t_slice)
-            images.append(im)
-        images[0].save(
-            img_io,
-            "PNG",
-            save_all=True,
-            default_image=True,
-            loop=0,
-            duration=frame_duration,
-            append_images=images,
-        )
-        img_io.seek(0)
-        return img_io.read()
-
-    if "time" in img_data.dims:
-        img_data = img_data.squeeze(dim="time", drop=True)
-
-    pillow_data = render_frame(img_data.transpose(xcoord, ycoord), width, height)
-    if not loop_over and animate:
-        return pillow_data
-
-    # Change PNG rendering to Pillow
-    im_final = Image.fromarray(pillow_data)
-    im_final.save(img_io, "PNG")
-    img_io.seek(0)
-    return img_io.read()
-
-
-def render_frame(img_data: xarray.Dataset, width: int, height: int) -> numpy.ndarray:
-    """Render to a 3D numpy array an Xarray RGB(A) Dataset input
-
-    Args:
-        img_data ([type]): Input 3D XArray
-        width ([type]): Width of the frame to render
-        height ([type]): Height of the frame to render
-
-    Returns:
-        numpy.ndarray: 3D Rendered Xarray as numpy array
-    """
-    masked = False
-    last_band = None
-    buffer = numpy.zeros((4, width, height), numpy.uint8)
-    band_index = {"red": 0, "green": 1, "blue": 2, "alpha": 3}
-    for band_var in img_data.data_vars:
-        band = str(band_var)
-        index = band_index[band]
-        band_data = img_data[band].values
-        if band == "alpha":
-            masked = True
-        buffer[index, :, :] = band_data
-        last_band = band_data
-    if not masked:
-        assert last_band is not None  # For typechecker.
-        alpha_mask = numpy.empty(last_band.shape).astype("uint8")
-        alpha_mask.fill(255)
-        buffer[3, :, :] = alpha_mask
-    return buffer.transpose()

--- a/datacube_ows/ows_configuration.py
+++ b/datacube_ows/ows_configuration.py
@@ -26,8 +26,6 @@ from threading import Lock
 from typing import Any, cast
 
 import numpy
-from babel.messages.catalog import Catalog
-from babel.messages.pofile import read_po
 from datacube import Datacube
 from datacube.cfg import ODCConfig
 from odc.geo import CRS, CRSError
@@ -63,6 +61,7 @@ TYPE_CHECKING = False
 if TYPE_CHECKING:
     from collections.abc import Iterable
 
+    from babel.messages.catalog import Catalog
     from datacube.api.query import GroupBy
     from datacube.cfg import ODCEnvironment
     from datacube.model import Measurement, Product
@@ -1686,6 +1685,8 @@ class OWSConfig(OWSMetadataConfig):
             )
             raise ODCInitException(e) from None
         if self.msg_file_name:
+            from babel.messages.pofile import read_po
+
             try:
                 with open(self.msg_file_name, "rb") as fp:
                     self.set_msg_src(
@@ -1712,6 +1713,8 @@ class OWSConfig(OWSMetadataConfig):
 
     def export_metadata(self) -> Catalog:
         if self.catalog is None:
+            from babel.messages.catalog import Catalog
+
             now = datetime.datetime.now()
             header: str = f"""# Translations for datacube-ows metadata instance:
 #      {self.title}

--- a/datacube_ows/startup_utils/__init__.py
+++ b/datacube_ows/startup_utils/__init__.py
@@ -15,6 +15,8 @@ from typing import Any, TypeVar
 from flask import Flask, g, request
 from sqlalchemy.exc import OperationalError
 
+from datacube_ows.debug import initialise_debugging
+
 TYPE_CHECKING = False
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -43,19 +45,6 @@ def initialise_ignorable_warnings() -> None:
     from rasterio.errors import NotGeoreferencedWarning
 
     warnings.simplefilter("ignore", category=NotGeoreferencedWarning)
-
-
-def initialise_debugging(log: Logger | None = None) -> None:
-    # PYCHARM Debugging
-    dbg = os.environ.get("PYDEV_DEBUG")
-    if dbg and dbg.lower() not in ("no", "false", "f", "n"):
-        import pydevd_pycharm
-
-        pydevd_pycharm.settrace(
-            "172.17.0.1", port=12321, stdout_to_server=True, stderr_to_server=True
-        )
-        if log:
-            log.info("PyCharm Debugging enabled")
 
 
 SentryEvent = TypeVar("SentryEvent")

--- a/datacube_ows/styles/api/__init__.py
+++ b/datacube_ows/styles/api/__init__.py
@@ -16,5 +16,7 @@ from datacube_ows.styles.api.base import (  # noqa: F401 isort:skip
     plot_image_with_style_cfg,
 )
 
-from datacube_ows.ogc_utils import create_geobox, xarray_image_as_png  # noqa: F401 isort:skip
+from datacube_ows.data import xarray_image_as_png  # noqa: F401
+
+from datacube_ows.ogc_utils import create_geobox  # noqa: F401 isort:skip
 from datacube_ows.band_utils import scale_data, scalable, band_modulator  # noqa: F401 isort:skip

--- a/datacube_ows/styles/base.py
+++ b/datacube_ows/styles/base.py
@@ -12,7 +12,6 @@ from typing import Any, cast
 
 import numpy as np
 import xarray as xr
-from PIL import Image
 from typing_extensions import override
 
 from datacube_ows.config_utils import (
@@ -33,6 +32,7 @@ if TYPE_CHECKING:
     from collections.abc import Iterable, Mapping, MutableMapping, Sized
 
     import datacube.model
+    from PIL import Image
 
     from datacube_ows.config_utils import (
         CFG_DICT,
@@ -450,6 +450,8 @@ class StyleDefBase(OWSExtensibleConfigEntry, OWSMetadataConfig):
         :param dates: The number of dates to render the legend for (e.g. for delta)
         :return: A PIL Image object, or None.
         """
+        from PIL import Image
+
         legend = self.get_legend_cfg(dates)
         if not legend.show_legend:
             return None

--- a/datacube_ows/styles/base.py
+++ b/datacube_ows/styles/base.py
@@ -12,7 +12,6 @@ from typing import Any, cast
 
 import numpy as np
 import xarray as xr
-from flask_babel import get_locale
 from PIL import Image
 from typing_extensions import override
 
@@ -458,6 +457,8 @@ class StyleDefBase(OWSExtensibleConfigEntry, OWSMetadataConfig):
         if legend.legend_urls:
             locale: str | None = None
             if self.global_config().internationalised:
+                from flask_babel import get_locale
+
                 locale = get_locale().language
             if locale not in self.global_config().locales:
                 locale = self.global_config().default_locale

--- a/datacube_ows/styles/base.py
+++ b/datacube_ows/styles/base.py
@@ -26,7 +26,6 @@ from datacube_ows.config_utils import (
     OWSFlagBandStandalone,
     OWSMetadataConfig,
 )
-from datacube_ows.legend_utils import get_image_from_url
 from datacube_ows.ogc_exceptions import WMSException
 
 TYPE_CHECKING = False
@@ -455,6 +454,8 @@ class StyleDefBase(OWSExtensibleConfigEntry, OWSMetadataConfig):
         if not legend.show_legend:
             return None
         if legend.legend_urls:
+            from datacube_ows.legend_utils import get_image_from_url
+
             locale: str | None = None
             if self.global_config().internationalised:
                 from flask_babel import get_locale

--- a/datacube_ows/styles/colormap.py
+++ b/datacube_ows/styles/colormap.py
@@ -12,9 +12,6 @@ from typing import cast
 import numpy
 import xarray
 from datacube.utils.masking import make_mask
-from matplotlib import patches as mpatches
-from matplotlib import pyplot as plt
-from matplotlib.colors import to_hex, to_rgba
 from typing_extensions import override
 from xarray import DataArray, Dataset
 
@@ -80,6 +77,8 @@ class AbstractValueMapRule(AbstractMaskRule):
         )
 
     def parse_color(self, cfg: CFG_DICT) -> None:
+        from matplotlib.colors import to_rgba
+
         self.color_str = cast("str", cfg["color"])
         if cfg.get("mask"):
             alpha: float | None = 0.0
@@ -307,6 +306,8 @@ def apply_value_map(
 
 class PatchTemplate:
     def __init__(self, idx: int, rule: AbstractValueMapRule) -> None:
+        from matplotlib.colors import to_hex
+
         self.idx = idx
         self.colour = to_hex(rule.rgba, keep_alpha=True)
         self.label = rule.label
@@ -338,6 +339,9 @@ class ColorMapLegendBase(StyleDefBase.Legend, OWSMetadataConfig):
 
     @override
     def render(self, bytesio: io.BytesIO) -> None:
+        from matplotlib import patches as mpatches
+        from matplotlib import pyplot as plt
+
         patches = [
             mpatches.Patch(color=pt.colour, label=self.patch_label(pt.idx))
             for pt in self.patches

--- a/datacube_ows/update_ranges.py
+++ b/datacube_ows/update_ranges.py
@@ -15,10 +15,10 @@ from sqlalchemy.exc import OperationalError, ProgrammingError
 
 from datacube_ows import __version__
 from datacube_ows.config_utils import ConfigException, OWSConfigNotReady
+from datacube_ows.debug import initialise_debugging
 from datacube_ows.index import AbortRun, ows_index
 from datacube_ows.index.api import InsufficientDbPrivileges
 from datacube_ows.ows_configuration import get_config
-from datacube_ows.startup_utils import initialise_debugging
 
 TYPE_CHECKING = False
 if TYPE_CHECKING:

--- a/tests/test_ogc_utils.py
+++ b/tests/test_ogc_utils.py
@@ -12,6 +12,7 @@ import pytest
 import xarray
 from odc.geo.geom import polygon
 
+import datacube_ows.data
 import datacube_ows.http_utils
 import datacube_ows.ogc_utils
 import datacube_ows.time_utils
@@ -313,7 +314,7 @@ def test_png_loop_over() -> None:
             "alpha": dummy_da(200, "alpha", xyt_coords, dtype="uint8"),
         }
     )
-    imgs = datacube_ows.ogc_utils.xarray_image_as_png(data, loop_over="time")
+    imgs = datacube_ows.data.xarray_image_as_png(data, loop_over="time")
     assert len(imgs) == 2
     assert len(imgs[0]) == 78
     assert imgs[0].find(b"\x89PNG") == 0
@@ -328,9 +329,7 @@ def test_png_loop_over_anim() -> None:
             "alpha": dummy_da(200, "alpha", xyt_coords, dtype="uint8"),
         }
     )
-    imgs = datacube_ows.ogc_utils.xarray_image_as_png(
-        data, loop_over="time", animate=True
-    )
+    imgs = datacube_ows.data.xarray_image_as_png(data, loop_over="time", animate=True)
     assert len(imgs) == 173
     assert imgs.find(b"\x89PNG") == 0
 
@@ -344,7 +343,7 @@ def test_render_frame() -> None:
             "alpha": dummy_da(200, "alpha", xy_coords, dtype="uint8"),
         }
     )
-    png = datacube_ows.ogc_utils.render_frame(data, 5, 2)
+    png = datacube_ows.data.render_frame(data, 5, 2)
     assert png.shape == (2, 5, 4)
     data = xarray.Dataset(
         {
@@ -353,7 +352,7 @@ def test_render_frame() -> None:
             "blue": dummy_da(150, "blue", xy_coords, dtype="uint8"),
         }
     )
-    png = datacube_ows.ogc_utils.render_frame(data, 5, 2)
+    png = datacube_ows.data.render_frame(data, 5, 2)
     assert png.shape == (2, 5, 4)
 
 

--- a/tests/test_startup.py
+++ b/tests/test_startup.py
@@ -92,21 +92,21 @@ def test_initialise_ign_warn() -> None:
 
 def test_initialise_nodebugging(monkeypatch) -> None:
     monkeypatch.setenv("PYDEV_DEBUG", "")
-    from datacube_ows.startup_utils import initialise_debugging
+    from datacube_ows.debug import initialise_debugging
 
     initialise_debugging()
 
 
 def test_initialise_explicit_nodebugging(monkeypatch) -> None:
     monkeypatch.setenv("PYDEV_DEBUG", "no")
-    from datacube_ows.startup_utils import initialise_debugging
+    from datacube_ows.debug import initialise_debugging
 
     initialise_debugging()
 
 
 def test_initialise_debugging(monkeypatch) -> None:
     monkeypatch.setenv("PYDEV_DEBUG", "YES")
-    from datacube_ows.startup_utils import initialise_debugging
+    from datacube_ows.debug import initialise_debugging
 
     fake_mod = MagicMock()
     with patch.dict("sys.modules", pydevd_pycharm=fake_mod):

--- a/tests/test_startup.py
+++ b/tests/test_startup.py
@@ -107,10 +107,13 @@ def test_initialise_explicit_nodebugging(monkeypatch) -> None:
 def test_initialise_debugging(monkeypatch) -> None:
     monkeypatch.setenv("PYDEV_DEBUG", "YES")
     from datacube_ows.debug import initialise_debugging
+    from datacube_ows.startup_utils import initialise_logger
 
     fake_mod = MagicMock()
     with patch.dict("sys.modules", pydevd_pycharm=fake_mod):
-        initialise_debugging()
+        log = initialise_logger("tim.the.testlogger")
+        assert log is not None
+        initialise_debugging(log)
         fake_mod.settrace.assert_called()
 
 

--- a/tests/test_style_api.py
+++ b/tests/test_style_api.py
@@ -10,6 +10,7 @@ from decimal import Decimal
 import pytest
 
 from datacube_ows.config_utils import ConfigException
+from datacube_ows.data import xarray_image_as_png
 from datacube_ows.styles.api import (
     StandaloneStyle,
     apply_ows_style,
@@ -20,7 +21,6 @@ from datacube_ows.styles.api import (
     plot_image,
     plot_image_with_style,
     plot_image_with_style_cfg,
-    xarray_image_as_png,
 )
 
 TYPE_CHECKING = False


### PR DESCRIPTION
Move around functions and imports to reduce what is imported by update_ranges. This is not enough to make update_ranges completely standalone, but it's a start.

Refs #1549 

<!-- readthedocs-preview datacube-ows start -->
----
📚 Documentation preview 📚: https://datacube-ows--1565.org.readthedocs.build/en/1565/

<!-- readthedocs-preview datacube-ows end -->