### PR TITLE
Require setuptools 83.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -158,7 +158,7 @@ ignore = [
 max-line-length = 120
 
 [build-system]
-requires = ["setuptools>=69", "setuptools_scm[toml]>=8"]
+requires = ["setuptools>=83.0.0", "setuptools_scm[toml]>=8"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
This fixes CVE-2026-59890.

<!-- readthedocs-preview datacube-ows start -->
----
📚 Documentation preview 📚: https://datacube-ows--1662.org.readthedocs.build/en/1662/

<!-- readthedocs-preview datacube-ows end -->