### PR TITLE
Allow per-layer override of load_driver.

### DIFF
--- a/datacube_ows/loading.py
+++ b/datacube_ows/loading.py
@@ -460,7 +460,7 @@ class DataStacker:
             skip_broken_datasets=skip_broken,
             patch_url=self._layer.patch_url,
             resampling=resampling,
-            driver=self.cfg.load_driver,
+            driver=self._layer.load_driver,
         )
 
     # TODO: Make skip_broken passed in via config

--- a/datacube_ows/ows_configuration.py
+++ b/datacube_ows/ows_configuration.py
@@ -665,12 +665,12 @@ class OWSNamedLayer(OWSExtensibleConfigEntry, OWSLayer):
         load_driver = cfg.get("load_driver")
         if load_driver is None:
             self.load_driver: str = global_cfg.load_driver
-        elif load_driver not in ["rio", "legacy"]:
+        elif load_driver in ["rio", "legacy"]:
+            self.load_driver = load_driver
+        else:
             raise ConfigException(
                 f"Invalid load_driver: {load_driver} Please use 'rio' or 'legacy' (or None to use the global setting)"
             )
-        else:
-            self.load_driver = cast("str", load_driver)
 
         if global_cfg.user_band_math_extension:
             self.user_band_math = bool(cfg.get("user_band_math", False))

--- a/datacube_ows/ows_configuration.py
+++ b/datacube_ows/ows_configuration.py
@@ -662,6 +662,16 @@ class OWSNamedLayer(OWSExtensibleConfigEntry, OWSLayer):
         self.declare_unready("product")
         self.declare_unready("definition")
 
+        load_driver = cfg.get("load_driver")
+        if load_driver is None:
+            self.load_driver: str = global_cfg.load_driver
+        elif load_driver not in ["rio", "legacy"]:
+            raise ConfigException(
+                f"Invalid load_driver: {load_driver} Please use 'rio' or 'legacy' (or None to use the global setting)"
+            )
+        else:
+            self.load_driver = cast("str", load_driver)
+
         if global_cfg.user_band_math_extension:
             self.user_band_math = bool(cfg.get("user_band_math", False))
         else:
@@ -901,7 +911,7 @@ class OWSNamedLayer(OWSExtensibleConfigEntry, OWSLayer):
             )
 
         if cfg.get("fuse_func"):
-            if self.global_cfg.load_driver == "legacy":
+            if self.load_driver == "legacy":
                 self.fuse_func: FunctionWrapper | str | None = FunctionWrapper(
                     self, cast("str | CFG_DICT", cfg["fuse_func"])
                 )

--- a/docs/cfg_global.rst
+++ b/docs/cfg_global.rst
@@ -26,11 +26,16 @@ You can override this with the ``env`` global config entry::
 Note that this can be over-ridden at the layer level, allowing one OWS instance to serve data
 from multiple indexes.
 
-Loader Driver
-=============
+Load Driver (load_driver)
+=========================
 
-Specifies the ODC loader driver to use.  Currently the default is "legacy".  Set to
+Specifies the global ODC loader driver to use.  Currently the default is "legacy".  Set to
 "rio" to use the rio loader driver from odc-loader.
+
+The "rio" driver offers better performance, but the "legacy" driver offers better support
+for non-standard file formats.
+
+The global ODC loader driver setting can be overridden by individual layers.
 
 Notes:
 

--- a/docs/cfg_layers.rst
+++ b/docs/cfg_layers.rst
@@ -305,6 +305,19 @@ The conditions under which to switch to the low-resolution product(s)
 are defined in the `resource_limits <#resource-limits-resource-limits>`_
 section, discussed below.
 
+-------------------------
+Load Driver (load_driver)
+-------------------------
+
+Specifies the ODC loader driver to use for the layer.  May have one of the following values:
+
+1. ``"legacy"``: Use the legacy ODC loader.
+2. ``"rio"``: Use the "rio" ODC loader.
+3. ``None``: Use the global ``load_driver`` setting.
+
+Note: For non-legacy loader drivers, fuser functions must be specified as a string (fully
+qualified Python name).
+
 -----------------------------------------
 Timeless Mosaic Layers (mosaic_date_func)
 -----------------------------------------
@@ -981,7 +994,7 @@ Fuse Function (fuse_func)
 Determines how multiple dataset arrays are compressed into a
 single time array.
 
