### PR TITLE
Fix `low_res_product_name` by actually using `resource_limited ` for styled layers. 

### DIFF
--- a/datacube_ows/loading.py
+++ b/datacube_ows/loading.py
@@ -194,7 +194,7 @@ class DataStacker:
     def n_datasets(self) -> int:
         if self.style:
             # we have a style - lets go with that.
-            queries = ProductBandQuery.style_queries(self.style)
+            queries = ProductBandQuery.style_queries(self.style, self.resource_limited)
         else:
             # Just take needed bands.
             queries = [
@@ -221,7 +221,7 @@ class DataStacker:
     def dsids(self) -> dict[ProductBandQuery, Iterable[UUID]]:
         if self.style:
             # we have a style - lets go with that.
-            queries = ProductBandQuery.style_queries(self.style)
+            queries = ProductBandQuery.style_queries(self.style, self.resource_limited)
         else:
             # Just take needed bands.
             queries = [
@@ -254,7 +254,7 @@ class DataStacker:
     ) -> dict[ProductBandQuery, xarray.DataArray]:
         if self.style:
             # we have a style - lets go with that.
-            queries = ProductBandQuery.style_queries(self.style)
+            queries = ProductBandQuery.style_queries(self.style, self.resource_limited)
         elif all_flag_bands:
             queries = ProductBandQuery.full_layer_queries(
                 self._layer, self.needed_bands()

--- a/datacube_ows/loading.py
+++ b/datacube_ows/loading.py
@@ -210,7 +210,7 @@ class DataStacker:
 
     def extent(self, crs: CRS | None = None) -> Geometry | None:
         query = ProductBandQuery.simple_layer_query(
-            self._layer, self.needed_bands(), self.resource_limited
+            self._layer, self.needed_bands(), resource_limited=self.resource_limited
         )
         geom = self._geobox.extent
         times = None if query.ignore_time else self._times
@@ -241,7 +241,7 @@ class DataStacker:
 
     def datasets_all_time(self, point: Geometry | None = None) -> xarray.DataArray:
         query = ProductBandQuery.simple_layer_query(
-            self._layer, self.needed_bands(), self.resource_limited
+            self._layer, self.needed_bands(), resource_limited=self.resource_limited
         )
         geom = point or self._geobox.extent
         result = self._layer.ows_index().ds_search(


### PR DESCRIPTION
Hi there, 

Thank you maintainers, this is a really helpful tool. I found an issue and have a small fix.

I have configured a styled layer with a `low_res_product_name`. This was still (very slowly) trying to load the high resolution data even though it was `resource_limited`. I have tested this PR locally and now it works well!

I was testing this with these:
```bash
# zoomed in - fullres
curl -o zoomed_in_fullres.png -m 30 \
"http://localhost:8000/?service=WMS&version=1.3.0&request=GetMap&layers=s2_geomad_annual_spectral&format=image/png&width=512&height=512&crs=EPSG:6933&bbox=10306772.1183124,-787968.478972056,10308650.2387255,-785644.211438856&time=2025-01-01"
# Looks good and returns in ~4s.

# Zoomed out - fullres
curl -o zoomed_out_fullres.png -m 60 \
"http://localhost:8000/?service=WMS&version=1.3.0&request=GetMap&layers=s2_geomad_annual_spectral&format=image/png&width=512&height=512&crs=EPSG:6933&bbox=9865261.78358675,-1382377.46792413,12253528.180262,46846.6166830986&time=2025-01-01"
# Didn't return after 60s. Should be as fast as lowres layer because it should return the same data. Switch setting to lowres isn't working.
# If I just removed `low_res_product_name` property, then it was fast to return the blue polygon area.
# Since applying my patch locally it returns in ~4s.
```
Thank you.

<!-- readthedocs-preview datacube-ows start -->
----
📚 Documentation preview 📚: https://datacube-ows--1659.org.readthedocs.build/en/1659/

<!-- readthedocs-preview datacube-ows end -->