### PR TITLE
CI: fix some Zizmor complaints

### DIFF
--- a/.github/workflows/complementary-config-test.yaml
+++ b/.github/workflows/complementary-config-test.yaml
@@ -32,6 +32,7 @@ concurrency:
 
 jobs:
   dea-config:
+    name: Complementary config test
     timeout-minutes: 15
     runs-on: ubuntu-latest
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -21,6 +21,12 @@ env:
 
 permissions: {}
 
+# When a PR is updated, cancel the jobs from the previous version. Merges
+# do not define head_ref, so use run_id to never cancel those jobs.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   build-and-push-image:
     name: Build Docker image and push to GHCR

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -23,6 +23,7 @@ permissions: {}
 
 jobs:
   build-and-push-image:
+    name: Build Docker image and push to GHCR
     timeout-minutes: 15
     runs-on: ubuntu-latest
 

--- a/.github/workflows/dockerfile-lint.yml
+++ b/.github/workflows/dockerfile-lint.yml
@@ -24,6 +24,7 @@ concurrency:
 
 jobs:
   dockerfile-lint:
+    name: Dockerfile linting
     timeout-minutes: 15
     runs-on: ubuntu-latest
 

--- a/.github/workflows/docpreview.yaml
+++ b/.github/workflows/docpreview.yaml
@@ -6,8 +6,7 @@ on:
     types:
       - opened
 
-permissions:
-  pull-requests: write
+permissions: {}
 
 # When a PR is updated, cancel the jobs from the previous version. Merges
 # do not define head_ref, so use run_id to never cancel those jobs.
@@ -20,6 +19,8 @@ jobs:
     name: Documentation preview
     timeout-minutes: 15
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write # For writing the URL to the pull request description
     steps:
       - uses: readthedocs/actions/preview@b8bba1484329bda1a3abe986df7ebc80a8950333 # v1.5
         with:

--- a/.github/workflows/docpreview.yaml
+++ b/.github/workflows/docpreview.yaml
@@ -17,6 +17,7 @@ concurrency:
 
 jobs:
   documentation-preview:
+    name: Documentation preview
     timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -48,6 +48,8 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
+          # Prevent cache poisoning for releases.
+          enable-cache: ${{ !startsWith(github.ref, 'refs/tags/') }}
           python-version: ${{ matrix.python-version }}
       - name: Install the project
         run: uv sync --locked --extra=dev

--- a/.github/workflows/pyspy-profiling.yaml
+++ b/.github/workflows/pyspy-profiling.yaml
@@ -92,8 +92,10 @@ jobs:
         docker compose -f docker-compose.yaml -f docker-compose.db.yaml -f docker-compose.pyspy.yaml \
         exec -T ows /bin/sh -c "cd /code && ./test_urls.sh &"
         docker compose -f docker-compose.yaml -f docker-compose.db.yaml -f docker-compose.pyspy.yaml \
-        run pyspy record -f speedscope -o ./artifacts/profile.json --duration 30 \
-        --pid ${{steps.set-output-container-id.outputs.PID}} --subprocesses
+          run pyspy record -f speedscope -o ./artifacts/profile.json --duration 30 \
+          --pid $TARGET_PID --subprocesses
+      env:
+        TARGET_PID: ${{ steps.set-output-container-id.outputs.PID }}
 
     - name: Stop py-spy profiling after timeout (stage 1 - stop profiling)
       run: |

--- a/.github/workflows/pyspy-profiling.yaml
+++ b/.github/workflows/pyspy-profiling.yaml
@@ -32,6 +32,7 @@ concurrency:
 
 jobs:
   build:
+    name: Py-spy profiling
     timeout-minutes: 15
     runs-on: ubuntu-latest
 

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -30,6 +30,7 @@ concurrency:
 
 jobs:
   cve-scanner:
+    name: CVE Scanner
     timeout-minutes: 15
     runs-on: ubuntu-latest
     if: github.event_name != 'release'

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name != 'release'
     permissions:
-      security-events: write
+      security-events: write # Required to upload SARIF files to Security tab
     steps:
       - name: Checkout git
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/.github/workflows/spellcheck.yaml
+++ b/.github/workflows/spellcheck.yaml
@@ -26,6 +26,7 @@ concurrency:
 
 jobs:
   pyspellcheck:
+    name: Spell check
     timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test-prod.yaml
+++ b/.github/workflows/test-prod.yaml
@@ -32,6 +32,7 @@ concurrency:
 
 jobs:
   prod-docker-compose-tests:
+    name: OWS production tests
     timeout-minutes: 15
     runs-on: ubuntu-latest
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -94,6 +94,9 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          # Prevent cache poisoning for releases.
+          enable-cache: ${{ !startsWith(github.ref, 'refs/tags/') }}
 
       - name: Build Packages
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,6 +37,7 @@ concurrency:
 
 jobs:
   unit-integration-performance-tests:
+    name: Unit/integration tests
     timeout-minutes: 45
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,7 @@ jobs:
     timeout-minutes: 45
     runs-on: ubuntu-latest
     permissions:
-      id-token: write
+      id-token: write  # For CodeCov/PyPi OIDC login
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,7 +74,7 @@ jobs:
       - name: Test and lint dev OWS image
         run: |
           mkdir artifacts
-          docker run -e LOCAL_UID=$(id -u $USER) -e LOCAL_GID=$(id -g $USER) -v ./:/src -v ${PWD}/artifacts:/mnt/artifacts ${{ env.DOCKER_IMAGE }} /bin/sh -c "cd /src && ./check-code.sh"
+          docker run -e LOCAL_UID=$(id -u $USER) -e LOCAL_GID=$(id -g $USER) -v ./:/src -v ${PWD}/artifacts:/mnt/artifacts ${DOCKER_IMAGE} /bin/sh -c "cd /src && ./check-code.sh"
           mv ./artifacts/coverage.xml ./artifacts/coverage-unit.xml
 
       - name: Dockerized Integration Pytest


### PR DESCRIPTION
Fix most of the security complaints from Zizmor, and some of the pedantic stuff like naming jobs so there is less noise in the Zizmor output

<!-- readthedocs-preview datacube-ows start -->
----
📚 Documentation preview 📚: https://datacube-ows--1632.org.readthedocs.build/en/1632/

<!-- readthedocs-preview datacube-ows end -->