### PR TITLE
CI: add attestation permissions

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -31,6 +31,7 @@ jobs:
       contents: read    # This is required for actions/checkout
       packages: write  # This is required for pushing to ghcr
       attestations: write # This is required for pushing the attestation
+      artifact-metadata: write # This is required for creating the storage record
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
This is some new permission from
early 2026 that is required for
creating the storage record.

<!-- readthedocs-preview datacube-ows start -->
----
📚 Documentation preview 📚: https://datacube-ows--1629.org.readthedocs.build/en/1629/

<!-- readthedocs-preview datacube-ows end -->