### PR TITLE
styles: import formula_parser from core

### DIFF
--- a/datacube_ows/styles/expression.py
+++ b/datacube_ows/styles/expression.py
@@ -40,6 +40,70 @@ def not_supported(op_name: object) -> Callable[[object, object], Any]:
     return impl
 
 
+def formula_parser() -> lark.Lark:
+    return lark.Lark(
+        """
+                ?expr: num_expr | bool_expr
+
+                ?bool_expr: or_clause | comparison_clause
+
+                ?or_clause: or_clause "|" and_clause -> or_
+                          | or_clause "^" and_clause -> xor
+                          | and_clause
+                ?and_clause: and_clause "&" term -> and_
+                           | term
+                ?term: "not" term -> not_
+                     | "(" bool_expr ")"
+
+                ?comparison_clause: eq | ne | le | ge | lt | gt
+
+                eq: num_expr "==" num_expr
+                ne: num_expr "!=" num_expr
+                le: num_expr "<=" num_expr
+                ge: num_expr ">=" num_expr
+                lt: num_expr "<" num_expr
+                gt: num_expr ">" num_expr
+
+
+                ?num_expr: shift
+
+                ?shift: shift "<<" sum -> lshift
+                      | shift ">>" sum -> rshift
+                      | sum
+
+                ?sum: sum "+" product -> add
+                    | sum "-" product -> sub
+                    | product
+
+                ?product: product "*" atom -> mul
+                        | product "/" atom -> truediv
+                        | product "//" atom -> floordiv
+                        | product "%" atom -> mod
+                        | atom
+
+                ?atom: "-" subatom -> neg
+                     | "+" subatom -> pos
+                     | "~" subatom -> inv
+                     | subatom "**" atom -> pow
+                     | subatom
+
+                ?subatom: NAME -> var_name
+                        | FLOAT -> float_literal
+                        | INT -> int_literal
+                        | "(" num_expr ")"
+
+
+                %import common.FLOAT
+                %import common.INT
+                %import common.WS_INLINE
+                %import common.CNAME -> NAME
+
+                %ignore WS_INLINE
+                """,
+        start="expr",
+    )
+
+
 @lark.v_args(inline=True)
 class ExpressionEvaluator(lark.Transformer):
     """
@@ -117,8 +181,6 @@ class Expression:
                       (may be a statically configured style, or user-defined).
         :param expr_str: The expression string to be parsed.
         """
-        from datacube.virtual.expr import formula_parser
-
         self.style = style
         self.expr_str = expr_str
         parser = formula_parser()


### PR DESCRIPTION
This is the only ODC package
that uses datacube.virtual.expr,
so put the function in this file
to avoid issues when this
is removed from core.

<!-- readthedocs-preview datacube-ows start -->
----
📚 Documentation preview 📚: https://datacube-ows--1608.org.readthedocs.build/en/1608/

<!-- readthedocs-preview datacube-ows end -->