### PR TITLE
CI: cosign the Docker image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
 
     permissions:
-      id-token: write   # This is required for requesting the JWT
+      id-token: write   # This is required for requesting the JWT+cosign
       contents: read    # This is required for actions/checkout
       packages: write  # This is required for pushing to ghcr
       attestations: write # This is required for pushing the attestation
@@ -53,6 +53,9 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
@@ -83,3 +86,9 @@ jobs:
           subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           subject-digest: ${{ steps.push.outputs.digest }}
           push-to-registry: true
+
+      - name: Sign the Docker image
+        env:
+          TAGS: ${{ steps.meta.outputs.tags }}
+          DIGEST: ${{ steps.push.outputs.digest }}
+        run: echo "${TAGS}" | xargs -I {} cosign sign --yes {}@${DIGEST}


### PR DESCRIPTION
This allows verifying images
with something like:

cosign verify ghcr.io/opendatacube/ows@sha256:<sha256> \
 --certificate-identity-regexp="^https://github.com/opendatacube/datacube-ows/.github/workflows/docker.yml@refs/heads/develop" \
 --certificate-oidc-issuer="https://token.actions.githubusercontent.com"

<!-- readthedocs-preview datacube-ows start -->
----
📚 Documentation preview 📚: https://datacube-ows--1661.org.readthedocs.build/en/1661/

<!-- readthedocs-preview datacube-ows end -->