-If the global "load_driver" is set to "rio", ``fuse_func`` must be a string
+If the "load_driver" for the layer is set to "rio", ``fuse_func`` must be a string
 representing an importable, fully-qualified python function name (or None).
 
 For the legacy loader only, ``fuse_func`` can be Specified using OWS's :doc:`function configuration

--- a/integration_tests/cfg/ows_test_cfg.py
+++ b/integration_tests/cfg/ows_test_cfg.py
@@ -1121,6 +1121,7 @@ ows_cfg = {
                             "title": "Surface reflectance (Sentinel-2) (postgis db)",
                             "name": "s2_l2a_postgis",
                             "abstract": """layer s2_l2a (postgis db)""",
+                            "load_driver": "legacy",
                             "product_name": "s2_l2a",
                             "bands": bands_sentinel,
                             "env": "owspostgis",

--- a/tests/test_cfg_layer.py
+++ b/tests/test_cfg_layer.py
@@ -921,3 +921,29 @@ def test_native_resolution_mismatch(
     assert lyr.ready
     assert math.isclose(lyr.resolution_x, 0.001, rel_tol=1e-8)
     assert math.isclose(lyr.resolution_y, -0.001, rel_tol=1e-8)
+
+
+def test_load_driver_inherit(
+        minimal_global_cfg, minimal_layer_cfg, minimal_dc, mock_range
+) -> None:
+    lyr = parse_ows_layer(minimal_layer_cfg, global_cfg=minimal_global_cfg)
+    assert lyr.load_driver == minimal_global_cfg.load_driver
+
+
+def test_load_driver_inherit(
+        minimal_global_cfg, minimal_layer_cfg, minimal_dc, mock_range
+) -> None:
+    minimal_global_cfg.load_driver = "rio"
+    minimal_layer_cfg["load_driver"] = "legacy"
+    lyr = parse_ows_layer(minimal_layer_cfg, global_cfg=minimal_global_cfg)
+    assert lyr.load_driver == "legacy"
+
+
+def test_invalid_load_driver(
+        minimal_global_cfg, minimal_layer_cfg, minimal_dc, mock_range
+) -> None:
+    minimal_layer_cfg["load_driver"] = "scoobydoo"
+    with pytest.raises(ConfigException) as e:
+        _ = parse_ows_layer(minimal_layer_cfg, global_cfg=minimal_global_cfg)
+    assert "Invalid load_driver" in str(e.value)
+    assert "scoobydoo" in str(e.value)

--- a/tests/test_cfg_layer.py
+++ b/tests/test_cfg_layer.py
@@ -924,14 +924,14 @@ def test_native_resolution_mismatch(
 
 
 def test_load_driver_inherit(
-        minimal_global_cfg, minimal_layer_cfg, minimal_dc, mock_range
+    minimal_global_cfg, minimal_layer_cfg, minimal_dc, mock_range
 ) -> None:
     lyr = parse_ows_layer(minimal_layer_cfg, global_cfg=minimal_global_cfg)
     assert lyr.load_driver == minimal_global_cfg.load_driver
 
 
-def test_load_driver_inherit(
-        minimal_global_cfg, minimal_layer_cfg, minimal_dc, mock_range
+def test_load_driver_override(
+    minimal_global_cfg, minimal_layer_cfg, minimal_dc, mock_range
 ) -> None:
     minimal_global_cfg.load_driver = "rio"
     minimal_layer_cfg["load_driver"] = "legacy"
@@ -940,7 +940,7 @@ def test_load_driver_inherit(
 
 
 def test_invalid_load_driver(
-        minimal_global_cfg, minimal_layer_cfg, minimal_dc, mock_range
+    minimal_global_cfg, minimal_layer_cfg, minimal_dc, mock_range
 ) -> None:
     minimal_layer_cfg["load_driver"] = "scoobydoo"
     with pytest.raises(ConfigException) as e:


### PR DESCRIPTION
The new "rio" driver is 10-15% faster but cannot load from multi-band COG files. This PR allows individual named layers to override the global load_driver setting.

<!-- readthedocs-preview datacube-ows start -->
----
📚 Documentation preview 📚: https://datacube-ows--1595.org.readthedocs.build/en/1595/

<!-- readthedocs-preview datacube-ows end -->