### PR TITLE
CI: retry intermittent failures

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -94,7 +94,8 @@ jobs:
           push-to-registry: true
 
       - name: Sign the Docker image
+        shell: bash
         env:
           TAGS: ${{ steps.meta.outputs.tags }}
           DIGEST: ${{ steps.push.outputs.digest }}
-        run: echo "${TAGS}" | xargs -I {} cosign sign --yes --recursive {}@${DIGEST}
+        run: (r=5;while ! echo "${TAGS}" | xargs -I {} cosign sign --yes --recursive {}@${DIGEST} ; do ((--r))||exit;sleep 15;done)


### PR DESCRIPTION
Cosign can fail intermittently,
so retry up to 5 times with
a delay when that happens.

<!-- readthedocs-preview datacube-ows start -->
----
📚 Documentation preview 📚: https://datacube-ows--1677.org.readthedocs.build/en/1677/

<!-- readthedocs-preview datacube-ows end -->