### PR TITLE
Bypass antimeridian hack for global 4326 products

### DIFF
--- a/datacube_ows/wms_utils.py
+++ b/datacube_ows/wms_utils.py
@@ -98,7 +98,9 @@ def _get_geobox_xy(cfg: OWSConfig, args, crs: CRS) -> tuple[float, float, float,
     return minx, miny, maxx, maxy
 
 
-def _get_geobox(cfg: OWSConfig, args, crs: CRS) -> GeoBox:
+def _get_geobox(
+    cfg: OWSConfig, args, crs: CRS, apply_antimeridian_hack: bool = True
+) -> GeoBox:
     width = int(args["width"])
     height = int(args["height"])
     minx, miny, maxx, maxy = _get_geobox_xy(cfg, args, crs)
@@ -123,13 +125,6 @@ def _get_geobox(cfg: OWSConfig, args, crs: CRS) -> GeoBox:
         crs = hack_crs
 
     return create_geobox(crs, minx, miny, maxx, maxy, width, height)
-
-
-def _get_polygon(cfg: OWSConfig, args, crs: CRS) -> geom.Geometry:
-    minx, miny, maxx, maxy = _get_geobox_xy(cfg, args, crs)
-    return geom.polygon(
-        [(minx, maxy), (minx, miny), (maxx, miny), (maxx, maxy), (minx, maxy)], crs
-    )
 
 
 def zoom_factor(cfg: OWSConfig, args, crs) -> float:
@@ -379,21 +374,22 @@ class GetParameters:
         # Layers
         self.layer = self.get_layer(cfg, args)
 
-        self.geometry = _get_polygon(cfg, args, self.crs)
-        # BBox, height and width parameters
-
         # Potentially apply an antimeridian hack if the native CRS is not EPSG:4236
         # (main logic is in _get_geobox())
         apply_antimeridian_hack = (
             CRS(self.layer.cfg_native_crs).epsg not in NATIVE_AM_BYPASS_CODES
         )
+
+        # BBox, height and width parameters
         self.geobox = _get_geobox(self.cfg, args, self.crs, apply_antimeridian_hack)
         if apply_antimeridian_hack and self.geobox.crs != self.crs:
             # If Web-merc antimeridian hack was applied in _get_geobox,
             # update the request CRS to match
             assert self.geobox.crs is not None  # For type checker.
             self.crs = self.geobox.crs
-            self.geometry = self.geometry.to_crs(self.crs)
+
+        # Extract geometry from (potentially hacked) geobox.
+        self.geometry = self.geobox.boundingbox.polygon
 
         # Time parameter
         self.times = get_times(args, self.layer)
@@ -535,7 +531,7 @@ class GetMapParameters(GetParameters):
         self.resampling = Resampling.nearest
 
         self.resources = RequestScale(
-            native_crs=CRS(self.layer.native_CRS),
+            native_crs=CRS(self.layer.cfg_native_crs),
             native_resolution=(self.layer.resolution_x, self.layer.resolution_y),
             geobox=self.geobox,
             n_dates=len(self.times),
@@ -612,7 +608,7 @@ def solar_correct_data(data, dataset) -> float:
     native_x = (dataset.bounds.right + dataset.bounds.left) / 2.0
     native_y = (dataset.bounds.top + dataset.bounds.bottom) / 2.0
     pt = geom.point(native_x, native_y, dataset.crs)
-    geo_pt = pt.to_crs("epsg:4326")
+    geo_pt = pt.to_crs(f"epsg:{EPSG_WGS84}")
     data_time = dataset.center_time.astimezone(UTC)
     data_lon, data_lat = geo_pt.coords[0]
 

--- a/datacube_ows/wms_utils.py
+++ b/datacube_ows/wms_utils.py
@@ -46,6 +46,15 @@ RESAMPLING_METHODS = {
     "average": Resampling.average,
 }
 
+# EPSG codes for antimeridian hack
+EPSG_WGS84 = 4326
+EPSG_WEB_MERC = 3857
+EPSG_PACIFIC_WEB_MERC = 3832
+
+# Native EPSG codes to bypass antimeridian hack for:
+# TODO: Allow declaration of antimeridian bypass per declared CRS in config.
+NATIVE_AM_BYPASS_CODES = {EPSG_WGS84, EPSG_WEB_MERC}
+
 
 def _bounding_pts(
     minx: float,
@@ -97,14 +106,21 @@ def _get_geobox(cfg: OWSConfig, args, crs: CRS) -> GeoBox:
     if minx == maxx or miny == maxy:
         raise WMSException("Bounding box must enclose a non-zero area")
 
-    if crs.epsg == 3857 and (maxx < -13_000_000 or minx > 13_000_000):
-        # EPSG:3857 query AND closer to the anti-meridian than the prime meridian:
+    if (
+        apply_antimeridian_hack
+        and crs.epsg == EPSG_WEB_MERC
+        and (maxx < -13_000_000 or minx > 13_000_000)
+    ):
+        # IF we are applying the AM hack (see GetParameters.__init__() below)
+        # AND this is a EPSG:3857 query
+        # AND is closer to the anti-meridian than the prime meridian:
         # re-project to epsg:3832 (Pacific Web-Mercator)
-        ll = geom.point(x=minx, y=miny, crs=crs).to_crs("epsg:3832")
-        ur = geom.point(x=maxx, y=maxy, crs=crs).to_crs("epsg:3832")
+        hack_crs = CRS(f"epsg:{EPSG_PACIFIC_WEB_MERC}")
+        ll = geom.point(x=minx, y=miny, crs=crs).to_crs(hack_crs)
+        ur = geom.point(x=maxx, y=maxy, crs=crs).to_crs(hack_crs)
         minx, miny = ll.coords[0]
         maxx, maxy = ur.coords[0]
-        crs = CRS("epsg:3832")
+        crs = hack_crs
 
     return create_geobox(crs, minx, miny, maxx, maxy, width, height)
 
@@ -129,7 +145,7 @@ def zoom_factor(cfg: OWSConfig, args, crs) -> float:
     # "standardised" in some sense, not dependent on the CRS of the request.
     # TODO: can we do better in polar regions?
     minx, miny, maxx, maxy = _bounding_pts(
-        minx, miny, maxx, maxy, crs, dst_crs="epsg:4326"
+        minx, miny, maxx, maxy, crs, dst_crs=f"epsg:{EPSG_WGS84}"
     )
     # Create geobox affine transformation (N.B. Don't need an actual Geobox)
     affine = Affine.translation(minx, miny) * Affine.scale(
@@ -365,9 +381,16 @@ class GetParameters:
 
         self.geometry = _get_polygon(cfg, args, self.crs)
         # BBox, height and width parameters
-        self.geobox = _get_geobox(self.cfg, args, self.crs)
-        # Web-merc antimeridian hack:
-        if self.geobox.crs != self.crs:
+
+        # Potentially apply an antimeridian hack if the native CRS is not EPSG:4236
+        # (main logic is in _get_geobox())
+        apply_antimeridian_hack = (
+            CRS(self.layer.cfg_native_crs).epsg not in NATIVE_AM_BYPASS_CODES
+        )
+        self.geobox = _get_geobox(self.cfg, args, self.crs, apply_antimeridian_hack)
+        if apply_antimeridian_hack and self.geobox.crs != self.crs:
+            # If Web-merc antimeridian hack was applied in _get_geobox,
+            # update the request CRS to match
             assert self.geobox.crs is not None  # For type checker.
             self.crs = self.geobox.crs
             self.geometry = self.geometry.to_crs(self.crs)

--- a/tests/test_wms_utils.py
+++ b/tests/test_wms_utils.py
@@ -347,6 +347,47 @@ def test_get_geobox() -> None:
     OWSConfig._instance = None
 
 
+def test_antimeridian_geobox() -> None:
+    from datacube_ows.ows_configuration import OWSConfig, get_config
+
+    mock_cfg = MagicMock()
+    mock_cfg.published_CRSs = {
+        "EPSG:3857": {  # Web Mercator
+            "vertical_coord_first": False,
+        },
+        "EPSG:3832": {  # Pacific Web Mercator
+            "vertical_coord_first": False,
+        },
+        "EPSG:4326": {  # WGS-84
+            "vertical_coord_first": True,
+        },
+    }
+    OWSConfig._instance = mock_cfg
+    cfg = get_config()
+    gbox = datacube_ows.wms_utils._get_geobox(
+        cfg,
+        args={
+            "width": "256",
+            "height": "256",
+            "bbox": "-19998372.584307235,-2074195.199546542,-19959236.82582522,-2035059.4410645328",
+        },
+        crs=CRS("EPSG:3857"),
+    )
+    assert gbox.affine
+    assert str(gbox.crs) == "EPSG:3832"
+    gbox = datacube_ows.wms_utils._get_geobox(
+        cfg,
+        args={
+            "width": "256",
+            "height": "256",
+            "bbox": "-998372.584307235,-2074195.199546542,-959236.82582522,-2035059.4410645328",
+        },
+        crs=CRS("EPSG:3857"),
+    )
+    assert gbox.affine
+    assert str(gbox.crs) == "EPSG:3857"
+
+
 def test_invalid_bbox() -> None:
     from datacube_ows.ows_configuration import OWSConfig, get_config
 


### PR DESCRIPTION
Bypass the "antimeridian" hack for layers whose native CRS is EPSG:4326 or EPSG:3857 (CRSs with baked in antimeridian).  

(e.g. for global 4326 products, as used by WFP)

A more general approach would be allow users to declare other CRSs as having baked-in antimeridian, and bypass them as well.

<!-- readthedocs-preview datacube-ows start -->
----
📚 Documentation preview 📚: https://datacube-ows--1640.org.readthedocs.build/en/1640/

<!-- readthedocs-preview datacube-ows end -->