### PR TITLE
Move ignore warnings to separate module

### DIFF
--- a/datacube_ows/startup_utils/__init__.py
+++ b/datacube_ows/startup_utils/__init__.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 import logging
 import os
 import sys
-import warnings
 from time import monotonic
 from typing import Any, TypeVar
 
@@ -16,6 +15,7 @@ from flask import Flask, g, request
 from sqlalchemy.exc import OperationalError
 
 from datacube_ows.debug import initialise_debugging
+from datacube_ows.warnings import initialise_ignorable_warnings
 
 TYPE_CHECKING = False
 if TYPE_CHECKING:
@@ -38,13 +38,6 @@ def initialise_logger(name: str | None = None) -> Logger:
     # produced by this application
     log.setLevel(logging.getLogger("gunicorn.error").getEffectiveLevel())
     return log
-
-
-def initialise_ignorable_warnings() -> None:
-    # Suppress annoying rasterio warning message every time we write to a non-georeferenced image format
-    from rasterio.errors import NotGeoreferencedWarning
-
-    warnings.simplefilter("ignore", category=NotGeoreferencedWarning)
 
 
 SentryEvent = TypeVar("SentryEvent")

--- a/datacube_ows/styles/api/base.py
+++ b/datacube_ows/styles/api/base.py
@@ -7,8 +7,8 @@ from __future__ import annotations
 
 import xarray
 
-from datacube_ows.startup_utils import initialise_ignorable_warnings
 from datacube_ows.styles.base import StandaloneProductProxy, StyleDefBase
+from datacube_ows.warnings import initialise_ignorable_warnings
 
 TYPE_CHECKING = False
 if TYPE_CHECKING:

--- a/datacube_ows/warnings.py
+++ b/datacube_ows/warnings.py
@@ -1,0 +1,16 @@
+# This file is part of datacube-ows, part of the Open Data Cube project.
+# See https://opendatacube.org for more information.
+#
+# Copyright (c) 2017-2024 OWS Contributors
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+import warnings
+
+
+def initialise_ignorable_warnings() -> None:
+    # Suppress annoying rasterio warning message every time we write to
+    # a non-georeferenced image format.
+    from rasterio.errors import NotGeoreferencedWarning
+
+    warnings.simplefilter("ignore", category=NotGeoreferencedWarning)

--- a/tests/test_startup.py
+++ b/tests/test_startup.py
@@ -85,7 +85,7 @@ def test_initialise_logger() -> None:
 
 
 def test_initialise_ign_warn() -> None:
-    from datacube_ows.startup_utils import initialise_ignorable_warnings
+    from datacube_ows.warnings import initialise_ignorable_warnings
 
     initialise_ignorable_warnings()
 


### PR DESCRIPTION
This function is imported by the style
API, so that depends on Flask. Move
the function to its own module to
avoid bringing in the webserver
stuff when importing the style API.

Refs #1590

<!-- readthedocs-preview datacube-ows start -->
----
📚 Documentation preview 📚: https://datacube-ows--1591.org.readthedocs.build/en/1591/

<!-- readthedocs-preview datacube-ows end -->