### PR TITLE
readthedocs: use Ubuntu 26.04/Python 3.14

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -8,9 +8,9 @@ version: 2
 # uv build from the documentation at:
 # https://docs.readthedocs.com/platform/latest/build-customization.html#install-dependencies-with-uv
 build:
-  os: ubuntu-24.04
+  os: ubuntu-26.04
   tools:
-    python: "3.12"
+    python: "3.14"
   jobs:
     post_checkout:
       - git fetch --prune --unshallow


### PR DESCRIPTION
Bump the build environment to
the latest Ubuntu LTS and its
Python version.

<!-- readthedocs-preview datacube-ows start -->
----
📚 Documentation preview 📚: https://datacube-ows--1619.org.readthedocs.build/en/1619/

<!-- readthedocs-preview datacube-ows end -->