### PR TITLE
Bypass spatial search

### DIFF
--- a/datacube_ows/index/postgis/api.py
+++ b/datacube_ows/index/postgis/api.py
@@ -179,7 +179,9 @@ class OWSPostgisIndex(OWSAbstractIndex):
         products: Iterable[Product] | None = None,
     ) -> Iterable[Dataset]:
         return layer.dc.index.datasets.search(
-            **self._query(layer, times, geom, products)
+            **self._query(
+                layer, times, None if layer.bypass_spatial_search else geom, products
+            )
         )
 
     @override

--- a/datacube_ows/index/postgres/api.py
+++ b/datacube_ows/index/postgres/api.py
@@ -125,7 +125,7 @@ class OWSPostgresIndex(OWSAbstractIndex):
                 layer.dc,
                 MVSelectOpts.DATASETS,
                 times=times,
-                geom=geom,
+                geom=None if layer.bypass_spatial_search else geom,
                 products=products,
             ),
         )

--- a/datacube_ows/ows_configuration.py
+++ b/datacube_ows/ows_configuration.py
@@ -755,6 +755,7 @@ class OWSNamedLayer(OWSExtensibleConfigEntry, OWSLayer):
 
         self.dynamic = cfg.get("dynamic", False)
 
+        self.bypass_spatial_search = bool(cfg.get("bypass_spatial_search"))
         self._ranges: LayerExtent | None = None
         self.bboxes: CFG_DICT = {}
         self.default_time: datetime.datetime | datetime.date | None = None

--- a/docs/cfg_layers.rst
+++ b/docs/cfg_layers.rst
@@ -318,6 +318,13 @@ Specifies the ODC loader driver to use for the layer.  May have one of the follo
 Note: For non-legacy loader drivers, fuser functions must be specified as a string (fully
 qualified Python name).
 
+---------------------------------------------
+Bypass Spatial Search (bypass_spatial_search)
+---------------------------------------------
+
+For products that are known to only have a single dataset per time-slice, setting the
+``bypass_spatial_search`` element to ``True`` may result in faster database searches.
+
 -----------------------------------------
 Timeless Mosaic Layers (mosaic_date_func)
 -----------------------------------------

--- a/integration_tests/cfg/ows_test_cfg.py
+++ b/integration_tests/cfg/ows_test_cfg.py
@@ -1074,6 +1074,7 @@ ows_cfg = {
                     "dynamic": False,
                     "native_crs": "EPSG:3577",
                     "time_resolution": "summary",
+                    "bypass_spatial_search": True,
                     "native_resolution": [25, -25],
                     "image_processing": {
                         "extent_mask_func": "datacube_ows.ogc_utils.mask_by_val",


### PR DESCRIPTION
Add per-layer `bypass_spatial_search` option for products with one dataset per timeslice (requiring no spatial search).

Fixes #1623 

I did this PR on my own time.

<!-- readthedocs-preview datacube-ows start -->
----
📚 Documentation preview 📚: https://datacube-ows--1627.org.readthedocs.build/en/1627/

<!-- readthedocs-preview datacube-ows end -->