### PR TITLE
CI: cosign images recursively

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -91,4 +91,4 @@ jobs:
         env:
           TAGS: ${{ steps.meta.outputs.tags }}
           DIGEST: ${{ steps.push.outputs.digest }}
-        run: echo "${TAGS}" | xargs -I {} cosign sign --yes {}@${DIGEST}
+        run: echo "${TAGS}" | xargs -I {} cosign sign --yes --recursive {}@${DIGEST}


### PR DESCRIPTION
We need to sign more than just
the top level manifest to be
able to enable the feature
in goharbor that requires
images to be cosigned, so
sign recursively.

<!-- readthedocs-preview datacube-ows start -->
----
📚 Documentation preview 📚: https://datacube-ows--1668.org.readthedocs.build/en/1668/

<!-- readthedocs-preview datacube-ows end -->